### PR TITLE
[bugfix] unguarded m_scriptStopAction access in lambda

### DIFF
--- a/src/ui/actions/onScripts.cpp
+++ b/src/ui/actions/onScripts.cpp
@@ -273,6 +273,7 @@ void MainWindow::onRunScript(const QString &path) {
     QPointer<ui::widgets::Q5250ScreenWidget> displayGuard = s->displayWidget;
     QPointer<core::scripting::ScriptExecutor> execGuard = s->scriptExecutor;
     QPointer<QLabel> macroLabelGuard = s->macroLabel;
+    QPointer<QAction> stopActionGuard = m_scriptStopAction;
 
     auto connKeyPress = std::make_shared<QMetaObject::Connection>();
     auto connAID = std::make_shared<QMetaObject::Connection>();
@@ -378,7 +379,7 @@ void MainWindow::onRunScript(const QString &path) {
             QObject::disconnect(*connLog);
             QObject::disconnect(*connPause);
             if (!macroLabelGuard.isNull()) macroLabelGuard->setText("");
-            if (m_scriptStopAction) m_scriptStopAction->setEnabled(false);
+            if (!stopActionGuard.isNull()) stopActionGuard->setEnabled(false);
         });
 
     // Error


### PR DESCRIPTION
## Summary
- Guard `m_scriptStopAction` with a `QPointer` in the `executionFinished` lambda, consistent with the other guarded members (`macroLabelGuard`, `execGuard`, `displayGuard`)
- Prevents use-after-free if `MainWindow` is destroyed while a script is finishing

## Test plan
- [ ] Build passes cleanly
- [ ] All existing tests pass
- [ ] Close app while script is executing — no crash on shutdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)