### PR TITLE
[enhancement] Add startup script support for sessions

### DIFF
--- a/scripts/login.5250script
+++ b/scripts/login.5250script
@@ -1,0 +1,43 @@
+# @script.name = "Login With AutoSignoff"
+# @script.author = "Remi GASCOU (Podalirius)"
+# @script.description = "Logs in to the system and auto signoff the last job if needed"
+# @script.version = "1.0"
+# @menu.path = "Login/Login With AutoSignoff"
+
+# Login to the system and auto signoff the last job if needed.
+DEF login($username, $password)
+    MOVE CURSOR AT (1,1)
+    MOVE CURSOR AT NEXT INPUTFIELD
+    TYPE "$username"
+    MOVE CURSOR AT NEXT INPUTFIELD
+    TYPE "$password"
+    PRESS ENTER
+    autosignoff($username, $password)
+ENDDEF
+
+# Auto signoff the last job if needed.
+DEF autosignoff($username, $password)
+    EXTRACT $title LINE 1
+    IF $title CONTAINS "Attempt to Recover Interactive Job" THEN
+        MOVE CURSOR AT (1,1)
+        MOVE CURSOR AT NEXT INPUTFIELD
+        TYPE "90"
+        PRESS ENTER
+        PRESS ENTER
+        login($username, $password)
+    ENDIF
+ENDDEF
+
+#===============================================================
+
+# When used as a startup script, $USERNAME and $PASSWORD are
+# automatically set from the session credentials.
+# Fallback to defaults if not provided.
+IF $USERNAME == "0" THEN
+    SET $USERNAME "QSECOFR"
+ENDIF
+IF $PASSWORD == "0" THEN
+    SET $PASSWORD "QSECOFR0"
+ENDIF
+
+login($USERNAME, $PASSWORD)

--- a/src/core/scripting/script_executor.cpp
+++ b/src/core/scripting/script_executor.cpp
@@ -41,6 +41,10 @@ ui::widgets::ScreenBuffer *ScriptExecutor::screenBuffer() const {
     return m_screenWidget ? m_screenWidget->screenBuffer() : nullptr;
 }
 
