### PR TITLE
[bugfix] Release session container on tab close (#69)

### DIFF
--- a/src/ui/actions/onCloseTabRequested.cpp
+++ b/src/ui/actions/onCloseTabRequested.cpp
@@ -76,7 +76,17 @@ void MainWindow::onCloseTabRequested(int index) {
     }
     m_sessions.remove(index);
     m_tabWidget->removeTab(index);
-    delete s; // deletes container and children (parser owned by container)
+    // removeTab() does not destroy the page widget, and Session is a plain
+    // struct whose delete does not cascade into its QObject members.
+    // Schedule the container for destruction so Qt's parent-child cleanup
+    // destroys the terminal view, screen buffer, parser, script executor,
+    // session logger, match-replace engine and every other object that was
+    // parented to the container.
+    if (s->container) {
+        s->container->deleteLater();
+        s->container = nullptr;
+    }
+    delete s;
     if (!m_sessions.isEmpty()) {
         int newIndex = qMin(index, m_sessions.size() - 1);
         setActiveSession(newIndex);


### PR DESCRIPTION
### Linked Issue
Closes #69

### Root Cause
`MainWindow::onCloseTabRequested()` freed the `Session` struct at
`delete s;` and relied on the inline comment's claim that this
\"deletes container and children (parser owned by container)\". The
claim is wrong in two ways:

1. `Session` is a plain POD (see `main_window.h` L129–L165) with no
   destructor and only raw-pointer members. `delete s;` frees the
   struct storage and does nothing else.
2. `QTabWidget::removeTab()` does not destroy the page widget — per
   Qt's documented contract it only removes the page from the
   internal `QStackedWidget`. The stacked widget retains the
   container as a hidden child until `MainWindow` is destroyed.

Every QObject that had been parented to `s->container` therefore
survived the close: the `Q5250TerminalView`, the
`Q5250ScreenWidget` (with its screen buffer and field list), the
agent panel and its chat history, the CRT overlay, background
pixmaps, the 5250 command handler, the decoder adapter, the script
executor, match-replace engine, session logger, macro recorder,
and so on. Repeated session open/close cycles accumulated memory
until the process exited.

### Fix Description
Call `s->container->deleteLater()` before `delete s;`. Qt's
parent-child cleanup then walks the full widget tree rooted at the
container and destroys each child. Null out the pointer first so a
late lambda that still holds `s` (stale queued signal, etc.) sees a
clean `nullptr` rather than a dangling pointer.

`deleteLater()` is preferred over immediate `delete` because the
close path can be invoked from inside a signal emitted by one of
the container's own children (e.g. the tab's own close button),
and Qt's documentation recommends deferring destruction in that
shape.

Rejected alternatives:
- Giving `Session` a destructor that deletes each pointer was
  considered but would duplicate logic that already exists in the
  worker-thread teardown path and would force every site that
  holds a `Session *` to reason about ordering. Parenting is the
  existing ownership model; we just have to honor it.

### How Verified
- Static trace of the destruction chain: `container` is the parent
  of `terminalContainer`, which is the parent of `terminalView`,
  which owns the `Q5250ScreenWidget`; `parser`, `matchReplace`,
  `sessionLogger`, `macroRecorder`, `scriptExecutor` are all
  constructed with `s->container` as parent; the agent panel is a
  child of `splitter` → `container`.
- Full-tree rebuild (`cmake --build build --target 5250ng`)
  succeeds.
- Behavioural smoke: opening a session, closing it, opening
  another continues to work; nothing about the live tab sequence
  depends on the container outliving the tab.

### Test Coverage
**None:** leak detection on a Qt widget tree is not part of the
existing test suite and wiring one in requires either Valgrind
plumbing or QWidget instrumentation — both out of scope for a
two-line correctness fix. Reviewers wanting to verify manually
can add a `QObject::destroyed` log on the container in a debug
build, close a tab, and observe that the log now fires.

### Scope of Change
- **Files changed:** `src/ui/actions/onCloseTabRequested.cpp`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none. The close path
  now frees memory that used to leak; nothing that was previously
  observable changes.

### Risk and Rollout
Narrow change in one function. The container was already orphaned
from the user's perspective (hidden, no longer in the tab); the
fix just finalizes its destruction. Safe to merge without staged
rollout.