### PR TITLE
[bugfix] Drop QIODevice::Text from MCP read_file and write_file (#65)

### DIFF
--- a/src/mcp/McpToolHandler.cpp
+++ b/src/mcp/McpToolHandler.cpp
@@ -601,8 +601,11 @@ QJsonObject McpToolHandler::handleReadFile(const QJsonObject &args) {
     if (path.isEmpty())
         return makeResult("No file path provided.", true);
 
+    // Open without QIODevice::Text so bytes are returned verbatim; the Text
+    // flag translates CRLF/CR to LF on read, which corrupts binary files and
+    // makes a read/write round-trip lossy.
     QFile file(path);
-    if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
+    if (!file.open(QIODevice::ReadOnly))
         return makeResult("Failed to read file: " + file.errorString(), true);
 
     QString content = QString::fromUtf8(file.readAll());
@@ -619,8 +622,11 @@ QJsonObject McpToolHandler::handleWriteFile(const QJsonObject &args) {
     QFileInfo fi(path);
     QDir().mkpath(fi.absolutePath());
 
+    // Open without QIODevice::Text so the payload is written verbatim;
+    // otherwise Qt injects platform-specific line-ending translations on
+    // Windows and the bytes on disk differ from what the caller supplied.
     QFile file(path);
-    if (!file.open(QIODevice::WriteOnly | QIODevice::Text))
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate))
         return makeResult("Failed to write file: " + file.errorString(), true);
 
     file.write(content.toUtf8());


### PR DESCRIPTION
### Linked Issue
Closes #65

### Root Cause
Both `handleReadFile()` and `handleWriteFile()` opened files with
`QIODevice::Text`. Qt documents the semantics clearly:
- On read, `\r\n` and a trailing `\r` are translated to `\n`.
- On write, `\n` is translated to the host platform's line ending.

These translations are applied at the byte level to **every** call,
regardless of whether the file actually contains text. Two concrete
consequences:

1. A binary payload (screenshot, zip, executable) gets mangled as
   soon as it contains a `0x0D 0x0A` byte pair, because the parser
   silently eats the `0x0D`.
2. Text files are no longer byte-identical after a read/write round
   trip: on Windows `"foo\r\nbar"` becomes `"foo\nbar"` on read, and
   re-writing it produces `"foo\r\nbar"` again — subtly corrupting
   files that mix line endings (e.g. shell scripts with mixed history).

### Fix Description
Remove `QIODevice::Text` from both `open()` calls. `handleWriteFile()`
additionally sets `QIODevice::Truncate` explicitly (it was implicit in
the previous `WriteOnly` call but making it explicit preserves the
prior \"overwrite the whole file\" semantics and keeps the code clear).

`QString::fromUtf8()` on the read path is kept because the MCP wire
format demands text; callers that need raw bytes already use other
tools (screenshots go through `QPixmap::save`, for example). The only
behaviour change is that the bytes the caller sees are the bytes that
are actually on disk.

### How Verified
- Static review of Qt `QIODevice` documentation against the diff.
- Full-tree rebuild (`cmake --build build --target 5250ng`) succeeds.
- Manual trace: a caller that writes `\"hello\\r\\n\"` now lands
  `hello\\r\\n` on disk on every OS; reading that file back returns
  the same string.

### Test Coverage
**None:** MCP filesystem tools have no existing test fixture. Adding
one requires introducing a new test binary and temp-directory
scaffolding — out of scope for a two-line correctness fix. A follow-up
to stand up test coverage for `McpToolHandler` file tools is a
reasonable next task.

### Scope of Change
- **Files changed:** `src/mcp/McpToolHandler.cpp`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none.

### Risk and Rollout
On Unix hosts the visible behaviour already matched the new code
(no CRLF translation takes place when Text is combined with
Unix-native newlines), so the observable delta there is limited to
exact-byte round-tripping of files that already contain `\r`. On
Windows hosts the delta is more visible: line endings written by
this tool will no longer be auto-translated. That matches what MCP
callers expect. Safe to merge without staged rollout.