### PR TITLE
[enhancement] Cap MCP HTTP parser buffer growth (#63)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -406,6 +406,15 @@ if(BUILD_TESTS)
     add_tn5250_test(test_host_data_stream tests/unit/test_host_data_stream.cpp)
     add_tn5250_test(test_password_encrypt tests/unit/test_password_encrypt.cpp)
 
+    # MCP transport tests
+    # McpHttpParser lives in the main application target (not tn5250_core),
+    # so compile it into the test binary directly.
+    add_executable(test_mcp_http_parser
+        tests/unit/test_mcp_http_parser.cpp
+        src/mcp/McpHttpParser.cpp)
+    target_link_libraries(test_mcp_http_parser PRIVATE tn5250_core Qt6::Test)
+    add_test(NAME test_mcp_http_parser COMMAND test_mcp_http_parser)
+
     # Scripting tests
     add_tn5250_test(test_script_lexer tests/unit/test_script_lexer.cpp)
     add_tn5250_test(test_script_parser tests/unit/test_script_parser.cpp)

--- a/src/mcp/McpHttpParser.cpp
+++ b/src/mcp/McpHttpParser.cpp
@@ -19,11 +19,24 @@
 namespace mcp {
 
 bool McpHttpParser::feed(const QByteArray &data) {
+    if (m_error) return false;
     m_buffer.append(data);
 
     if (!m_headersParsed) {
         int headerEnd = m_buffer.indexOf("\r\n\r\n");
-        if (headerEnd < 0) return false;
+        if (headerEnd < 0) {
+            if (m_buffer.size() > kMaxHeaderSize) {
+                m_error = true;
+                m_errorMessage = QStringLiteral("Request header exceeds maximum size");
+            }
+            return false;
+        }
+
+        if (headerEnd > kMaxHeaderSize) {
+            m_error = true;
+            m_errorMessage = QStringLiteral("Request header exceeds maximum size");
+            return false;
+        }
 
         m_bodyStart = headerEnd + 4;
 
@@ -48,13 +61,25 @@ bool McpHttpParser::feed(const QByteArray &data) {
             }
         }
 
-        m_contentLength = m_request.headers.value("content-length", "0").toInt();
+        bool lengthOk = false;
+        const QString lengthHeader = m_request.headers.value("content-length", "0");
+        m_contentLength = lengthHeader.toInt(&lengthOk);
+        if (!lengthOk || m_contentLength < 0 || m_contentLength > kMaxBodySize) {
+            m_error = true;
+            m_errorMessage = QStringLiteral("Invalid or oversized Content-Length");
+            return false;
+        }
         m_headersParsed = true;
     }
 
     // Check if we have the full body
     if (m_headersParsed) {
         int available = m_buffer.size() - m_bodyStart;
+        if (available > kMaxBodySize) {
+            m_error = true;
+            m_errorMessage = QStringLiteral("Request body exceeds maximum size");
+            return false;
+        }
         if (available >= m_contentLength) {
             m_request.body = m_buffer.mid(m_bodyStart, m_contentLength);
             return true;
@@ -70,6 +95,8 @@ void McpHttpParser::reset() {
     m_headersParsed = false;
     m_contentLength = 0;
     m_bodyStart = -1;
+    m_error = false;
+    m_errorMessage.clear();
 }
 
 QByteArray HttpResponse::toBytes() const {

--- a/src/mcp/McpHttpParser.h
+++ b/src/mcp/McpHttpParser.h
@@ -41,7 +41,15 @@ struct HttpResponse {
 /// Minimal HTTP/1.1 request parser for MCP transport.
 class McpHttpParser {
   public:
+    /// Maximum bytes accepted before `\r\n\r\n` is seen.
+    static constexpr int kMaxHeaderSize = 64 * 1024;
+    /// Maximum body bytes accepted, both by Content-Length and by actual
+    /// buffered payload.
+    static constexpr int kMaxBodySize = 16 * 1024 * 1024;
+
     /// Feed raw TCP data. Returns true when a complete request is available.
+    /// Returns false if the request is incomplete or if the parser has
+    /// entered an error state; check hasError() to distinguish.
     bool feed(const QByteArray &data);
 
     /// Returns the parsed request. Only valid after feed() returns true.
@@ -50,12 +58,22 @@ class McpHttpParser {
     /// Reset for the next request.
     void reset();
 
+    /// True once the parser has refused the stream (oversized or malformed).
+    /// After an error the parser will not accept further data; the caller
+    /// should close the connection.
+    bool hasError() const { return m_error; }
+
+    /// Human-readable reason for the current error, or empty if none.
+    QString errorMessage() const { return m_errorMessage; }
+
   private:
     QByteArray m_buffer;
     HttpRequest m_request;
     bool m_headersParsed = false;
     int m_contentLength = 0;
     int m_bodyStart = -1;
+    bool m_error = false;
+    QString m_errorMessage;
 };
 
 } // namespace mcp

--- a/src/mcp/McpServer.cpp
+++ b/src/mcp/McpServer.cpp
@@ -162,6 +162,18 @@ void McpServer::onClientData() {
         // disconnected.  Only reset the parser if the socket is still alive.
         if (!socket.isNull())
             httpParser->reset();
+    } else if (httpParser->hasError()) {
+        MCP_ERROR(QString("HTTP parse error: %1").arg(httpParser->errorMessage()));
+        HttpResponse resp;
+        resp.statusCode = 413;
+        resp.statusText = QStringLiteral("Payload Too Large");
+        resp.headers["Content-Type"] = "application/json";
+        QJsonObject err;
+        err["error"] = httpParser->errorMessage();
+        resp.body = QJsonDocument(err).toJson(QJsonDocument::Compact);
+        socket->write(resp.toBytes());
+        socket->flush();
+        socket->disconnectFromHost();
     }
 }
 

--- a/tests/unit/test_mcp_http_parser.cpp
+++ b/tests/unit/test_mcp_http_parser.cpp
@@ -1,0 +1,105 @@
+// 5250ng - A modern IBM TN5250 terminal emulator
+// Copyright (C) 2025-2026 Remi GASCOU (Podalirius)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include "mcp/McpHttpParser.h"
+#include <QByteArray>
+#include <QTest>
+
+using namespace mcp;
+
+class TestMcpHttpParser : public QObject {
+    Q_OBJECT
+
+  private slots:
+    void parsesSimpleRequest() {
+        McpHttpParser p;
+        QByteArray req = "POST /mcp HTTP/1.1\r\n"
+                         "Host: localhost\r\n"
+                         "Content-Type: application/json\r\n"
+                         "Content-Length: 2\r\n"
+                         "\r\n"
+                         "{}";
+        QVERIFY(p.feed(req));
+        QVERIFY(!p.hasError());
+        QCOMPARE(p.request().method, QStringLiteral("POST"));
+        QCOMPARE(p.request().path, QStringLiteral("/mcp"));
+        QCOMPARE(p.request().body, QByteArray("{}"));
+    }
+
+    void rejectsOversizedHeaderBlock() {
+        McpHttpParser p;
+        // Send header bytes beyond the parser's kMaxHeaderSize limit,
+        // without the terminating \r\n\r\n, to simulate a slow-loris
+        // style client that would otherwise grow the buffer unboundedly.
+        QByteArray big = QByteArray("GET / HTTP/1.1\r\nX-Pad: ")
+                         + QByteArray(McpHttpParser::kMaxHeaderSize + 1, 'a');
+        QVERIFY(!p.feed(big));
+        QVERIFY(p.hasError());
+        QVERIFY(!p.errorMessage().isEmpty());
+    }
+
+    void rejectsOversizedContentLength() {
+        McpHttpParser p;
+        QByteArray req = "POST /mcp HTTP/1.1\r\n"
+                         "Content-Length: "
+                       + QByteArray::number(static_cast<qint64>(McpHttpParser::kMaxBodySize) + 1)
+                       + "\r\n\r\n";
+        QVERIFY(!p.feed(req));
+        QVERIFY(p.hasError());
+    }
+
+    void rejectsNegativeContentLength() {
+        McpHttpParser p;
+        QByteArray req = "POST /mcp HTTP/1.1\r\n"
+                         "Content-Length: -1\r\n\r\n";
+        QVERIFY(!p.feed(req));
+        QVERIFY(p.hasError());
+    }
+
+    void rejectsNonNumericContentLength() {
+        McpHttpParser p;
+        QByteArray req = "POST /mcp HTTP/1.1\r\n"
+                         "Content-Length: lots\r\n\r\n";
+        QVERIFY(!p.feed(req));
+        QVERIFY(p.hasError());
+    }
+
+    void ignoresFurtherDataOnceErrored() {
+        McpHttpParser p;
+        QByteArray req = "POST /mcp HTTP/1.1\r\n"
+                         "Content-Length: -5\r\n\r\n";
+        QVERIFY(!p.feed(req));
+        QVERIFY(p.hasError());
+        // Additional bytes after the error must not be accepted and must not
+        // grow the buffer.
+        QVERIFY(!p.feed(QByteArray(1024, 'x')));
+        QVERIFY(p.hasError());
+    }
+
+    void resetClearsErrorState() {
+        McpHttpParser p;
+        QByteArray req = "POST /mcp HTTP/1.1\r\n"
+                         "Content-Length: -1\r\n\r\n";
+        QVERIFY(!p.feed(req));
+        QVERIFY(p.hasError());
+        p.reset();
+        QVERIFY(!p.hasError());
+        QCOMPARE(p.errorMessage(), QString());
+    }
+};
+
+QTEST_MAIN(TestMcpHttpParser)
+#include "test_mcp_http_parser.moc"


### PR DESCRIPTION
### Linked Issue
Closes #63

### Root Cause
`McpHttpParser::feed()` did `m_buffer.append(data)` on every invocation
with no upper bound. The MCP server binds to localhost and calls
`feed()` every time `readyRead` fires on an accepted socket, so any
process that can reach port 9250 controls how fast the buffer grows.
Two concrete failure modes:

1. A client that writes bytes but never the `\r\n\r\n` terminator
   causes `m_buffer` to grow until the header block is completed —
   unbounded.
2. A client that sends valid headers with `Content-Length:
   9999999999` (or any value that stays non-negative under `toInt()`)
   causes the parser to keep buffering up to that many body bytes
   before declaring the request complete — also unbounded in practice.

The parser was written assuming a trusted local consumer and never
grew any back-pressure.

### Fix Description
Impose two constants at class scope:

- `kMaxHeaderSize = 64 * 1024` — bytes admitted before the header
  terminator is seen.
- `kMaxBodySize   = 16 * 1024 * 1024` — maximum declared and actual
  body size.

`feed()` now enforces three checks:

1. If `\r\n\r\n` has not arrived by `kMaxHeaderSize`, reject.
2. On header parse, validate that `Content-Length` parses cleanly and
   lies in `[0, kMaxBodySize]`.
3. As body bytes accumulate, reject if the buffered tail exceeds
   `kMaxBodySize` (covers the case where the client declared a small
   length but sent more).

After any of these fire, `m_error` is set and subsequent `feed()`
calls are no-ops. Callers use `hasError()` / `errorMessage()` to
distinguish an incomplete request from a refused one.

`McpServer::onClientData()` now responds with `413 Payload Too Large`
and calls `disconnectFromHost()` when the parser errors, so a hostile
client cannot hold the connection open and keep feeding bytes.

Rejected alternatives:
- Changing `feed()`'s return to a tri-state enum was considered but
  would churn the call site for a single caller; a bool plus
  `hasError()` stays source-compatible with anyone else.
- Letting the OS kill the process on OOM was rejected because it
  takes the whole terminal emulator down, not just the MCP server.

### How Verified
- Added `tests/unit/test_mcp_http_parser.cpp` (new test binary wired
  in via `add_executable`/`add_test` in the top-level `CMakeLists.txt`
  since `McpHttpParser.cpp` does not live in the `tn5250_core` target).
- 9/9 cases pass, covering: happy path, oversized header block,
  oversized `Content-Length`, negative `Content-Length`, non-numeric
  `Content-Length`, post-error rejection, and `reset()` clearing the
  error state.
- Local full-tree build (`cmake --build build`) succeeds.

### Test Coverage
**Added:** `tests/unit/test_mcp_http_parser.cpp`
- `parsesSimpleRequest`
- `rejectsOversizedHeaderBlock`
- `rejectsOversizedContentLength`
- `rejectsNegativeContentLength`
- `rejectsNonNumericContentLength`
- `ignoresFurtherDataOnceErrored`
- `resetClearsErrorState`

### Scope of Change
- **Files changed:**
  - `src/mcp/McpHttpParser.h`
  - `src/mcp/McpHttpParser.cpp`
  - `src/mcp/McpServer.cpp`
  - `tests/unit/test_mcp_http_parser.cpp` (new)
  - `CMakeLists.txt` (wire new test binary)
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Requests that fit under the new limits parse identically to before,
so well-behaved clients are unaffected. Any client that previously
relied on sending headers larger than 64 KB or bodies larger than 16
MB on this transport will now get a 413; those limits are generous
for MCP JSON-RPC and can be bumped in one place if a workload
actually needs more. Safe to merge without staged rollout.