### PR TITLE
[bugfix] lone trailing $ in variable interpolation

### DIFF
--- a/src/core/scripting/script_executor.cpp
+++ b/src/core/scripting/script_executor.cpp
@@ -659,8 +659,13 @@ QString ScriptExecutor::interpolateVariables(const QString &text) const {
                 int start = i;
                 i++; // skip $
                 while (i < text.length() && (text[i].isLetterOrNumber() || text[i] == '_')) i++;
-                QString varName = text.mid(start, i - start);
-                result += resolveVariable(varName);
+                if (i - start <= 1) {
+                    // Lone $ with no variable name — emit literal $
+                    result += '$';
+                } else {
+                    QString varName = text.mid(start, i - start);
+                    result += resolveVariable(varName);
+                }
             }
         } else {
             result += text[i];


### PR DESCRIPTION
## Summary
- A lone `$` at end of string (or before non-identifier characters) was resolved as variable `$` → `"0"` instead of being treated as a literal dollar sign
- Now emits `$` literally when no variable name follows

## Test plan
- [ ] Build passes cleanly
- [ ] All existing tests pass
- [ ] `TYPE "price is $"` now types `price is $` instead of `price is 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)