### PR TITLE
[bugfix] lexer silently accepting unterminated string literals

### DIFF
--- a/src/core/scripting/script_lexer.cpp
+++ b/src/core/scripting/script_lexer.cpp
@@ -326,7 +326,12 @@ ScriptToken ScriptLexer::readStringLiteral(const QString &line, int &pos, int li
         value += line[pos];
         pos++;
     }
-    if (pos < line.length()) pos++; // skip closing quote
+    if (pos < line.length()) {
+        pos++; // skip closing quote
+    } else {
+        // Unterminated string literal — return UNKNOWN so the parser reports an error
+        return ScriptToken(TokenType::UNKNOWN, value, lineNumber, col);
+    }
     return ScriptToken(TokenType::STRING_LITERAL, value, lineNumber, col);
 }
 


### PR DESCRIPTION
## Summary
- Return `UNKNOWN` token type when a string literal has no closing quote, instead of silently treating it as a valid `STRING_LITERAL`
- The parser already rejects `UNKNOWN` tokens, so this surfaces the error to the user

## Test plan
- [ ] Build passes cleanly
- [ ] All existing tests pass
- [ ] Script with `TYPE "hello` (no closing quote) now produces a parse error instead of running silently

🤖 Generated with [Claude Code](https://claude.com/claude-code)