### PR TITLE
[bugfix] potential WHILE loop index underflow in executor

### DIFF
--- a/src/core/scripting/script_executor.cpp
+++ b/src/core/scripting/script_executor.cpp
@@ -350,7 +350,7 @@ void ScriptExecutor::executeNode(const std::shared_ptr<ASTNode> &node) {
         if (evaluateCondition(left, node->condOp, right)) {
             if (!node->children.isEmpty()) {
                 // Decrement parent frame index so WHILE is re-executed after body completes
-                if (!m_execStack.isEmpty()) {
+                if (!m_execStack.isEmpty() && m_execStack.last().index > 0) {
                     m_execStack.last().index--;
                 }
                 m_execStack.append({&node->children, 0, 0, 0});


### PR DESCRIPTION
## Summary
- Add `index > 0` guard before decrementing the parent frame index in the WHILE loop re-execution logic
- Prevents index going negative if execution state was modified between iterations (e.g. via GOTO)

## Test plan
- [ ] Build passes cleanly
- [ ] All existing tests pass
- [ ] WHILE loops continue to work correctly in normal operation

🤖 Generated with [Claude Code](https://claude.com/claude-code)