### PR TITLE
[bugfix] Report failed writes in MCP write_file (#64)

### DIFF
--- a/src/mcp/McpToolHandler.cpp
+++ b/src/mcp/McpToolHandler.cpp
@@ -623,8 +623,23 @@ QJsonObject McpToolHandler::handleWriteFile(const QJsonObject &args) {
     if (!file.open(QIODevice::WriteOnly | QIODevice::Text))
         return makeResult("Failed to write file: " + file.errorString(), true);
 
-    file.write(content.toUtf8());
+    const QByteArray payload = content.toUtf8();
+    const qint64 written = file.write(payload);
+    if (written != payload.size()) {
+        const QString errText = file.errorString();
+        file.close();
+        return makeResult(QString("Failed to write file (wrote %1 of %2 bytes): %3")
+                              .arg(written).arg(payload.size()).arg(errText),
+                          true);
+    }
+    if (!file.flush()) {
+        const QString errText = file.errorString();
+        file.close();
+        return makeResult("Failed to flush file: " + errText, true);
+    }
     file.close();
+    if (file.error() != QFileDevice::NoError)
+        return makeResult("Failed to close file: " + file.errorString(), true);
     return makeResult("File written successfully: " + path);
 }
 


### PR DESCRIPTION
### Linked Issue
Closes #64

### Root Cause
`McpToolHandler::handleWriteFile()` called `file.write(content.toUtf8())`
and immediately replied \"File written successfully\", discarding three
independent failure signals:

- `QFile::write()` returns a short byte count or `-1` when the sink
  cannot accept all bytes (disk full, quota, broken pipe on FIFO
  targets).
- `QFile::close()` silently sets `error()` if buffered data could not
  be flushed to the OS.
- Without an explicit `flush()`, close-time errors are the only place
  flush failures surface.

An agent consuming the MCP reply therefore couldn't distinguish a
real write from a partial or failed one.

### Fix Description
Inspect all three signals:

1. Compare `file.write(payload)` against `payload.size()`; on
   mismatch, return an error result that includes the bytes-written
   count and `file.errorString()`.
2. Call `file.flush()` before `close()` and surface any failure.
3. After `close()`, check `file.error() != QFileDevice::NoError` and
   surface the error string.

The happy path still returns the same success string.

### How Verified
- Static review of `QFile` / `QFileDevice` documented semantics against
  the diff.
- Full-tree rebuild (`cmake --build build --target 5250ng`) succeeds.

### Test Coverage
**None:** the MCP filesystem tools are not currently exercised by the
test suite (no test fixtures for `McpToolHandler`), and adding one
requires introducing a new test binary and mock registry — beyond the
scope of this bug fix. Reproducing a short-write deterministically
also requires platform-specific setup (a filled tmpfs or a named pipe
reader that stops draining). Follow-up to add MCP tool-handler tests
can be filed separately.

### Scope of Change
- **Files changed:** `src/mcp/McpToolHandler.cpp`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none. Success replies
  are byte-for-byte unchanged; only failing writes flip from success
  to error.

### Risk and Rollout
Narrow: one function, success path unchanged. The new error paths
trigger only when the underlying filesystem genuinely fails. Safe to
merge without staged rollout.