### PR TITLE
[bugfix] missing row bounds check in readScreenText()

### DIFF
--- a/src/core/scripting/script_executor.cpp
+++ b/src/core/scripting/script_executor.cpp
@@ -745,6 +745,7 @@ void ScriptExecutor::updateBuiltinVariables() {
 QString ScriptExecutor::readScreenText(int row, int col, int length) const {
     auto *buf = screenBuffer();
     if (!buf) return {};
+    if (row < 0 || row >= buf->rows() || col < 0) return {};
 
     QString result;
     for (int i = 0; i < length && col + i < buf->cols(); ++i) {


### PR DESCRIPTION
## Summary
- Add row bounds validation in `readScreenText()` to match the existing checks in `screenContainsTextAt()` and `screenContainsTextAtRow()`
- Prevents out-of-bounds memory access when scripts use `EXTRACT ... FROM` with invalid row values

## Test plan
- [ ] Build passes cleanly
- [ ] All existing tests pass
- [ ] Script with `EXTRACT $var FROM 0 0 LENGTH 5` (invalid row) returns empty instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)