### PR TITLE
[bugfix] missing scriptExecutor cleanup when closing a tab

### DIFF
--- a/src/ui/actions/onCloseTabRequested.cpp
+++ b/src/ui/actions/onCloseTabRequested.cpp
@@ -43,6 +43,11 @@ void MainWindow::onCloseTabRequested(int index) {
         s->macroRecorder->stopPlayback();
         s->macroRecorder->disconnect();
     }
+    // Stop script execution if running
+    if (s->scriptExecutor) {
+        s->scriptExecutor->stop();
+        s->scriptExecutor->disconnect();
+    }
     // Stop session logging
     if (s->sessionLogger && s->sessionLogger->isActive()) {
         s->sessionLogger->stop();


### PR DESCRIPTION
## Summary
- Stop and disconnect `scriptExecutor` in `onCloseTabRequested()` before destroying the session
- Prevents use-after-free when a running script's timer callbacks fire against deleted widgets

## Test plan
- [ ] Build passes cleanly
- [ ] All existing tests pass
- [ ] Start a long-running script, close the tab mid-execution — no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)