### PR TITLE
[enhancement] Document git clone command in Linux build instructions (#83)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@
 ### Linux (Ubuntu / Debian)
 
 ```bash
+git clone --recurse-submodules https://github.com/5250ng/5250ng.git
+cd 5250ng
 sudo apt install qt6-base-dev cmake g++ libxkbcommon-dev libssl-dev
 cmake -S . -B build
 cmake --build build


### PR DESCRIPTION
### Linked Issue
Closes #83

### Motivation
A first-time Linux contributor reported that the README's Linux (Ubuntu / Debian) build block does not tell the reader how to obtain the source. They guessed the right invocation — `git clone --recurse-submodules https://github.com/5250ng/5250ng.git` — but since the repo depends on two submodules (`libs/5250script`, `src/network/tn5250`), anyone who runs a plain `git clone` ends up with an empty submodule tree and a broken build. The Windows section already shows an equivalent `--recursive` line; Linux was the outlier.

### What Changed
In `README.md`, two lines prepended to the Linux install fenced block:

```
git clone --recurse-submodules https://github.com/5250ng/5250ng.git
cd 5250ng
```

Everything else (`apt install`, `cmake -S . -B build`, `cmake --build build`, launch line) is untouched. No other section of the README is modified.

### Acceptance Criteria Check
- [x] The Linux block starts with `git clone --recurse-submodules https://github.com/5250ng/5250ng.git` followed by `cd 5250ng` — see the diff on `README.md` L53–L54.
- [x] The remaining `apt install`, `cmake`, and launch lines are unchanged — diff shows insertions only, no context line rewrites.
- [x] No other section modified — `git diff --stat` reports `README.md | 2 ++` and nothing else.

### How Verified
- **Manual:** rendered the new `README.md` in the GitHub preview; the Linux fenced block reads top-to-bottom as a reproducible sequence (clone → cd → install deps → configure → build → run).
- **Runtime sanity:** `git clone --recurse-submodules https://github.com/5250ng/5250ng.git` is the exact command the reporting user used successfully, and matches the two submodule entries in `.gitmodules`.

### Test Coverage
**None:** docs-only change to `README.md`; there is no code path to test.

### Scope of Change
- **Files changed:** `README.md`
- **Submodule pointer updated:** no
- **Public API changes:** none
- **Behavioral changes outside the stated enhancement:** none

### Notes
macOS has the same gap (no `git clone` line in its install block). Not addressed here to keep scope tight to the reported feedback; easy to follow up with a separate enhancement if wanted.