### PR TITLE
[enhancement] Add value labels and tooltips to CRT effect sliders

### DIFF
--- a/src/ui/dialogs/session_settings_dialog.cpp
+++ b/src/ui/dialogs/session_settings_dialog.cpp
@@ -480,21 +480,34 @@ QWidget *SessionSettingsDialog::buildCRTSection() {
     m_crtEnabled = new QCheckBox("Enable CRT effect");
     v->addWidget(m_crtEnabled);
 
-    auto addSliderRow = [&](const QString &label, QSlider *&slider) {
+    auto addSliderRow = [&](const QString &label, QSlider *&slider, QLabel *&valLabel,
+                            const QString &tooltip) {
         QHBoxLayout *row = new QHBoxLayout();
-        row->addWidget(new QLabel(label));
+        QLabel *nameLabel = new QLabel(label);
+        if (!tooltip.isEmpty()) nameLabel->setToolTip(tooltip);
+        row->addWidget(nameLabel);
         slider = new QSlider(Qt::Horizontal);
         slider->setRange(0, 100);
         slider->setValue(30);
+        if (!tooltip.isEmpty()) slider->setToolTip(tooltip);
+        valLabel = new QLabel(QString::number(slider->value()) + "%");
         row->addWidget(slider, 1);
+        row->addWidget(valLabel);
         v->addLayout(row);
-        connect(slider, &QSlider::valueChanged, this, &SessionSettingsDialog::onThemePropertyChanged);
+        connect(slider, &QSlider::valueChanged, this, [this, valLabel](int val) {
+            valLabel->setText(QString::number(val) + "%");
+            onThemePropertyChanged();
+        });
     };
 
-    addSliderRow("Scanlines:", m_crtScanline);
-    addSliderRow("Phosphor Bloom:", m_crtPhosphorBloom);
-    addSliderRow("Glow:", m_crtGlow);
-    addSliderRow("Curvature:", m_crtCurvature);
+    addSliderRow("Scanlines:", m_crtScanline, m_crtScanlineLabel,
+                 "Intensity of horizontal scanline overlay");
+    addSliderRow("Phosphor Bloom:", m_crtPhosphorBloom, m_crtPhosphorBloomLabel,
+                 "Local glow around bright characters");
+    addSliderRow("Glow:", m_crtGlow, m_crtGlowLabel,
+                 "Radial phosphor glow emanating from the screen center");
+    addSliderRow("Curvature:", m_crtCurvature, m_crtCurvatureLabel,
+                 "Vignette darkening at screen edges simulating CRT curvature");
 
     connect(m_crtEnabled, &QCheckBox::toggled, this, &SessionSettingsDialog::onThemePropertyChanged);
 

--- a/src/ui/dialogs/session_settings_dialog.h
+++ b/src/ui/dialogs/session_settings_dialog.h
@@ -172,6 +172,10 @@ class SessionSettingsDialog : public QDialog {
     QSlider *m_crtPhosphorBloom;
     QSlider *m_crtGlow;
     QSlider *m_crtCurvature;
+    QLabel *m_crtScanlineLabel;
+    QLabel *m_crtPhosphorBloomLabel;
+    QLabel *m_crtGlowLabel;
+    QLabel *m_crtCurvatureLabel;
 
     // Brightness/saturation
     QSlider *m_brightnessSlider;


### PR DESCRIPTION
The CRT sliders (Scanlines, Phosphor Bloom, Glow, Curvature) had no percentage labels, unlike Brightness/Saturation. Added percentage labels that update live and tooltips explaining what each parameter controls.