+void ScriptExecutor::setInitialVariables(const QHash<QString, QString> &vars) {
+    m_initialVariables = vars;
+}
+
 void ScriptExecutor::execute(const ParseResult &parseResult) {
     if (m_running) return;
 
@@ -63,6 +67,11 @@ void ScriptExecutor::execute(const ParseResult &parseResult) {
     setVariable("$EXPECT_RESULT", "OK");
     setVariable("$REPEAT_INDEX", "0");
     updateBuiltinVariables();
+
+    // Apply initial variables (e.g. $USERNAME, $PASSWORD from session config)
+    for (auto it = m_initialVariables.constBegin(); it != m_initialVariables.constEnd(); ++it) {
+        setVariable(it.key(), it.value());
+    }
 
     // Push root frame
     m_execStack.append({&m_parseResult.root->children, 0, 0, 0});

--- a/src/core/scripting/script_executor.h
+++ b/src/core/scripting/script_executor.h
@@ -41,6 +41,7 @@ class ScriptExecutor : public QObject {
     void execute(const ParseResult &parseResult);
     void stop();
     bool isRunning() const { return m_running; }
+    void setInitialVariables(const QHash<QString, QString> &vars);
 
   signals:
     // Key injection — connect these to MainWindow lambdas that synthesize QKeyEvents
@@ -97,6 +98,7 @@ class ScriptExecutor : public QObject {
 
     // Variables
     QHash<QString, QString> m_variables;
+    QHash<QString, QString> m_initialVariables;
     QString resolveVariable(const QString &name) const;
     void setVariable(const QString &name, const QString &value);
     QString interpolateVariables(const QString &text) const;

--- a/src/session/config.cpp
+++ b/src/session/config.cpp
@@ -22,7 +22,7 @@ namespace session {
 
 SessionConfig::SessionConfig(QObject *parent) : QObject(parent), m_name("New Session"), m_hostname(""), m_port(23), m_useTLS(false), m_deviceName("IBM-3179-2"), m_screenRows(24), m_screenCols(80), m_codePage(core::CodePage::ID::CP037), m_terminalThemeId("classic_green") {}
 
-SessionConfig::SessionConfig(const SessionConfig &other) : QObject(other.parent()), m_name(other.m_name), m_hostname(other.m_hostname), m_port(other.m_port), m_useTLS(other.m_useTLS), m_deviceName(other.m_deviceName), m_screenRows(other.m_screenRows), m_screenCols(other.m_screenCols), m_codePage(other.m_codePage), m_terminalThemeId(other.m_terminalThemeId), m_username(other.m_username), m_password(other.m_password) {}
+SessionConfig::SessionConfig(const SessionConfig &other) : QObject(other.parent()), m_name(other.m_name), m_hostname(other.m_hostname), m_port(other.m_port), m_useTLS(other.m_useTLS), m_deviceName(other.m_deviceName), m_screenRows(other.m_screenRows), m_screenCols(other.m_screenCols), m_codePage(other.m_codePage), m_terminalThemeId(other.m_terminalThemeId), m_startupScript(other.m_startupScript), m_username(other.m_username), m_password(other.m_password) {}
 
 SessionConfig &SessionConfig::operator=(const SessionConfig &other) {
     if (this != &other) {
@@ -35,6 +35,7 @@ SessionConfig &SessionConfig::operator=(const SessionConfig &other) {
         m_screenCols = other.m_screenCols;
         m_codePage = other.m_codePage;
         m_terminalThemeId = other.m_terminalThemeId;
+        m_startupScript = other.m_startupScript;
         m_username = other.m_username;
         m_password = other.m_password;
         emit changed();
@@ -53,6 +54,8 @@ QJsonObject SessionConfig::toJson() const {
     json["screenCols"] = m_screenCols;
     json["codePage"] = static_cast<int>(m_codePage);
     json["terminalTheme"] = m_terminalThemeId;
+    if (!m_startupScript.isEmpty())
+        json["startupScript"] = m_startupScript;
     return json;
 }
 
@@ -83,6 +86,9 @@ bool SessionConfig::fromJson(const QJsonObject &json) {
     }
     if (json.contains("terminalTheme") && json["terminalTheme"].isString()) {
         m_terminalThemeId = json["terminalTheme"].toString();
+    }
+    if (json.contains("startupScript") && json["startupScript"].isString()) {
+        m_startupScript = json["startupScript"].toString();
     }
     emit changed();
     return isValid();

--- a/src/session/config.h
+++ b/src/session/config.h
@@ -65,6 +65,10 @@ class SessionConfig : public QObject {
     QString terminalThemeId() const { return m_terminalThemeId; }
     void setTerminalThemeId(const QString &id) { m_terminalThemeId = id; }
 
+    // Startup script (persisted — path relative to scripts dir)
+    QString startupScript() const { return m_startupScript; }
+    void setStartupScript(const QString &script) { m_startupScript = script; }
+
     // Credentials (transient — not serialized to JSON)
     QString username() const { return m_username; }
     void setUsername(const QString &username) { m_username = username; }
@@ -92,6 +96,7 @@ class SessionConfig : public QObject {
     int m_screenCols;
     core::CodePage::ID m_codePage;
     QString m_terminalThemeId;
+    QString m_startupScript;
     QString m_username;
     QString m_password;
 

--- a/src/ui/actions/onScripts.cpp
+++ b/src/ui/actions/onScripts.cpp
@@ -534,3 +534,177 @@ void MainWindow::onOpenScriptsFolder() {
     QDesktopServices::openUrl(QUrl::fromLocalFile(scriptsDir()));
 }
 
+// ---------------------------------------------------------------------------
+// Run startup script for a session (with $USERNAME and $PASSWORD pre-seeded)
+// ---------------------------------------------------------------------------
+
+void MainWindow::runStartupScript(Session *s, const QString &scriptPath) {
+    if (!s || !s->displayWidget) return;
+
+    // Make sure this session is active so the UI indicators work
+    int idx = m_sessions.indexOf(s);
+    if (idx >= 0 && idx != m_activeIndex)
+        setActiveSession(idx);
+
+    // Set initial variables from session credentials
+    QHash<QString, QString> initialVars;
+    if (!s->config.username().isEmpty())
+        initialVars["$USERNAME"] = s->config.username();
+    if (!s->config.password().isEmpty())
+        initialVars["$PASSWORD"] = s->config.password();
+
+    // Load script text
+    QFile file(scriptPath);
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) return;
+    QString scriptText = QString::fromUtf8(file.readAll());
+    file.close();
+
+    // Parse
+    core::scripting::ScriptParser parser;
+    auto parseResult = parser.parse(scriptText);
+    if (parseResult.hasErrors()) return;
+
+    // Create executor
+    if (!s->scriptExecutor) {
+        s->scriptExecutor = new core::scripting::ScriptExecutor(s->container);
+    }
+    s->scriptExecutor->setScreenWidget(s->displayWidget);
+    s->scriptExecutor->setInitialVariables(initialVars);
+
+    // Wire signals (same as onRunScript)
+    QPointer<ui::widgets::Q5250ScreenWidget> displayGuard = s->displayWidget;
+    QPointer<core::scripting::ScriptExecutor> execGuard = s->scriptExecutor;
+    QPointer<QLabel> macroLabelGuard = s->macroLabel;
+    QPointer<QAction> stopActionGuard = m_scriptStopAction;
+
+    auto connKeyPress = std::make_shared<QMetaObject::Connection>();
+    auto connAID = std::make_shared<QMetaObject::Connection>();
+    auto connMoveCursor = std::make_shared<QMetaObject::Connection>();
+    auto connMoveStep = std::make_shared<QMetaObject::Connection>();
+    auto connMoveField = std::make_shared<QMetaObject::Connection>();
+    auto connScreen = std::make_shared<QMetaObject::Connection>();
+    auto connState = std::make_shared<QMetaObject::Connection>();
+    auto connFinish = std::make_shared<QMetaObject::Connection>();
+    auto connError = std::make_shared<QMetaObject::Connection>();
+    auto connLog = std::make_shared<QMetaObject::Connection>();
+    auto connPause = std::make_shared<QMetaObject::Connection>();
+
+    *connKeyPress = connect(s->scriptExecutor, &core::scripting::ScriptExecutor::injectKeyPress, this,
+        [displayGuard](int key, Qt::KeyboardModifiers mods, const QString &text) {
+            if (displayGuard.isNull()) return;
+            QKeyEvent ev(QEvent::KeyPress, key, mods, text);
+            QApplication::sendEvent(displayGuard.data(), &ev);
+        });
+
+    *connAID = connect(s->scriptExecutor, &core::scripting::ScriptExecutor::injectAIDKey, this,
+        [displayGuard](uint8_t aid) {
+            if (displayGuard.isNull()) return;
+            int qtKey = 0;
+            Qt::KeyboardModifiers mods = Qt::NoModifier;
+            if (aid == 0xF1) { qtKey = Qt::Key_Return; }
+            else if (aid == 0x70) { qtKey = Qt::Key_Escape; mods = Qt::ControlModifier; }
+            else if (aid == 0x71) { qtKey = Qt::Key_SysReq; }
+            else if (aid >= 0x31 && aid <= 0x3C) { qtKey = Qt::Key_F1 + (aid - 0x31); }
+            else if (aid >= 0xB1 && aid <= 0xBC) { qtKey = Qt::Key_F1 + (aid - 0xB1); mods = Qt::ShiftModifier; }
+            else if (aid == 0xF3) { qtKey = Qt::Key_F1; mods = Qt::ControlModifier; }
+            else if (aid == 0xF4) { qtKey = Qt::Key_PageDown; }
+            else if (aid == 0xF5) { qtKey = Qt::Key_PageUp; }
+            else if (aid == 0xF6) { qtKey = Qt::Key_Print; }
+            else if (aid == 0xBD) { qtKey = Qt::Key_Pause; mods = Qt::ControlModifier; }
+            else return;
+            QKeyEvent ev(QEvent::KeyPress, qtKey, mods, QString());
+            QApplication::sendEvent(displayGuard.data(), &ev);
+        });
+
+    *connMoveCursor = connect(s->scriptExecutor, &core::scripting::ScriptExecutor::moveCursor, this,
+        [displayGuard](int row, int col) {
+            if (displayGuard.isNull()) return;
+            displayGuard->moveCursor(row, col);
+        });
+
+    *connMoveStep = connect(s->scriptExecutor, &core::scripting::ScriptExecutor::moveCursorStep, this,
+        [displayGuard](const QString &dir) {
+            if (displayGuard.isNull()) return;
+            if (dir == "UP") displayGuard->moveCursorUp();
+            else if (dir == "DOWN") displayGuard->moveCursorDown();
+            else if (dir == "LEFT") displayGuard->moveCursorLeft();
+            else if (dir == "RIGHT") displayGuard->moveCursorRight();
+        });
+
+    *connMoveField = connect(s->scriptExecutor, &core::scripting::ScriptExecutor::gotoInputField, this,
+        [displayGuard](int fieldIndex) {
+            if (displayGuard.isNull()) return;
+            auto *buf = displayGuard->screenBuffer();
+            if (!buf) return;
+            const auto &fields = buf->fields();
+            QVector<const ui::widgets::ScreenBuffer::Field *> inputFields;
+            for (const auto &f : fields) {
+                if (!f.protected_field)
+                    inputFields.append(&f);
+            }
+            if (inputFields.isEmpty()) return;
+            if (fieldIndex == -1) {
+                displayGuard->moveToNextField();
+            } else if (fieldIndex == -2) {
+                displayGuard->moveToPreviousField();
+            } else if (fieldIndex >= 1 && fieldIndex <= inputFields.size()) {
+                auto *f = inputFields[fieldIndex - 1];
+                displayGuard->moveCursor(f->startRow, f->startCol);
+            }
+        });
+
+    *connScreen = connect(s->displayWidget->screenBuffer(), &ui::widgets::ScreenBuffer::screenChanged,
+        s->scriptExecutor, &core::scripting::ScriptExecutor::notifyScreenChanged);
+
+    *connState = connect(s->displayWidget, &ui::widgets::Q5250ScreenWidget::terminalStateChanged,
+        s->scriptExecutor, &core::scripting::ScriptExecutor::notifyTerminalStateChanged);
+
+    *connFinish = connect(s->scriptExecutor, &core::scripting::ScriptExecutor::executionFinished, this,
+        [=]() {
+            QObject::disconnect(*connKeyPress);
+            QObject::disconnect(*connAID);
+            QObject::disconnect(*connMoveCursor);
+            QObject::disconnect(*connMoveStep);
+            QObject::disconnect(*connMoveField);
+            QObject::disconnect(*connScreen);
+            QObject::disconnect(*connState);
+            QObject::disconnect(*connFinish);
+            QObject::disconnect(*connError);
+            QObject::disconnect(*connLog);
+            QObject::disconnect(*connPause);
+            if (!macroLabelGuard.isNull()) macroLabelGuard->setText("");
+            if (!stopActionGuard.isNull()) stopActionGuard->setEnabled(false);
+        });
+
+    *connError = connect(s->scriptExecutor, &core::scripting::ScriptExecutor::executionError, this,
+        [this](int line, const QString &msg) {
+            ui::widgets::StyledMessageBox::information(this, "Script Error",
+                QString("Line %1: %2").arg(line).arg(msg));
+        });
+
+    *connLog = connect(s->scriptExecutor, &core::scripting::ScriptExecutor::logMessage, this,
+        [this](const QString &msg) {
+            if (m_activeIndex >= 0 && m_activeIndex < m_sessions.size()) {
+                auto *s = m_sessions[m_activeIndex];
+                if (s->sessionLogger)
+                    s->sessionLogger->logEvent(QString("[SCRIPT] %1").arg(msg));
+            }
+        });
+
+    *connPause = connect(s->scriptExecutor, &core::scripting::ScriptExecutor::pauseRequested, this,
+        [this, execGuard]() {
+            ui::widgets::StyledMessageBox::information(this, "Script Paused",
+                "Script execution paused.\nClick OK to continue.");
+            if (!execGuard.isNull()) execGuard->resumeAfterPause();
+        });
+
+    if (s->macroLabel) {
+        s->macroLabel->setText("SCRIPT");
+        s->macroLabel->setStyleSheet(
+            "color: #00ccff; background-color: black; padding: 0px 4px; font-weight: bold;");
+    }
+    m_scriptStopAction->setEnabled(true);
+
+    s->scriptExecutor->execute(parseResult);
+}
+

--- a/src/ui/dialogs/connect_dialog.cpp
+++ b/src/ui/dialogs/connect_dialog.cpp
@@ -18,7 +18,10 @@
 #include "core/codepage.h"
 #include "session/manager.h"
 #include "ui/themes/terminal_theme_manager.h"
+#include <QDir>
+#include <QFileInfo>
 #include <QGroupBox>
+#include <QStandardPaths>
 #include <QInputDialog>
 #include "ui/widgets/Frameless/StyledMessageBox.h"
 
@@ -170,6 +173,21 @@ void ConnectDialog::setupUI() {
     themeGroup->setLayout(themeLayout);
     mainLayout->addWidget(themeGroup);
 
+    // Startup script group
+    QGroupBox *scriptGroup = new QGroupBox("Startup Script", this);
+    QFormLayout *scriptLayout = new QFormLayout(scriptGroup);
+    m_startupScriptCombo = new QComboBox(this);
+    m_startupScriptCombo->addItem("(None)", QString());
+    QString sDir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)
+                   + "/scripts";
+    QDir scriptDir(sDir);
+    for (const QFileInfo &fi : scriptDir.entryInfoList({"*.5250script"}, QDir::Files, QDir::Name)) {
+        m_startupScriptCombo->addItem(fi.baseName(), fi.fileName());
+    }
+    scriptLayout->addRow("Run on connect:", m_startupScriptCombo);
+    scriptGroup->setLayout(scriptLayout);
+    mainLayout->addWidget(scriptGroup);
+
     // Buttons
     QHBoxLayout *buttonLayout = new QHBoxLayout();
     m_connectButton = new QPushButton("Connect", this);
@@ -232,6 +250,14 @@ void ConnectDialog::updateUI() {
     if (themeIdx >= 0) {
         m_themeCombo->setCurrentIndex(themeIdx);
     }
+
+    // Startup script
+    int scriptIdx = m_startupScriptCombo->findData(m_currentConfig.startupScript());
+    if (scriptIdx >= 0) {
+        m_startupScriptCombo->setCurrentIndex(scriptIdx);
+    } else {
+        m_startupScriptCombo->setCurrentIndex(0); // (None)
+    }
 }
 
 session::SessionConfig ConnectDialog::getSessionConfig() const {
@@ -252,6 +278,7 @@ session::SessionConfig ConnectDialog::getSessionConfig() const {
     config.setCodePage(static_cast<core::CodePage::ID>(
         m_codePageCombo->currentData().toInt()));
     config.setTerminalThemeId(m_themeCombo->currentData().toString());
+    config.setStartupScript(m_startupScriptCombo->currentData().toString());
     return config;
 }
 

--- a/src/ui/dialogs/connect_dialog.h
+++ b/src/ui/dialogs/connect_dialog.h
@@ -84,6 +84,7 @@ class ConnectDialog : public ui::widgets::BaseFramelessDialog {
     QGroupBox *m_displayGroup;
     QComboBox *m_codePageCombo;
     QComboBox *m_themeCombo;
+    QComboBox *m_startupScriptCombo;
 
     session::SessionConfig m_currentConfig;
     QVector<tn5250::devices::Device> m_supported;

--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -29,8 +29,10 @@
 #include <QContextMenuEvent>
 #include <QDir>
 #include <QEvent>
+#include <QFile>
 #include <QFileDialog>
 #include <QFrame>
+#include <QStandardPaths>
 #include <QHBoxLayout>
 #include <QInputDialog>
 #include <QLabel>
@@ -288,8 +290,9 @@ void MainWindow::connectToServer(const session::SessionConfig &config) {
     connect(session->thread, &QThread::finished, session->worker, &QObject::deleteLater);
     // Per-session state handling - always updates this session's status widget,
     // and only touches global menu actions when this is the active tab.
+    auto startupScriptRan = std::make_shared<bool>(false);
     connect(session->worker, &tn5250::session::Worker::stateChanged, this,
-        [this, session](tn5250::client::TN5250Client::ConnectionState state) {
+        [this, session, startupScriptRan](tn5250::client::TN5250Client::ConnectionState state) {
             if (session->connectionStatus) {
                 session->connectionStatus->setState(state);
                 switch (state) {
@@ -298,6 +301,19 @@ void MainWindow::connectToServer(const session::SessionConfig &config) {
                         QString("Connected to %1:%2")
                             .arg(session->config.hostname())
                             .arg(session->config.port()));
+                    // Run startup script once on first connect
+                    if (!*startupScriptRan && !session->config.startupScript().isEmpty()) {
+                        *startupScriptRan = true;
+                        QString scriptPath = QStandardPaths::writableLocation(
+                            QStandardPaths::AppDataLocation)
+                            + "/scripts/" + session->config.startupScript();
+                        if (QFile::exists(scriptPath)) {
+                            // Delay to let the terminal finish setup
+                            QTimer::singleShot(500, this, [this, session, scriptPath]() {
+                                runStartupScript(session, scriptPath);
+                            });
+                        }
+                    }
                     break;
                 case tn5250::client::TN5250Client::ConnectionState::Connecting:
                     session->connectionStatus->setStatusText("Connecting");

--- a/src/ui/main_window.h
+++ b/src/ui/main_window.h
@@ -156,6 +156,7 @@ class MainWindow : public ui::widgets::BaseFramelessWindow {
         core::MatchReplaceEngine *matchReplace = nullptr;
     };
 
+    void runStartupScript(Session *session, const QString &scriptPath);
     void applyThemeToSession(Session *session, const QString &themeId);
 
     QTabWidget *m_tabWidget;


### PR DESCRIPTION
## Summary
- Sessions can now have a **startup script** that runs automatically when the session first connects
- The startup script receives `$USERNAME` and `$PASSWORD` variables pre-seeded from the session's credentials, so login scripts can use them without hardcoding
- A "Run on connect" dropdown in the Connect Dialog lets users pick any `.5250script` from the scripts directory
- The setting is persisted in the session JSON config (`startupScript` field)

## Changes

| File | Change |
|------|--------|
| `src/session/config.h/.cpp` | Add `m_startupScript` field with getter/setter, JSON serialization |
| `src/ui/dialogs/connect_dialog.h/.cpp` | Add startup script combo box populated from scripts directory |
| `src/core/scripting/script_executor.h/.cpp` | Add `setInitialVariables()` to pre-seed variables before execution |
| `src/ui/main_window.h/.cpp` | Trigger startup script on first `Connected` state change |
| `src/ui/actions/onScripts.cpp` | Implement `runStartupScript()` with credential variable injection |
| `scripts/login.5250script` | Updated example to use `$USERNAME`/`$PASSWORD` from session |

## How it works
1. User selects a startup script in the Connect Dialog
2. On first `Connected` state (after TN5250 negotiation), the script is launched with a 500ms delay
3. `$USERNAME` and `$PASSWORD` are injected as script variables from the session credentials
4. Scripts can use these variables directly (e.g., `TYPE "$USERNAME"`) or fall back to defaults

## Test plan
- [ ] Build passes cleanly, all 13 tests pass
- [ ] Connect with no startup script selected — behaves as before
- [ ] Connect with a startup script selected — script runs on connect
- [ ] `$USERNAME` and `$PASSWORD` are available in the script
- [ ] Startup script only runs once (not on reconnect)
- [ ] Saved sessions persist the startup script selection