### PR TITLE
[bugfix] Fix GDS record length silently truncated for oversized payloads (#75)

### DIFF
--- a/src/network/tn5250_qt/client/client_telnet.cpp
+++ b/src/network/tn5250_qt/client/client_telnet.cpp
@@ -413,7 +413,15 @@ void TN5250Client::sendData(const QByteArray &data) {
     // Then IAC-escape the entire record and append IAC EOR.
     using namespace tn5250::protocol;
     QByteArray record;
-    int recLen = GDS_HEADER_SIZE + data.size();
+    const qint64 recLen64 = static_cast<qint64>(GDS_HEADER_SIZE) + data.size();
+    if (recLen64 > 0xFFFF) {
+        logger::Logger::instance()->error(
+            QString("[TN5250->Client]: sendData: GDS record length %1 exceeds "
+                    "16-bit maximum (65535); refusing to send truncated record")
+                .arg(recLen64));
+        return;
+    }
+    const int recLen = static_cast<int>(recLen64);
 
     // 2-byte big-endian record length
     record.append(static_cast<char>((recLen >> 8) & 0xFF));
@@ -465,7 +473,15 @@ void TN5250Client::sendRawData(const QByteArray &data) {
 void TN5250Client::sendGDS(uint8_t flagsHi, uint8_t opcode, const QByteArray &payload) {
     using namespace tn5250::protocol;
     QByteArray record;
-    int recLen = GDS_HEADER_SIZE + payload.size();
+    const qint64 recLen64 = static_cast<qint64>(GDS_HEADER_SIZE) + payload.size();
+    if (recLen64 > 0xFFFF) {
+        logger::Logger::instance()->error(
+            QString("[TN5250->Client]: sendGDS: GDS record length %1 exceeds "
+                    "16-bit maximum (65535); refusing to send truncated record")
+                .arg(recLen64));
+        return;
+    }
+    const int recLen = static_cast<int>(recLen64);
 
     // 2-byte big-endian record length
     record.append(static_cast<char>((recLen >> 8) & 0xFF));


### PR DESCRIPTION
### Linked Issue
Closes #75

### Root Cause
`TN5250Client::sendData` and `TN5250Client::sendGDS` computed the record length as a 32-bit `int` and wrote only the low 16 bits to the GDS header, without ever checking whether the length fit. The GDS framing field is 16-bit by protocol, so any payload pushing `GDS_HEADER_SIZE + data.size()` past 65 535 would silently go out with a wrong length prefix while the full payload was appended to the socket. The server then desynchronises from the stream — it reads a short record, then reads the leftover payload as unrelated framing, and typically closes the connection.

### Fix Description
Both call sites now compute the length in `qint64`, compare against `0xFFFF`, and bail out with a logged error when the record would overflow:

- `sendData` (payload path for `Worker::sendInput`)
- `sendGDS` (structured-record path for attention, system-request, heartbeat, agent-driven sends)

On overflow the functions log the oversized length at `error` level and return before touching the socket. This leaves the stream in frame, surfaces the protocol violation in the log, and avoids the previous silent truncation. No changes to the happy path — for any reasonable 5250 payload (< 4 KB) the cast-and-store sequence is byte-identical.

### How Verified
- Static: re-read `client_telnet.cpp` L398–L447 and L475–L505 after the patch. The 64-bit computation is done before any buffer is appended, and the early return happens before `record.append` and `sendRawData`, so no partial record can reach the wire.
- Build: `cmake --build build -j 4` succeeds; no new warnings.

### Test Coverage
**None:** the guarded path requires constructing a `QByteArray` of ~65 530 bytes and poking it into `sendData` while the client is in `Connected` state. Doing this in-process would need a Qt TCP test harness with a fake server reading the framed bytes. The change is narrow (a bounds check plus early return around untouched code) and the logic is straightforward enough to be covered by static review.

### Scope of Change
- **Files changed:** `src/network/tn5250_qt/client/client_telnet.cpp`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Tiny blast radius: the new branch only fires on payloads > 65 525 bytes, which never occurs in normal 5250 screen traffic. When it does fire, the previous behaviour was to corrupt the server's GDS parser — any change is an improvement. Safe to merge without staged rollout.

### Notes
The identical pattern exists in `src/network/tn5250/tn5250/client/protocol_handler.cpp` at L239 and L259 (the `protocol-tn5250` submodule). That implementation is currently not used by the Qt client, but the same fix should land there via a follow-up PR on the submodule.
