### PR TITLE
[bugfix] Fix missing closing brace in testDeserializationRejectsOutOfRange (#81)

### DIFF
--- a/tests/unit/test_session_config.cpp
+++ b/tests/unit/test_session_config.cpp
@@ -227,6 +227,8 @@ void TestSessionConfig::testDeserializationRejectsOutOfRange() {
         QVERIFY(cfg.fromJson(j));
         QCOMPARE(cfg.codePage(), core::CodePage::ID::CP037);
     }
+}
+
 void TestSessionConfig::testAllowInvalidCertificatesDefaultsOff() {
     SessionConfig fresh;
     QVERIFY(!fresh.allowInvalidCertificates());


### PR DESCRIPTION
### Linked Issue
Closes #81

### Root Cause
`TestSessionConfig::testDeserializationRejectsOutOfRange()` was added with a function body opened at L154 but no matching closing `}` for the outer function. The trailing `}` at L229 closed only the inner anonymous block that exercises the successful `cfg.fromJson(j)` case. As a result the compiler treated the next function declaration (`TestSessionConfig::testAllowInvalidCertificatesDefaultsOff()` at L230) as a nested qualified-id inside the still-open body, which then cascaded into `qualified-id in declaration before '(' token` errors for every subsequent method definition, rejected `QTEST_MAIN(TestSessionConfig)` as a function-definition in an invalid context, and made the generated `test_session_config_autogen/include/test_session_config.moc` fail with `expected '}' at end of input`.

### Fix Description
Insert the missing `}` to terminate `testDeserializationRejectsOutOfRange()` before `testAllowInvalidCertificatesDefaultsOff()`. Two-line change; no behavioral edits to any test logic.

### How Verified
- **Runtime (before):** `make` aborted while building `CMakeFiles/test_session_config.dir/tests/unit/test_session_config.cpp.o` with the `qualified-id in declaration before '('` chain on L230/L251/L280 plus the moc `expected '}' at end of input` error.
- **Runtime (after):** `make` completes with `[100%] Built target test_session_config` and `Build complete!`.
- **Runtime (tests):** `./build/test_session_config` — 10 passed, 0 failed, including `testDeserializationRejectsOutOfRange`, `testAllowInvalidCertificatesDefaultsOff`, `testAllowInvalidCertificatesRoundTrip` which were previously unreachable.

### Test Coverage
**Existing:** the three affected tests (`testDeserializationRejectsOutOfRange`, `testAllowInvalidCertificatesDefaultsOff`, `testAllowInvalidCertificatesRoundTrip`) now compile and run — they cover the logic they were designed to cover. No new tests are warranted: a syntactic typo that prevents compilation is caught the moment CI builds the target, which it already does.

### Scope of Change
- **Files changed:** `tests/unit/test_session_config.cpp`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Trivial and local: the change only adds a brace that should have been there, restoring the test suite to a compilable state. Safe to merge.