### PR TITLE
[enhancement] Release agent panel collapsible block map on Clear (#70)

### DIFF
--- a/src/ui/widgets/QAgentPanelWidget/QAgentPanelWidget.cpp
+++ b/src/ui/widgets/QAgentPanelWidget/QAgentPanelWidget.cpp
@@ -85,6 +85,10 @@ QAgentPanelWidget::QAgentPanelWidget(QWidget *parent) : QWidget(parent) {
     m_clearButton->setStyleSheet("font-size: 11px; padding: 2px 8px;");
     connect(m_clearButton, &QPushButton::clicked, this, [this]() {
         m_chatHistory->clear();
+        // The visible transcript is gone, so the anchors that referenced
+        // m_collapsibleBlocks entries are unreachable; release the payloads
+        // so the map does not grow monotonically across Clear clicks.
+        m_collapsibleBlocks.clear();
         m_thinkingTimer->stop();
         m_thinkingBlockPosition = -1;
         if (m_scriptRunner && m_scriptRunner->isRunning())


### PR DESCRIPTION
### Linked Issue
Closes #70

### Root Cause
The agent panel's Clear button handler at
`src/ui/widgets/QAgentPanelWidget/QAgentPanelWidget.cpp` L86–L99
wiped the visible chat transcript (`m_chatHistory->clear()`) but
left `m_collapsibleBlocks` — the side-cache that holds the full
HTML body of every collapsible tool-call block — untouched.

Every `appendCollapsibleBlock()` at L418–L429 inserts a
`CollapsibleBlock` with its `title` and `fullHtml` into the map
under a fresh monotonic ID. Those payloads are typically the
entire tool input JSON plus the entire tool result text, i.e. the
biggest strings the widget ever handles. Once the chat is
cleared, the anchor (`<a href=\"toggle://ID\">`) that would let
`onAnchorClicked` look the entry up disappears with the HTML, so
the map entry is unreachable from the UI — but it still consumes
memory.

The map therefore grew monotonically across the widget's
lifetime, one entry per tool call, never released except when the
owning widget itself was destroyed.

### Fix Description
Add one line — `m_collapsibleBlocks.clear()` — right after
`m_chatHistory->clear()` in the Clear handler. Once the visible
anchors are gone, the backing payloads should go with them.

`m_nextBlockId` is deliberately not reset: keeping IDs monotonic
means a queued HTML fragment that somehow still references a
pre-clear ID cannot accidentally collide with a new post-clear
block.

### How Verified
- Static review: the only writer into `m_collapsibleBlocks` is
  `appendCollapsibleBlock()`, and the only reader (besides the
  Clear handler after this fix) is `replaceCollapsibleBlock()` /
  `onAnchorClicked`, both of which check `contains(blockId)`
  before use and therefore tolerate the map being reset.
- `cmake --build build --target 5250ng` succeeds.

### Test Coverage
**None:** the agent panel has no test harness in the current
tree, and standing one up requires instantiating the widget with
its many Qt dependencies (provider, script runner, theme manager)
— out of scope for a one-line correctness fix.

### Scope of Change
- **Files changed:**
  `src/ui/widgets/QAgentPanelWidget/QAgentPanelWidget.cpp`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none.

### Notes
The adjacent leak in the session `container` widget tree is a
separate, larger issue covered by #69 and its PR; this change is
deliberately narrow.