### PR TITLE
[bugfix] null pointer dereference in checkExpectCondition()

### DIFF
--- a/src/core/scripting/script_executor.cpp
+++ b/src/core/scripting/script_executor.cpp
@@ -548,12 +548,16 @@ bool ScriptExecutor::checkExpectCondition(const std::shared_ptr<ASTNode> &node) 
         result = screenContainsTextAtRow(node->stringValue, node->intValue - 1);
         break;
     case ExpectType::CursorAtPos: {
-        QPoint pos = screenBuffer()->cursorPosition();
+        auto *buf = screenBuffer();
+        if (!buf) break;
+        QPoint pos = buf->cursorPosition();
         result = (pos.y() == node->intValue - 1 && pos.x() == node->intValue2 - 1);
         break;
     }
     case ExpectType::CursorAtRow: {
-        QPoint pos = screenBuffer()->cursorPosition();
+        auto *buf = screenBuffer();
+        if (!buf) break;
+        QPoint pos = buf->cursorPosition();
         result = (pos.y() == node->intValue - 1);
         break;
     }


### PR DESCRIPTION
## Summary
- Add null checks for `screenBuffer()` in the `CursorAtPos` and `CursorAtRow` cases of `checkExpectCondition()`
- Prevents crash when the screen widget is destroyed mid-execution (e.g. tab closed while a script is running)

## Test plan
- [ ] Build passes cleanly
- [ ] All existing tests pass
- [ ] Run a script with `EXPECT CURSOR AT` and close the tab mid-execution — no crash