### PR TITLE
[bugfix] Fix unconditional TLS certificate validation bypass (#73)

### DIFF
--- a/src/network/tn5250_qt/client/client.h
+++ b/src/network/tn5250_qt/client/client.h
@@ -77,6 +77,12 @@ class TN5250Client : public QObject {
     void setCodePage(core::CodePage::ID cp) { m_codePage = cp; }
     core::CodePage::ID codePage() const { return m_codePage; }
 
+    // When true, SSL/TLS certificate validation errors (self-signed, expired,
+    // hostname mismatch, untrusted chain) are ignored for this session. When
+    // false (default), any SSL error aborts the connection before data flows.
+    void setAllowInvalidCertificates(bool allow) { m_allowInvalidCertificates = allow; }
+    bool allowInvalidCertificates() const { return m_allowInvalidCertificates; }
+
   signals:
     void connected();
     void disconnected();
@@ -114,6 +120,7 @@ class TN5250Client : public QObject {
     void startTLS();
     void handleStartTLS();
 
+    bool m_allowInvalidCertificates = false;
     QAbstractSocket *m_socket;
 #ifdef HAVE_QT6_SSL
     QSslSocket *m_sslSocket;

--- a/src/network/tn5250_qt/client/client_io.cpp
+++ b/src/network/tn5250_qt/client/client_io.cpp
@@ -80,12 +80,27 @@ void TN5250Client::onSocketError(QAbstractSocket::SocketError /*error*/) {
 
 #ifdef HAVE_QT6_SSL
 void TN5250Client::onSslErrors(const QList<QSslError> &errors) {
+    QStringList errorStrings;
     for (const QSslError &err : errors) {
+        errorStrings << err.errorString();
         logger::Logger::instance()->warning(
             QString("[TN5250->Client]: SSL error: %1").arg(err.errorString()));
     }
-    // Accept the connection despite errors (self-signed certs are common on AS/400).
-    // TODO: make this configurable so users can enforce strict certificate validation.
+
+    if (!m_allowInvalidCertificates) {
+        const QString combined = errorStrings.join("; ");
+        logger::Logger::instance()->error(
+            QString("[TN5250->Client]: TLS certificate validation failed: %1").arg(combined));
+        setState(ConnectionState::Error);
+        emit errorOccurred(QString("TLS certificate validation failed: %1").arg(combined));
+        if (m_sslSocket) {
+            static_cast<QSslSocket *>(m_sslSocket)->abort();
+        }
+        return;
+    }
+
+    logger::Logger::instance()->warning(
+        "[TN5250->Client]: Ignoring SSL errors (allowInvalidCertificates=true)");
     if (m_sslSocket) {
         static_cast<QSslSocket *>(m_sslSocket)->ignoreSslErrors();
     }

--- a/src/session/config.cpp
+++ b/src/session/config.cpp
@@ -23,7 +23,7 @@ namespace session {
 
 SessionConfig::SessionConfig(QObject *parent) : QObject(parent), m_name("New Session"), m_hostname(""), m_port(23), m_useTLS(false), m_deviceType("IBM-3179-2"), m_deviceName(""), m_screenRows(24), m_screenCols(80), m_codePage(core::CodePage::ID::CP037), m_terminalThemeId("classic_green") {}
 
-SessionConfig::SessionConfig(const SessionConfig &other) : QObject(other.parent()), m_name(other.m_name), m_hostname(other.m_hostname), m_port(other.m_port), m_useTLS(other.m_useTLS), m_deviceType(other.m_deviceType), m_deviceName(other.m_deviceName), m_screenRows(other.m_screenRows), m_screenCols(other.m_screenCols), m_codePage(other.m_codePage), m_terminalThemeId(other.m_terminalThemeId), m_startupScriptSource(other.m_startupScriptSource), m_startupScriptName(other.m_startupScriptName), m_sessionVariables(other.m_sessionVariables), m_username(other.m_username), m_password(other.m_password) {}
+SessionConfig::SessionConfig(const SessionConfig &other) : QObject(other.parent()), m_name(other.m_name), m_hostname(other.m_hostname), m_port(other.m_port), m_useTLS(other.m_useTLS), m_allowInvalidCertificates(other.m_allowInvalidCertificates), m_deviceType(other.m_deviceType), m_deviceName(other.m_deviceName), m_screenRows(other.m_screenRows), m_screenCols(other.m_screenCols), m_codePage(other.m_codePage), m_terminalThemeId(other.m_terminalThemeId), m_startupScriptSource(other.m_startupScriptSource), m_startupScriptName(other.m_startupScriptName), m_sessionVariables(other.m_sessionVariables), m_username(other.m_username), m_password(other.m_password) {}
 
 SessionConfig &SessionConfig::operator=(const SessionConfig &other) {
     if (this != &other) {
@@ -31,6 +31,7 @@ SessionConfig &SessionConfig::operator=(const SessionConfig &other) {
         m_hostname = other.m_hostname;
         m_port = other.m_port;
         m_useTLS = other.m_useTLS;
+        m_allowInvalidCertificates = other.m_allowInvalidCertificates;
         m_deviceType = other.m_deviceType;
         m_deviceName = other.m_deviceName;
         m_screenRows = other.m_screenRows;
@@ -53,6 +54,8 @@ QJsonObject SessionConfig::toJson() const {
     json["hostname"] = m_hostname;
     json["port"] = m_port;
     json["useTLS"] = m_useTLS;
+    if (m_allowInvalidCertificates)
+        json["allowInvalidCertificates"] = m_allowInvalidCertificates;
     json["deviceType"] = m_deviceType;
     if (!m_deviceName.isEmpty())
         json["deviceName"] = m_deviceName;
@@ -89,6 +92,11 @@ bool SessionConfig::fromJson(const QJsonObject &json) {
     }
     if (json.contains("useTLS") && json["useTLS"].isBool()) {
         m_useTLS = json["useTLS"].toBool();
+    }
+    if (json.contains("allowInvalidCertificates") && json["allowInvalidCertificates"].isBool()) {
+        m_allowInvalidCertificates = json["allowInvalidCertificates"].toBool();
+    } else {
+        m_allowInvalidCertificates = false;
     }
     if (json.contains("deviceType") && json["deviceType"].isString()) {
         m_deviceType = json["deviceType"].toString();

--- a/src/session/config.h
+++ b/src/session/config.h
@@ -48,6 +48,12 @@ class SessionConfig : public QObject {
     bool useTLS() const { return m_useTLS; }
     void setUseTLS(bool useTLS) { m_useTLS = useTLS; }
 
+    // When true, SSL/TLS certificate validation errors (self-signed, expired,
+    // hostname mismatch, untrusted chain) are ignored. Default is false.
+    // Only set for hosts the user has knowingly accepted as insecure.
+    bool allowInvalidCertificates() const { return m_allowInvalidCertificates; }
+    void setAllowInvalidCertificates(bool allow) { m_allowInvalidCertificates = allow; }
+
     // Device type is the terminal model (e.g. IBM-3179-2) sent via TERMINAL_TYPE
     QString deviceType() const { return m_deviceType; }
     void setDeviceType(const QString &type) { m_deviceType = type; }
@@ -105,6 +111,7 @@ class SessionConfig : public QObject {
     QString m_hostname;
     quint16 m_port;
     bool m_useTLS;
+    bool m_allowInvalidCertificates = false;
     QString m_deviceType;
     QString m_deviceName;
     int m_screenRows;

--- a/src/session/worker.cpp
+++ b/src/session/worker.cpp
@@ -50,6 +50,7 @@ void Worker::start() {
     m_client->setTerminalType(termType);
     m_client->setCredentials(m_config.username(), m_config.password());
     m_client->setCodePage(m_config.codePage());
+    m_client->setAllowInvalidCertificates(m_config.allowInvalidCertificates());
 
     connect(m_client, &tn5250::client::TN5250Client::connected, this, &Worker::connected);
     connect(m_client, &tn5250::client::TN5250Client::disconnected, this, &Worker::disconnected);

--- a/src/ui/dialogs/connect_dialog.cpp
+++ b/src/ui/dialogs/connect_dialog.cpp
@@ -87,6 +87,12 @@ void ConnectDialog::setupUI() {
     m_tlsCheck = new QCheckBox("Use TLS/SSL", this);
     formLayout->addRow("", m_tlsCheck);
 
+    m_allowInvalidCertsCheck = new QCheckBox("Allow invalid TLS certificates (insecure)", this);
+    m_allowInvalidCertsCheck->setToolTip(
+        "When enabled, self-signed, expired, or hostname-mismatched TLS "
+        "certificates are accepted. Leave off unless you trust the host.");
+    formLayout->addRow("", m_allowInvalidCertsCheck);
+
     m_usernameEdit = new QLineEdit(this);
     m_usernameEdit->setPlaceholderText("(optional - for encrypted sign-on)");
     formLayout->addRow("Username:", m_usernameEdit);
@@ -233,6 +239,7 @@ void ConnectDialog::updateUI() {
     m_hostnameEdit->setText(m_currentConfig.hostname());
     m_portSpin->setValue(m_currentConfig.port());
     m_tlsCheck->setChecked(m_currentConfig.useTLS());
+    m_allowInvalidCertsCheck->setChecked(m_currentConfig.allowInvalidCertificates());
     m_usernameEdit->setText(m_currentConfig.username());
     m_passwordEdit->setText(m_currentConfig.password());
     // Select device type in combo if supported
@@ -294,6 +301,7 @@ session::SessionConfig ConnectDialog::getSessionConfig() const {
     config.setHostname(m_hostnameEdit->text());
     config.setPort(static_cast<quint16>(m_portSpin->value()));
     config.setUseTLS(m_tlsCheck->isChecked());
+    config.setAllowInvalidCertificates(m_allowInvalidCertsCheck->isChecked());
     if (m_deviceCombo->currentIndex() == m_customDeviceIndex) {
         config.setDeviceType(m_customDeviceEdit->text());
     } else {

--- a/src/ui/dialogs/connect_dialog.h
+++ b/src/ui/dialogs/connect_dialog.h
@@ -73,6 +73,7 @@ class ConnectDialog : public ui::widgets::BaseFramelessDialog {
     QLineEdit *m_hostnameEdit;
     QSpinBox *m_portSpin;
     QCheckBox *m_tlsCheck;
+    QCheckBox *m_allowInvalidCertsCheck;
     QLineEdit *m_usernameEdit;
     QLineEdit *m_passwordEdit;
     QComboBox *m_deviceCombo;

--- a/tests/unit/test_session_config.cpp
+++ b/tests/unit/test_session_config.cpp
@@ -31,6 +31,8 @@ class TestSessionConfig : public QObject {
     void testValidation();
     void testSerialization();
     void testDeserialization();
+    void testAllowInvalidCertificatesDefaultsOff();
+    void testAllowInvalidCertificatesRoundTrip();
 
   private:
     SessionConfig *m_config;
@@ -146,6 +148,56 @@ void TestSessionConfig::testDeserialization() {
     QCOMPARE(loaded.deviceName(), QString("MYTERM01"));
     QCOMPARE(loaded.screenRows(), 27);
     QCOMPARE(loaded.screenCols(), 132);
+}
+
+void TestSessionConfig::testAllowInvalidCertificatesDefaultsOff() {
+    SessionConfig fresh;
+    QVERIFY(!fresh.allowInvalidCertificates());
+
+    QJsonObject json;
+    json["name"] = "Secure";
+    json["hostname"] = "example.com";
+    json["port"] = 992;
+    json["useTLS"] = true;
+    json["deviceType"] = "IBM-3179-2";
+    json["deviceName"] = "TERM";
+    json["screenRows"] = 24;
+    json["screenCols"] = 80;
+    SessionConfig loaded;
+    QVERIFY(loaded.fromJson(json));
+    QVERIFY(!loaded.allowInvalidCertificates());
+
+    QJsonObject out = loaded.toJson();
+    QVERIFY(!out.contains("allowInvalidCertificates"));
+}
+
+void TestSessionConfig::testAllowInvalidCertificatesRoundTrip() {
+    m_config->setName("Legacy AS400");
+    m_config->setHostname("legacy.example.com");
+    m_config->setPort(992);
+    m_config->setUseTLS(true);
+    m_config->setAllowInvalidCertificates(true);
+
+    QJsonObject json = m_config->toJson();
+    QCOMPARE(json.value("allowInvalidCertificates").toBool(), true);
+
+    SessionConfig loaded;
+    QVERIFY(loaded.fromJson(json));
+    QCOMPARE(loaded.allowInvalidCertificates(), true);
+
+    QJsonObject reset;
+    reset["name"] = "Reset";
+    reset["hostname"] = "a.example.com";
+    reset["port"] = 23;
+    reset["useTLS"] = false;
+    reset["deviceType"] = "IBM-3179-2";
+    reset["deviceName"] = "T";
+    reset["screenRows"] = 24;
+    reset["screenCols"] = 80;
+    SessionConfig second;
+    second.setAllowInvalidCertificates(true);
+    QVERIFY(second.fromJson(reset));
+    QVERIFY(!second.allowInvalidCertificates());
 }
 
 QTEST_MAIN(TestSessionConfig)


### PR DESCRIPTION
### Linked Issue
Closes #73

### Root Cause
`TN5250Client::onSslErrors` was written as a placeholder that always called `ignoreSslErrors()`, with a TODO to make it configurable. There was no per-session knob anywhere in the stack — `SessionConfig` stored only `useTLS`, `TN5250Client` had no setter, and the connect dialog had no toggle. The net effect: enabling TLS only prevented passive eavesdroppers. Any active MITM presenting an arbitrary certificate was accepted without user input.

### Fix Description
- `SessionConfig` gains a `bool m_allowInvalidCertificates` (default `false`) with getter/setter, JSON round-trip, and copy-constructor / assignment coverage. On deserialization the field explicitly resets to `false` when absent, so existing sessions stay secure by default.
- `TN5250Client` gains `setAllowInvalidCertificates(bool)` and a matching private flag. `onSslErrors` now logs every error, and when the flag is `false` it transitions state to `Error`, emits `errorOccurred` with the combined error strings, and aborts the socket. Only when the flag is `true` does it fall through to `ignoreSslErrors()`.
- `Worker::start` plumbs the flag from `SessionConfig` into the client before `connectToHost`.
- `ConnectDialog` surfaces the setting as "Allow invalid TLS certificates (insecure)" with a tooltip; it reads/writes the field through `setAllowInvalidCertificates` / `allowInvalidCertificates`.

No other behavioural changes: when `allowInvalidCertificates=true`, the client retains its previous permissive behaviour, so legacy AS/400 hosts with self-signed certs continue to work once the user opts in.

### How Verified
- Static: re-read `client_io.cpp` L82–L108 after patch — the `!m_allowInvalidCertificates` branch now calls `abort()` before any application data can be exchanged, and `emit errorOccurred` surfaces the reason to the UI.
- Tests: `tests/unit/test_session_config.cpp` now includes two new cases. `testAllowInvalidCertificatesDefaultsOff` asserts the field defaults to `false` on fresh objects and on JSON that omits the key, and that `toJson` does not emit the key when unset. `testAllowInvalidCertificatesRoundTrip` asserts the JSON round-trip and that loading a JSON without the key overrides any prior stale value to `false`.
- Build: `cmake --build build -j 4` clean.
- Runtime (tests): `./test_session_config` — 9 passed, 0 failed.

### Test Coverage
**Added:**
- `tests/unit/test_session_config.cpp::testAllowInvalidCertificatesDefaultsOff`
- `tests/unit/test_session_config.cpp::testAllowInvalidCertificatesRoundTrip`

Network-level test for `onSslErrors` is impractical without a Qt TLS test harness; the code path is covered by static review (single call site, `m_sslSocket->abort()` on the non-allow branch).

### Scope of Change
- **Files changed:**
  - `src/session/config.h`, `src/session/config.cpp`
  - `src/network/tn5250_qt/client/client.h`, `src/network/tn5250_qt/client/client_io.cpp`
  - `src/session/worker.cpp`
  - `src/ui/dialogs/connect_dialog.h`, `src/ui/dialogs/connect_dialog.cpp`
  - `tests/unit/test_session_config.cpp`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Default-closed: users with saved sessions that relied on the old permissive behaviour will see connections fail at TLS handshake with a surfaced error until they toggle the new checkbox. This is the correct behaviour for a security fix — the previous default was unsafe — and the error message names the specific certificate problem so the user can act.
