### PR TITLE
[enhancement] Add virtual 5250 keyboard with user-configurable key remapping (#85)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,8 @@ set(CORE_SOURCES
     src/core/codepage.h
     src/core/keyboard_encoder.cpp
     src/core/keyboard_encoder.h
+    src/core/keyboard_mapping.cpp
+    src/core/keyboard_mapping.h
     src/core/hotspot_detector.cpp
     src/core/hotspot_detector.h
     src/core/screen_history.cpp
@@ -212,6 +214,8 @@ set(UI_SOURCES
     src/ui/widgets/QCRTOverlayWidget/QCRTOverlayWidget.h
     src/ui/widgets/QConnectionStatusWidget/QConnectionStatusWidget.cpp
     src/ui/widgets/QConnectionStatusWidget/QConnectionStatusWidget.h
+    src/ui/widgets/QVirtualKeyboardWidget/QVirtualKeyboardWidget.cpp
+    src/ui/widgets/QVirtualKeyboardWidget/QVirtualKeyboardWidget.h
     src/ui/widgets/Frameless/BaseFramelessWindow.cpp
     src/ui/widgets/Frameless/BaseFramelessWindow.h
     src/ui/widgets/Frameless/BaseFramelessDialog.cpp
@@ -241,6 +245,8 @@ set(UI_SOURCES
     src/ui/dialogs/theme_preview_widget.h
     src/ui/dialogs/match_replace_dialog.cpp
     src/ui/dialogs/match_replace_dialog.h
+    src/ui/dialogs/keyboard_remap_dialog.cpp
+    src/ui/dialogs/keyboard_remap_dialog.h
     # themes
     src/ui/themes/manager.cpp
     src/ui/themes/manager.h
@@ -278,6 +284,7 @@ set(UI_SOURCES
     src/ui/actions/onScreenHistory.cpp
     src/ui/actions/onToggleAgentPanel.cpp
     src/ui/actions/onMatchReplace.cpp
+    src/ui/actions/onVirtualKeyboard.cpp
     # setup
     src/ui/setup/setupUI.cpp
     src/ui/setup/setupMenuBar.cpp
@@ -395,6 +402,7 @@ if(BUILD_TESTS)
     add_tn5250_test(test_ebcdic tests/unit/test_ebcdic.cpp)
     add_tn5250_test(test_screen_buffer tests/unit/test_screen_buffer.cpp)
     add_tn5250_test(test_keyboard_encoder tests/unit/test_keyboard_encoder.cpp)
+    add_tn5250_test(test_keyboard_mapping tests/unit/test_keyboard_mapping.cpp)
     add_tn5250_test(test_session_config tests/unit/test_session_config.cpp)
 
     add_tn5250_test(test_ibmrseed tests/unit/test_ibmrseed.cpp)

--- a/src/core/keyboard_mapping.cpp
+++ b/src/core/keyboard_mapping.cpp
@@ -165,6 +165,14 @@ KeyChord KeyboardMapping::chordFor(MappedAction action) const {
     return KeyChord{};
 }
 
+QList<KeyChord> KeyboardMapping::chordsFor(MappedAction action) const {
+    QList<KeyChord> out;
+    for (auto it = m_chordToAction.constBegin(); it != m_chordToAction.constEnd(); ++it) {
+        if (it.value() == action) out.append(it.key());
+    }
+    return out;
+}
+
 void KeyboardMapping::setBinding(const KeyChord &chord, MappedAction action) {
     if (!chord.isValid()) return;
     if (action == MappedAction::None) {

--- a/src/core/keyboard_mapping.cpp
+++ b/src/core/keyboard_mapping.cpp
@@ -1,0 +1,287 @@
+// 5250ng - A modern IBM TN5250 terminal emulator
+// Copyright (C) 2025-2026 Remi GASCOU (Podalirius)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include "keyboard_mapping.h"
+
+#include <QJsonArray>
+#include <QKeySequence>
+#include <QSettings>
+#include <QStringList>
+
+namespace core {
+
+namespace {
+
+// Action <-> name mapping used for JSON and the dialog.
+// The name is stable (not localized) so saved mappings survive UI changes.
+struct ActionEntry {
+    MappedAction action;
+    const char *name;
+};
+
+const ActionEntry kActionEntries[] = {
+    {MappedAction::None, "None"},
+    {MappedAction::Enter, "Enter"},
+    {MappedAction::PF1, "PF1"},   {MappedAction::PF2, "PF2"},   {MappedAction::PF3, "PF3"},
+    {MappedAction::PF4, "PF4"},   {MappedAction::PF5, "PF5"},   {MappedAction::PF6, "PF6"},
+    {MappedAction::PF7, "PF7"},   {MappedAction::PF8, "PF8"},   {MappedAction::PF9, "PF9"},
+    {MappedAction::PF10, "PF10"}, {MappedAction::PF11, "PF11"}, {MappedAction::PF12, "PF12"},
+    {MappedAction::PF13, "PF13"}, {MappedAction::PF14, "PF14"}, {MappedAction::PF15, "PF15"},
+    {MappedAction::PF16, "PF16"}, {MappedAction::PF17, "PF17"}, {MappedAction::PF18, "PF18"},
+    {MappedAction::PF19, "PF19"}, {MappedAction::PF20, "PF20"}, {MappedAction::PF21, "PF21"},
+    {MappedAction::PF22, "PF22"}, {MappedAction::PF23, "PF23"}, {MappedAction::PF24, "PF24"},
+    {MappedAction::Clear, "Clear"},
+    {MappedAction::Help, "Help"},
+    {MappedAction::Print, "Print"},
+    {MappedAction::RollUp, "RollUp"},
+    {MappedAction::RollDown, "RollDown"},
+    {MappedAction::Attn, "Attn"},
+    {MappedAction::SysReq, "SysReq"},
+    {MappedAction::FieldExit, "FieldExit"},
+    {MappedAction::FieldPlus, "FieldPlus"},
+    {MappedAction::FieldMinus, "FieldMinus"},
+    {MappedAction::Tab, "Tab"},
+    {MappedAction::BackTab, "BackTab"},
+    {MappedAction::Home, "Home"},
+    {MappedAction::End, "End"},
+    {MappedAction::ArrowUp, "ArrowUp"},
+    {MappedAction::ArrowDown, "ArrowDown"},
+    {MappedAction::ArrowLeft, "ArrowLeft"},
+    {MappedAction::ArrowRight, "ArrowRight"},
+    {MappedAction::Backspace, "Backspace"},
+    {MappedAction::Delete, "Delete"},
+    {MappedAction::Insert, "Insert"},
+    {MappedAction::EraseEOF, "EraseEOF"},
+    {MappedAction::EraseField, "EraseField"},
+    {MappedAction::EraseInput, "EraseInput"},
+    {MappedAction::Dup, "Dup"},
+    {MappedAction::Reset, "Reset"},
+};
+
+} // namespace
+
+QString KeyChord::toString() const {
+    if (!isValid()) return QString();
+    return QKeySequence(static_cast<int>(modifiers) | key).toString(QKeySequence::PortableText);
+}
+
+KeyChord KeyChord::fromString(const QString &s) {
+    KeyChord out;
+    if (s.isEmpty()) return out;
+    QKeySequence seq(s, QKeySequence::PortableText);
+    if (seq.isEmpty()) return out;
+    int combined = seq[0].toCombined();
+    out.key = combined & ~Qt::KeyboardModifierMask;
+    out.modifiers = QFlags<Qt::KeyboardModifier>(
+        static_cast<Qt::KeyboardModifiers>(combined & Qt::KeyboardModifierMask));
+    return out;
+}
+
+KeyboardMapping::KeyboardMapping() {
+    resetToDefaults();
+}
+
+KeyboardMapping &KeyboardMapping::instance() {
+    static KeyboardMapping inst;
+    return inst;
+}
+
+void KeyboardMapping::resetToDefaults() {
+    m_chordToAction.clear();
+
+    // PF1..PF12 → F1..F12
+    for (int i = 0; i < 12; ++i) {
+        KeyChord c{Qt::Key_F1 + i, Qt::NoModifier};
+        m_chordToAction.insert(c, static_cast<MappedAction>(
+            static_cast<int>(MappedAction::PF1) + i));
+    }
+    // PF13..PF24 → Shift+F1..Shift+F12 (matches the existing convention)
+    for (int i = 0; i < 12; ++i) {
+        KeyChord c{Qt::Key_F1 + i, Qt::ShiftModifier};
+        m_chordToAction.insert(c, static_cast<MappedAction>(
+            static_cast<int>(MappedAction::PF13) + i));
+    }
+    // Native Qt F13..F24 when available on the host keyboard
+    for (int i = 0; i < 12; ++i) {
+        KeyChord c{Qt::Key_F13 + i, Qt::NoModifier};
+        m_chordToAction.insert(c, static_cast<MappedAction>(
+            static_cast<int>(MappedAction::PF13) + i));
+    }
+
+    m_chordToAction.insert({Qt::Key_Return, Qt::NoModifier}, MappedAction::Enter);
+    m_chordToAction.insert({Qt::Key_Enter, Qt::NoModifier}, MappedAction::Enter);
+    m_chordToAction.insert({Qt::Key_Escape, Qt::ControlModifier}, MappedAction::Attn);
+    m_chordToAction.insert({Qt::Key_SysReq, Qt::NoModifier}, MappedAction::SysReq);
+    m_chordToAction.insert({Qt::Key_PageUp, Qt::NoModifier}, MappedAction::RollUp);
+    m_chordToAction.insert({Qt::Key_PageDown, Qt::NoModifier}, MappedAction::RollDown);
+    m_chordToAction.insert({Qt::Key_Tab, Qt::NoModifier}, MappedAction::Tab);
+    m_chordToAction.insert({Qt::Key_Backtab, Qt::NoModifier}, MappedAction::BackTab);
+    m_chordToAction.insert({Qt::Key_Tab, Qt::ShiftModifier}, MappedAction::BackTab);
+    m_chordToAction.insert({Qt::Key_Home, Qt::NoModifier}, MappedAction::Home);
+    m_chordToAction.insert({Qt::Key_End, Qt::NoModifier}, MappedAction::End);
+    m_chordToAction.insert({Qt::Key_End, Qt::ControlModifier}, MappedAction::FieldExit);
+    m_chordToAction.insert({Qt::Key_Up, Qt::NoModifier}, MappedAction::ArrowUp);
+    m_chordToAction.insert({Qt::Key_Down, Qt::NoModifier}, MappedAction::ArrowDown);
+    m_chordToAction.insert({Qt::Key_Left, Qt::NoModifier}, MappedAction::ArrowLeft);
+    m_chordToAction.insert({Qt::Key_Right, Qt::NoModifier}, MappedAction::ArrowRight);
+    m_chordToAction.insert({Qt::Key_Backspace, Qt::NoModifier}, MappedAction::Backspace);
+    m_chordToAction.insert({Qt::Key_Backspace, Qt::ControlModifier}, MappedAction::EraseField);
+    m_chordToAction.insert({Qt::Key_Delete, Qt::NoModifier}, MappedAction::Delete);
+    m_chordToAction.insert({Qt::Key_Delete, Qt::ControlModifier}, MappedAction::EraseEOF);
+    m_chordToAction.insert({Qt::Key_Delete, Qt::AltModifier}, MappedAction::EraseInput);
+    m_chordToAction.insert({Qt::Key_Insert, Qt::NoModifier}, MappedAction::Insert);
+    m_chordToAction.insert({Qt::Key_Insert, Qt::ShiftModifier}, MappedAction::Dup);
+    m_chordToAction.insert({Qt::Key_Plus, Qt::AltModifier}, MappedAction::FieldPlus);
+    m_chordToAction.insert({Qt::Key_Minus, Qt::AltModifier}, MappedAction::FieldMinus);
+}
+
+MappedAction KeyboardMapping::lookup(int key, Qt::KeyboardModifiers modifiers) const {
+    return lookup(KeyChord{key, modifiers});
+}
+
+MappedAction KeyboardMapping::lookup(const KeyChord &chord) const {
+    auto it = m_chordToAction.constFind(chord);
+    if (it == m_chordToAction.constEnd()) return MappedAction::None;
+    return it.value();
+}
+
+KeyChord KeyboardMapping::chordFor(MappedAction action) const {
+    for (auto it = m_chordToAction.constBegin(); it != m_chordToAction.constEnd(); ++it) {
+        if (it.value() == action) return it.key();
+    }
+    return KeyChord{};
+}
+
+void KeyboardMapping::setBinding(const KeyChord &chord, MappedAction action) {
+    if (!chord.isValid()) return;
+    if (action == MappedAction::None) {
+        m_chordToAction.remove(chord);
+        return;
+    }
+    m_chordToAction.insert(chord, action);
+}
+
+void KeyboardMapping::clearChord(const KeyChord &chord) {
+    m_chordToAction.remove(chord);
+}
+
+void KeyboardMapping::clearAction(MappedAction action) {
+    QList<KeyChord> toRemove;
+    for (auto it = m_chordToAction.constBegin(); it != m_chordToAction.constEnd(); ++it) {
+        if (it.value() == action) toRemove.append(it.key());
+    }
+    for (const auto &c : toRemove) m_chordToAction.remove(c);
+}
+
+void KeyboardMapping::replaceAllBindings(const QHash<KeyChord, MappedAction> &bindings) {
+    m_chordToAction = bindings;
+}
+
+void KeyboardMapping::load() {
+    QSettings settings;
+    settings.beginGroup("KeyboardMapping");
+    // beginReadArray returns 0 when nothing was saved, which preserves defaults.
+    int n = settings.beginReadArray("entries");
+    if (n <= 0) {
+        settings.endArray();
+        settings.endGroup();
+        return;
+    }
+    QHash<KeyChord, MappedAction> loaded;
+    for (int i = 0; i < n; ++i) {
+        settings.setArrayIndex(i);
+        QString chordStr = settings.value("chord").toString();
+        QString actionName = settings.value("action").toString();
+        KeyChord chord = KeyChord::fromString(chordStr);
+        MappedAction action = KeyboardMapping::actionFromName(actionName);
+        if (chord.isValid() && action != MappedAction::None) {
+            loaded.insert(chord, action);
+        }
+    }
+    settings.endArray();
+    settings.endGroup();
+    // Replace unconditionally: a saved mapping with zero valid entries is an
+    // explicit "no bindings" state the user intentionally exported.
+    m_chordToAction = loaded;
+}
+
+void KeyboardMapping::save() const {
+    QSettings settings;
+    settings.beginGroup("KeyboardMapping");
+    settings.remove("");
+    settings.beginWriteArray("entries", m_chordToAction.size());
+    int i = 0;
+    for (auto it = m_chordToAction.constBegin(); it != m_chordToAction.constEnd(); ++it, ++i) {
+        settings.setArrayIndex(i);
+        settings.setValue("chord", it.key().toString());
+        settings.setValue("action", KeyboardMapping::actionName(it.value()));
+    }
+    settings.endArray();
+    settings.endGroup();
+}
+
+QJsonObject KeyboardMapping::toJson() const {
+    QJsonArray arr;
+    for (auto it = m_chordToAction.constBegin(); it != m_chordToAction.constEnd(); ++it) {
+        QJsonObject o;
+        o["chord"] = it.key().toString();
+        o["action"] = KeyboardMapping::actionName(it.value());
+        arr.append(o);
+    }
+    QJsonObject root;
+    root["entries"] = arr;
+    return root;
+}
+
+bool KeyboardMapping::fromJson(const QJsonObject &obj) {
+    if (!obj.contains("entries") || !obj["entries"].isArray()) return false;
+    QHash<KeyChord, MappedAction> loaded;
+    for (const auto &v : obj["entries"].toArray()) {
+        if (!v.isObject()) continue;
+        QJsonObject e = v.toObject();
+        KeyChord chord = KeyChord::fromString(e["chord"].toString());
+        MappedAction action = KeyboardMapping::actionFromName(e["action"].toString());
+        if (chord.isValid() && action != MappedAction::None) {
+            loaded.insert(chord, action);
+        }
+    }
+    m_chordToAction = loaded;
+    return true;
+}
+
+QString KeyboardMapping::actionName(MappedAction action) {
+    for (const auto &e : kActionEntries) {
+        if (e.action == action) return QString::fromLatin1(e.name);
+    }
+    return QStringLiteral("None");
+}
+
+MappedAction KeyboardMapping::actionFromName(const QString &name) {
+    for (const auto &e : kActionEntries) {
+        if (name == QLatin1String(e.name)) return e.action;
+    }
+    return MappedAction::None;
+}
+
+QList<MappedAction> KeyboardMapping::allActions() {
+    QList<MappedAction> out;
+    for (const auto &e : kActionEntries) {
+        if (e.action != MappedAction::None) out.append(e.action);
+    }
+    return out;
+}
+
+} // namespace core

--- a/src/core/keyboard_mapping.h
+++ b/src/core/keyboard_mapping.h
@@ -101,8 +101,15 @@ class KeyboardMapping {
     MappedAction lookup(const KeyChord &chord) const;
 
     // Reverse lookup: return the chord currently bound to an action, or an
-    // empty chord (isValid()==false) if none is bound.
+    // empty chord (isValid()==false) if none is bound. When several chords are
+    // bound to the same action the result is unspecified among them; callers
+    // that care about the full set should use chordsFor() instead.
     KeyChord chordFor(MappedAction action) const;
+
+    // All chords currently bound to a given action. Empty if the action has
+    // no binding. Ordering is stable within a run but not guaranteed across
+    // runs (QHash iteration order).
+    QList<KeyChord> chordsFor(MappedAction action) const;
 
     // Set or clear a binding. Setting a chord that was previously bound to a
     // different action unbinds the old action silently. Setting action=None

--- a/src/core/keyboard_mapping.h
+++ b/src/core/keyboard_mapping.h
@@ -1,0 +1,138 @@
+// 5250ng - A modern IBM TN5250 terminal emulator
+// Copyright (C) 2025-2026 Remi GASCOU (Podalirius)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <QHash>
+#include <QJsonObject>
+#include <QList>
+#include <QMetaType>
+#include <QString>
+#include <Qt>
+#include <optional>
+
+namespace core {
+
+// Every 5250 action a user can bind a host key chord to.
+// These are logical actions (what the operator means to do), not wire bytes.
+enum class MappedAction : int {
+    None = 0,
+    // AID keys
+    Enter,
+    PF1, PF2, PF3, PF4, PF5, PF6, PF7, PF8, PF9, PF10, PF11, PF12,
+    PF13, PF14, PF15, PF16, PF17, PF18, PF19, PF20, PF21, PF22, PF23, PF24,
+    Clear,
+    Help,
+    Print,
+    RollUp,
+    RollDown,
+    Attn,
+    SysReq,
+    // Field / cursor
+    FieldExit,
+    FieldPlus,
+    FieldMinus,
+    Tab,
+    BackTab,
+    Home,
+    End,
+    ArrowUp,
+    ArrowDown,
+    ArrowLeft,
+    ArrowRight,
+    // Editing
+    Backspace,
+    Delete,
+    Insert,
+    EraseEOF,
+    EraseField,
+    EraseInput,
+    Dup,
+    // Misc
+    Reset,
+};
+
+struct KeyChord {
+    int key = 0;                                 // Qt::Key value
+    Qt::KeyboardModifiers modifiers = Qt::NoModifier;
+
+    bool isValid() const { return key != 0; }
+    bool operator==(const KeyChord &o) const {
+        return key == o.key && modifiers == o.modifiers;
+    }
+    bool operator!=(const KeyChord &o) const { return !(*this == o); }
+
+    // Serialize to/from a string like "Shift+F1" or "Ctrl+Alt+R".
+    QString toString() const;
+    static KeyChord fromString(const QString &s);
+};
+
+inline uint qHash(const KeyChord &c, uint seed = 0) noexcept {
+    return ::qHash(c.key, seed) ^ static_cast<uint>(c.modifiers);
+}
+
+class KeyboardMapping {
+  public:
+    static KeyboardMapping &instance();
+
+    // Persistence (uses QSettings group "KeyboardMapping").
+    void load();
+    void save() const;
+
+    // Defaults mirror the hardcoded behavior of
+    // KeyboardEncoder / Q5250ScreenWidget so existing users see no change.
+    void resetToDefaults();
+
+    // Lookup a chord; returns None when no binding is set.
+    MappedAction lookup(int key, Qt::KeyboardModifiers modifiers) const;
+    MappedAction lookup(const KeyChord &chord) const;
+
+    // Reverse lookup: return the chord currently bound to an action, or an
+    // empty chord (isValid()==false) if none is bound.
+    KeyChord chordFor(MappedAction action) const;
+
+    // Set or clear a binding. Setting a chord that was previously bound to a
+    // different action unbinds the old action silently. Setting action=None
+    // removes the chord; calling clearAction() removes by action.
+    void setBinding(const KeyChord &chord, MappedAction action);
+    void clearChord(const KeyChord &chord);
+    void clearAction(MappedAction action);
+
+    // Full snapshot / replace (for dialog apply).
+    QHash<KeyChord, MappedAction> allBindings() const { return m_chordToAction; }
+    void replaceAllBindings(const QHash<KeyChord, MappedAction> &bindings);
+
+    // JSON import/export.
+    QJsonObject toJson() const;
+    bool fromJson(const QJsonObject &obj);
+
+    // Friendly names for the mapping table UI.
+    static QString actionName(MappedAction action);
+    static QList<MappedAction> allActions();
+    static MappedAction actionFromName(const QString &name);
+
+    // Construct an empty table. Callers typically use instance() or
+    // resetToDefaults(); the public constructor is provided for JSON
+    // import/export and unit tests.
+    KeyboardMapping();
+
+  private:
+    QHash<KeyChord, MappedAction> m_chordToAction;
+};
+
+} // namespace core
+
+Q_DECLARE_METATYPE(core::MappedAction)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,6 +16,7 @@
 
 #include "version.h"
 #include "agent/config.h"
+#include "core/keyboard_mapping.h"
 #include "logger/logger.h"
 #include "session/config.h"
 #include "session/manager.h"
@@ -241,6 +242,9 @@ int main(int argc, char *argv[]) {
     // Load terminal themes (builtin + user-created)
     ui::themes::TerminalThemeManager::instance().loadBuiltinThemes();
     ui::themes::TerminalThemeManager::instance().loadUserThemes();
+
+    // Load user keyboard mapping (falls back to defaults when none saved).
+    core::KeyboardMapping::instance().load();
 
     MainWindow win;
     win.show();

--- a/src/ui/actions/onCurrentTabChanged.cpp
+++ b/src/ui/actions/onCurrentTabChanged.cpp
@@ -18,6 +18,9 @@
 
 void MainWindow::onCurrentTabChanged(int index) {
     setActiveSession(index);
+    // Re-route the virtual keyboard pulse feed onto the new active session so
+    // the on-screen keyboard keeps highlighting the right host chord.
+    rebindVirtualKeyboardPulse();
     if (index >= 0 && index < m_sessions.size()) {
         Session *s = m_sessions[index];
         // Clear activity indicator when the tab gains focus

--- a/src/ui/actions/onVirtualKeyboard.cpp
+++ b/src/ui/actions/onVirtualKeyboard.cpp
@@ -38,6 +38,22 @@ void MainWindow::onToggleVirtualKeyboard() {
     bool show = !m_virtualKeyboard->isVisible();
     m_virtualKeyboard->setVisible(show);
     if (m_virtualKeyboardAction) m_virtualKeyboardAction->setChecked(show);
+    rebindVirtualKeyboardPulse();
+}
+
+void MainWindow::rebindVirtualKeyboardPulse() {
+    // Drop the previous session's connection (harmless if it is already stale).
+    if (m_virtualKeyboardPulseConnection) {
+        QObject::disconnect(m_virtualKeyboardPulseConnection);
+        m_virtualKeyboardPulseConnection = QMetaObject::Connection();
+    }
+    if (!m_virtualKeyboard || !m_virtualKeyboard->isVisible() || !m_displayWidget) return;
+    m_virtualKeyboardPulseConnection = connect(
+        m_displayWidget, &ui::widgets::Q5250ScreenWidget::keyRecorded,
+        m_virtualKeyboard,
+        [this](int key, Qt::KeyboardModifiers mods, const QString &) {
+            m_virtualKeyboard->pulseForChord(key, mods);
+        });
 }
 
 void MainWindow::onEditKeyboardMapping() {

--- a/src/ui/actions/onVirtualKeyboard.cpp
+++ b/src/ui/actions/onVirtualKeyboard.cpp
@@ -1,0 +1,71 @@
+// 5250ng - A modern IBM TN5250 terminal emulator
+// Copyright (C) 2025-2026 Remi GASCOU (Podalirius)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include "../main_window.h"
+#include "ui/dialogs/keyboard_remap_dialog.h"
+#include <QVBoxLayout>
+
+void MainWindow::onToggleVirtualKeyboard() {
+    if (!m_virtualKeyboard) {
+        m_virtualKeyboard = new ui::widgets::QVirtualKeyboardWidget(this);
+        connect(m_virtualKeyboard, &ui::widgets::QVirtualKeyboardWidget::actionTriggered,
+                this, &MainWindow::onVirtualKeyboardAction);
+        connect(m_virtualKeyboard, &ui::widgets::QVirtualKeyboardWidget::characterTriggered,
+                this, &MainWindow::onVirtualKeyboardCharacter);
+        connect(m_virtualKeyboard, &ui::widgets::QVirtualKeyboardWidget::remapRequested,
+                this, &MainWindow::onVirtualKeyboardRemap);
+        // Attach at the bottom of the main content area.
+        QVBoxLayout *root = contentLayout();
+        if (root) {
+            // Insert before the last widget (global bottom status bar).
+            int insertAt = root->count() > 0 ? root->count() - 1 : 0;
+            root->insertWidget(insertAt, m_virtualKeyboard);
+        }
+    }
+    bool show = !m_virtualKeyboard->isVisible();
+    m_virtualKeyboard->setVisible(show);
+    if (m_virtualKeyboardAction) m_virtualKeyboardAction->setChecked(show);
+}
+
+void MainWindow::onEditKeyboardMapping() {
+    ui::dialogs::KeyboardRemapDialog dlg(this);
+    connect(&dlg, &ui::dialogs::KeyboardRemapDialog::mappingChanged, this, [this]() {
+        if (m_virtualKeyboard) m_virtualKeyboard->refreshChordLabels();
+    });
+    dlg.exec();
+}
+
+void MainWindow::onVirtualKeyboardAction(core::MappedAction action) {
+    if (m_displayWidget) {
+        m_displayWidget->setFocus();
+        m_displayWidget->dispatchMappedAction(action);
+    }
+}
+
+void MainWindow::onVirtualKeyboardCharacter(QChar ch) {
+    if (m_displayWidget) {
+        m_displayWidget->setFocus();
+        m_displayWidget->dispatchCharacter(ch);
+    }
+}
+
+void MainWindow::onVirtualKeyboardRemap(core::MappedAction action) {
+    ui::dialogs::KeyboardRemapDialog dlg(this, action);
+    connect(&dlg, &ui::dialogs::KeyboardRemapDialog::mappingChanged, this, [this]() {
+        if (m_virtualKeyboard) m_virtualKeyboard->refreshChordLabels();
+    });
+    dlg.exec();
+}

--- a/src/ui/dialogs/keyboard_remap_dialog.cpp
+++ b/src/ui/dialogs/keyboard_remap_dialog.cpp
@@ -27,6 +27,7 @@
 #include <QKeySequence>
 #include <QLabel>
 #include <QPushButton>
+#include <QSignalBlocker>
 #include <QString>
 #include <QVBoxLayout>
 
@@ -67,12 +68,92 @@ void KeyChordCaptureEdit::keyPressEvent(QKeyEvent *event) {
     event->accept();
 }
 
+// --- ChordListEditor -------------------------------------------------------
+
+ChordListEditor::ChordListEditor(MappedAction action, QWidget *parent)
+    : QWidget(parent), m_action(action) {
+    m_layout = new QHBoxLayout(this);
+    m_layout->setContentsMargins(0, 0, 0, 0);
+    m_layout->setSpacing(4);
+    m_addBtn = new QPushButton(tr("+ Add chord"), this);
+    m_addBtn->setFocusPolicy(Qt::NoFocus);
+    connect(m_addBtn, &QPushButton::clicked, this, [this]() {
+        addChip(core::KeyChord{}, /*startFocused=*/true);
+    });
+    m_layout->addWidget(m_addBtn);
+    m_layout->addStretch(1);
+}
+
+QList<core::KeyChord> ChordListEditor::chords() const {
+    QList<core::KeyChord> out;
+    for (const auto &e : m_entries) {
+        core::KeyChord c = e.edit->chord();
+        if (c.isValid()) out.append(c);
+    }
+    return out;
+}
+
+void ChordListEditor::setChords(const QList<core::KeyChord> &chords) {
+    // Clear and rebuild; block signals so we don't emit during setup.
+    while (!m_entries.isEmpty()) {
+        Entry e = m_entries.takeLast();
+        m_layout->removeWidget(e.edit);
+        m_layout->removeWidget(e.removeBtn);
+        e.edit->deleteLater();
+        e.removeBtn->deleteLater();
+    }
+    QSignalBlocker block(this);
+    for (const auto &c : chords) addChip(c, /*startFocused=*/false);
+}
+
+void ChordListEditor::addChip(const core::KeyChord &chord, bool startFocused) {
+    Entry entry;
+    entry.edit = new KeyChordCaptureEdit(this);
+    entry.edit->setChord(chord);
+    entry.edit->setMinimumWidth(140);
+    entry.removeBtn = new QPushButton(QString::fromUtf8("\xc3\x97"), this); // ×
+    entry.removeBtn->setFocusPolicy(Qt::NoFocus);
+    entry.removeBtn->setFixedWidth(24);
+    entry.removeBtn->setToolTip(tr("Remove this chord"));
+
+    // Insert before the "+ Add chord" button and the trailing stretch.
+    int insertAt = m_layout->count() - 2;
+    if (insertAt < 0) insertAt = 0;
+    m_layout->insertWidget(insertAt, entry.edit);
+    m_layout->insertWidget(insertAt + 1, entry.removeBtn);
+    m_entries.append(entry);
+
+    connect(entry.edit, &KeyChordCaptureEdit::chordCaptured, this,
+            [this](const core::KeyChord &) { emitChords(); });
+    connect(entry.removeBtn, &QPushButton::clicked, this, [this, editPtr = entry.edit]() {
+        for (int i = 0; i < m_entries.size(); ++i) {
+            if (m_entries[i].edit == editPtr) { removeChipAt(i); return; }
+        }
+    });
+
+    if (startFocused) entry.edit->setFocus();
+}
+
+void ChordListEditor::removeChipAt(int index) {
+    if (index < 0 || index >= m_entries.size()) return;
+    Entry e = m_entries.takeAt(index);
+    m_layout->removeWidget(e.edit);
+    m_layout->removeWidget(e.removeBtn);
+    e.edit->deleteLater();
+    e.removeBtn->deleteLater();
+    emitChords();
+}
+
+void ChordListEditor::emitChords() {
+    emit chordsChanged(m_action, chords());
+}
+
 // --- KeyboardRemapDialog ---------------------------------------------------
 
 KeyboardRemapDialog::KeyboardRemapDialog(QWidget *parent, MappedAction focusOn)
     : ui::widgets::BaseFramelessDialog(parent), m_focusOn(focusOn) {
     setWindowTitle(tr("Remap Keyboard"));
-    resize(640, 520);
+    resize(720, 560);
     m_working = KeyboardMapping::instance().allBindings();
     buildUI();
     populateRows();
@@ -81,8 +162,8 @@ KeyboardRemapDialog::KeyboardRemapDialog(QWidget *parent, MappedAction focusOn)
         if (row >= 0) {
             m_table->scrollToItem(m_table->item(row, 0));
             m_table->setCurrentCell(row, 1);
-            QWidget *w = m_table->cellWidget(row, 1);
-            if (w) w->setFocus();
+            ChordListEditor *editor = editorForAction(m_focusOn);
+            if (editor) editor->setFocus();
         }
     }
 }
@@ -99,12 +180,11 @@ void KeyboardRemapDialog::buildUI() {
     root->addWidget(hint);
 
     m_table = new QTableWidget(this);
-    m_table->setColumnCount(3);
-    m_table->setHorizontalHeaderLabels({tr("Action"), tr("Chord"), tr("")});
-    m_table->horizontalHeader()->setStretchLastSection(false);
+    m_table->setColumnCount(2);
+    m_table->setHorizontalHeaderLabels({tr("Action"), tr("Chords")});
+    m_table->horizontalHeader()->setStretchLastSection(true);
     m_table->horizontalHeader()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
     m_table->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);
-    m_table->horizontalHeader()->setSectionResizeMode(2, QHeaderView::ResizeToContents);
     m_table->verticalHeader()->setVisible(false);
     m_table->setSelectionBehavior(QAbstractItemView::SelectRows);
     m_table->setEditTriggers(QAbstractItemView::NoEditTriggers);
@@ -142,50 +222,51 @@ void KeyboardRemapDialog::populateRows() {
         nameItem->setData(Qt::UserRole, static_cast<int>(action));
         m_table->setItem(r, 0, nameItem);
 
-        // Find the chord currently bound to this action in the working copy.
-        KeyChord bound;
+        // Collect every chord currently bound to this action from the working copy.
+        QList<KeyChord> bound;
         for (auto it = m_working.constBegin(); it != m_working.constEnd(); ++it) {
-            if (it.value() == action) { bound = it.key(); break; }
+            if (it.value() == action) bound.append(it.key());
         }
 
-        auto *chordEdit = new KeyChordCaptureEdit(this);
-        chordEdit->setChord(bound);
-        connect(chordEdit, &KeyChordCaptureEdit::chordCaptured, this,
-                [this, action, chordEdit](const KeyChord &chord) {
-                    // Remove the action's old binding and any other action that used the new chord.
-                    for (auto it = m_working.begin(); it != m_working.end();) {
-                        if (it.value() == action) {
-                            it = m_working.erase(it);
-                        } else if (chord.isValid() && it.key() == chord) {
-                            // Clear the row that previously owned this chord.
-                            MappedAction replaced = it.value();
-                            int row = rowForAction(replaced);
-                            if (row >= 0) {
-                                auto *w = qobject_cast<KeyChordCaptureEdit *>(m_table->cellWidget(row, 1));
-                                if (w) w->setChord(KeyChord{});
-                            }
-                            it = m_working.erase(it);
-                        } else {
-                            ++it;
-                        }
-                    }
-                    if (chord.isValid()) m_working.insert(chord, action);
-                    // Reflect change in the edit itself.
-                    chordEdit->setChord(chord);
-                });
-        m_table->setCellWidget(r, 1, chordEdit);
-
-        auto *clearBtn = new QPushButton(tr("Clear"), this);
-        clearBtn->setFocusPolicy(Qt::NoFocus);
-        connect(clearBtn, &QPushButton::clicked, this, [this, action, chordEdit]() {
-            for (auto it = m_working.begin(); it != m_working.end();) {
-                if (it.value() == action) it = m_working.erase(it);
-                else ++it;
-            }
-            chordEdit->setChord(KeyChord{});
-        });
-        m_table->setCellWidget(r, 2, clearBtn);
+        auto *editor = new ChordListEditor(action, this);
+        editor->setChords(bound);
+        connect(editor, &ChordListEditor::chordsChanged,
+                this, &KeyboardRemapDialog::onRowChordsChanged);
+        m_table->setCellWidget(r, 1, editor);
     }
+    m_table->resizeRowsToContents();
+}
+
+void KeyboardRemapDialog::onRowChordsChanged(MappedAction action,
+                                             const QList<KeyChord> &chords) {
+    // Drop every existing binding for this action so we can rebuild from the
+    // editor's current set.
+    for (auto it = m_working.begin(); it != m_working.end();) {
+        if (it.value() == action) it = m_working.erase(it);
+        else ++it;
+    }
+
+    // For each captured chord: steal it from whichever action owned it, then
+    // assign it to this one. Editors that lose a chord are refreshed in place.
+    for (const auto &chord : chords) {
+        if (!chord.isValid()) continue;
+        auto existing = m_working.constFind(chord);
+        if (existing != m_working.constEnd() && existing.value() != action) {
+            MappedAction prevOwner = existing.value();
+            m_working.remove(chord);
+            ChordListEditor *otherEditor = editorForAction(prevOwner);
+            if (otherEditor) {
+                QList<KeyChord> remaining;
+                for (const auto &c : otherEditor->chords()) {
+                    if (c != chord) remaining.append(c);
+                }
+                QSignalBlocker block(otherEditor);
+                otherEditor->setChords(remaining);
+            }
+        }
+        m_working.insert(chord, action);
+    }
+    m_table->resizeRowsToContents();
 }
 
 int KeyboardRemapDialog::rowForAction(MappedAction action) const {
@@ -194,6 +275,12 @@ int KeyboardRemapDialog::rowForAction(MappedAction action) const {
         if (it && it->data(Qt::UserRole).toInt() == static_cast<int>(action)) return r;
     }
     return -1;
+}
+
+ChordListEditor *KeyboardRemapDialog::editorForAction(MappedAction action) const {
+    int row = rowForAction(action);
+    if (row < 0) return nullptr;
+    return qobject_cast<ChordListEditor *>(m_table->cellWidget(row, 1));
 }
 
 void KeyboardRemapDialog::onResetDefaultsClicked() {

--- a/src/ui/dialogs/keyboard_remap_dialog.cpp
+++ b/src/ui/dialogs/keyboard_remap_dialog.cpp
@@ -239,6 +239,43 @@ void KeyboardRemapDialog::populateRows() {
 
 void KeyboardRemapDialog::onRowChordsChanged(MappedAction action,
                                              const QList<KeyChord> &chords) {
+    // Snapshot this action's previous bindings BEFORE any mutation so we can
+    // roll the editor back if the user declines a conflict prompt.
+    QList<KeyChord> previous;
+    for (auto it = m_working.constBegin(); it != m_working.constEnd(); ++it) {
+        if (it.value() == action) previous.append(it.key());
+    }
+
+    // Ask the user before silently stealing a chord from a different action.
+    // Only newly captured chords are candidates — reordering or re-entering the
+    // same chord must not trigger a prompt.
+    for (const auto &chord : chords) {
+        if (!chord.isValid()) continue;
+        if (previous.contains(chord)) continue;
+        auto existing = m_working.constFind(chord);
+        if (existing == m_working.constEnd() || existing.value() == action) continue;
+
+        MappedAction prevOwner = existing.value();
+        QString prompt = tr(
+            "%1 is currently bound to \"%2\".\n\n"
+            "Replace that binding with \"%3\"?")
+            .arg(chord.toString(),
+                 KeyboardMapping::actionName(prevOwner),
+                 KeyboardMapping::actionName(action));
+        auto result = ui::widgets::StyledMessageBox::question(
+            this, tr("Replace existing binding?"), prompt);
+        if (result != ui::widgets::StyledMessageBox::Yes) {
+            // Roll the row back to its prior state without touching m_working.
+            ChordListEditor *editor = editorForAction(action);
+            if (editor) {
+                QSignalBlocker block(editor);
+                editor->setChords(previous);
+            }
+            m_table->resizeRowsToContents();
+            return;
+        }
+    }
+
     // Drop every existing binding for this action so we can rebuild from the
     // editor's current set.
     for (auto it = m_working.begin(); it != m_working.end();) {

--- a/src/ui/dialogs/keyboard_remap_dialog.cpp
+++ b/src/ui/dialogs/keyboard_remap_dialog.cpp
@@ -1,0 +1,263 @@
+// 5250ng - A modern IBM TN5250 terminal emulator
+// Copyright (C) 2025-2026 Remi GASCOU (Podalirius)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include "keyboard_remap_dialog.h"
+
+#include "ui/widgets/Frameless/StyledFileDialog.h"
+#include "ui/widgets/Frameless/StyledMessageBox.h"
+#include <QFile>
+#include <QHBoxLayout>
+#include <QHeaderView>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QKeyEvent>
+#include <QKeySequence>
+#include <QLabel>
+#include <QPushButton>
+#include <QString>
+#include <QVBoxLayout>
+
+namespace ui::dialogs {
+
+using core::KeyboardMapping;
+using core::KeyChord;
+using core::MappedAction;
+
+// --- KeyChordCaptureEdit ----------------------------------------------------
+
+KeyChordCaptureEdit::KeyChordCaptureEdit(QWidget *parent) : QLineEdit(parent) {
+    setReadOnly(true);
+    setPlaceholderText(tr("Click and press a chord…"));
+    setFocusPolicy(Qt::StrongFocus);
+}
+
+void KeyChordCaptureEdit::setChord(const core::KeyChord &chord) {
+    m_chord = chord;
+    setText(chord.isValid() ? chord.toString() : QString());
+}
+
+void KeyChordCaptureEdit::keyPressEvent(QKeyEvent *event) {
+    // Ignore bare modifier presses — wait for a real key.
+    int key = event->key();
+    if (key == Qt::Key_Shift || key == Qt::Key_Control ||
+        key == Qt::Key_Alt || key == Qt::Key_Meta ||
+        key == Qt::Key_AltGr || key == Qt::Key_CapsLock) {
+        QLineEdit::keyPressEvent(event);
+        return;
+    }
+    KeyChord c;
+    c.key = key;
+    c.modifiers = event->modifiers() & (Qt::ShiftModifier | Qt::ControlModifier |
+                                        Qt::AltModifier | Qt::MetaModifier);
+    setChord(c);
+    emit chordCaptured(c);
+    event->accept();
+}
+
+// --- KeyboardRemapDialog ---------------------------------------------------
+
+KeyboardRemapDialog::KeyboardRemapDialog(QWidget *parent, MappedAction focusOn)
+    : ui::widgets::BaseFramelessDialog(parent), m_focusOn(focusOn) {
+    setWindowTitle(tr("Remap Keyboard"));
+    resize(640, 520);
+    m_working = KeyboardMapping::instance().allBindings();
+    buildUI();
+    populateRows();
+    if (m_focusOn != MappedAction::None) {
+        int row = rowForAction(m_focusOn);
+        if (row >= 0) {
+            m_table->scrollToItem(m_table->item(row, 0));
+            m_table->setCurrentCell(row, 1);
+            QWidget *w = m_table->cellWidget(row, 1);
+            if (w) w->setFocus();
+        }
+    }
+}
+
+void KeyboardRemapDialog::buildUI() {
+    QVBoxLayout *root = contentLayout();
+    root->setContentsMargins(10, 10, 10, 10);
+    root->setSpacing(8);
+
+    QLabel *hint = new QLabel(
+        tr("Click a Chord field, then press the host keyboard combination you "
+           "want bound to the 5250 action. Leave blank to unbind."), this);
+    hint->setWordWrap(true);
+    root->addWidget(hint);
+
+    m_table = new QTableWidget(this);
+    m_table->setColumnCount(3);
+    m_table->setHorizontalHeaderLabels({tr("Action"), tr("Chord"), tr("")});
+    m_table->horizontalHeader()->setStretchLastSection(false);
+    m_table->horizontalHeader()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
+    m_table->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);
+    m_table->horizontalHeader()->setSectionResizeMode(2, QHeaderView::ResizeToContents);
+    m_table->verticalHeader()->setVisible(false);
+    m_table->setSelectionBehavior(QAbstractItemView::SelectRows);
+    m_table->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    root->addWidget(m_table, 1);
+
+    QHBoxLayout *btns = new QHBoxLayout();
+    QPushButton *resetBtn = new QPushButton(tr("Reset to Defaults"), this);
+    QPushButton *importBtn = new QPushButton(tr("Import…"), this);
+    QPushButton *exportBtn = new QPushButton(tr("Export…"), this);
+    btns->addWidget(resetBtn);
+    btns->addWidget(importBtn);
+    btns->addWidget(exportBtn);
+    btns->addStretch(1);
+    QPushButton *cancelBtn = new QPushButton(tr("Cancel"), this);
+    QPushButton *saveBtn = new QPushButton(tr("Save"), this);
+    saveBtn->setDefault(true);
+    btns->addWidget(cancelBtn);
+    btns->addWidget(saveBtn);
+    root->addLayout(btns);
+
+    connect(resetBtn, &QPushButton::clicked, this, &KeyboardRemapDialog::onResetDefaultsClicked);
+    connect(importBtn, &QPushButton::clicked, this, &KeyboardRemapDialog::onImportClicked);
+    connect(exportBtn, &QPushButton::clicked, this, &KeyboardRemapDialog::onExportClicked);
+    connect(cancelBtn, &QPushButton::clicked, this, &KeyboardRemapDialog::onCancelClicked);
+    connect(saveBtn, &QPushButton::clicked, this, &KeyboardRemapDialog::onSaveClicked);
+}
+
+void KeyboardRemapDialog::populateRows() {
+    const QList<MappedAction> actions = KeyboardMapping::allActions();
+    m_table->setRowCount(actions.size());
+    for (int r = 0; r < actions.size(); ++r) {
+        MappedAction action = actions[r];
+        auto *nameItem = new QTableWidgetItem(KeyboardMapping::actionName(action));
+        nameItem->setFlags(nameItem->flags() & ~Qt::ItemIsEditable);
+        nameItem->setData(Qt::UserRole, static_cast<int>(action));
+        m_table->setItem(r, 0, nameItem);
+
+        // Find the chord currently bound to this action in the working copy.
+        KeyChord bound;
+        for (auto it = m_working.constBegin(); it != m_working.constEnd(); ++it) {
+            if (it.value() == action) { bound = it.key(); break; }
+        }
+
+        auto *chordEdit = new KeyChordCaptureEdit(this);
+        chordEdit->setChord(bound);
+        connect(chordEdit, &KeyChordCaptureEdit::chordCaptured, this,
+                [this, action, chordEdit](const KeyChord &chord) {
+                    // Remove the action's old binding and any other action that used the new chord.
+                    for (auto it = m_working.begin(); it != m_working.end();) {
+                        if (it.value() == action) {
+                            it = m_working.erase(it);
+                        } else if (chord.isValid() && it.key() == chord) {
+                            // Clear the row that previously owned this chord.
+                            MappedAction replaced = it.value();
+                            int row = rowForAction(replaced);
+                            if (row >= 0) {
+                                auto *w = qobject_cast<KeyChordCaptureEdit *>(m_table->cellWidget(row, 1));
+                                if (w) w->setChord(KeyChord{});
+                            }
+                            it = m_working.erase(it);
+                        } else {
+                            ++it;
+                        }
+                    }
+                    if (chord.isValid()) m_working.insert(chord, action);
+                    // Reflect change in the edit itself.
+                    chordEdit->setChord(chord);
+                });
+        m_table->setCellWidget(r, 1, chordEdit);
+
+        auto *clearBtn = new QPushButton(tr("Clear"), this);
+        clearBtn->setFocusPolicy(Qt::NoFocus);
+        connect(clearBtn, &QPushButton::clicked, this, [this, action, chordEdit]() {
+            for (auto it = m_working.begin(); it != m_working.end();) {
+                if (it.value() == action) it = m_working.erase(it);
+                else ++it;
+            }
+            chordEdit->setChord(KeyChord{});
+        });
+        m_table->setCellWidget(r, 2, clearBtn);
+    }
+}
+
+int KeyboardRemapDialog::rowForAction(MappedAction action) const {
+    for (int r = 0; r < m_table->rowCount(); ++r) {
+        QTableWidgetItem *it = m_table->item(r, 0);
+        if (it && it->data(Qt::UserRole).toInt() == static_cast<int>(action)) return r;
+    }
+    return -1;
+}
+
+void KeyboardRemapDialog::onResetDefaultsClicked() {
+    KeyboardMapping tmp;
+    tmp.resetToDefaults();
+    m_working = tmp.allBindings();
+    m_table->clearContents();
+    populateRows();
+}
+
+void KeyboardRemapDialog::onImportClicked() {
+    QString path = ui::widgets::StyledFileDialog::getOpenFileName(
+        this, tr("Import Keyboard Mapping"), QString(), tr("JSON (*.json)"));
+    if (path.isEmpty()) return;
+    QFile f(path);
+    if (!f.open(QIODevice::ReadOnly)) {
+        ui::widgets::StyledMessageBox::warning(this, tr("Import failed"),
+            tr("Could not open %1.").arg(path));
+        return;
+    }
+    QJsonParseError err;
+    QJsonDocument doc = QJsonDocument::fromJson(f.readAll(), &err);
+    if (err.error != QJsonParseError::NoError || !doc.isObject()) {
+        ui::widgets::StyledMessageBox::warning(this, tr("Import failed"),
+            tr("Invalid JSON: %1").arg(err.errorString()));
+        return;
+    }
+    KeyboardMapping tmp;
+    tmp.resetToDefaults();
+    if (!tmp.fromJson(doc.object())) {
+        ui::widgets::StyledMessageBox::warning(this, tr("Import failed"),
+            tr("File does not contain a keyboard mapping."));
+        return;
+    }
+    m_working = tmp.allBindings();
+    m_table->clearContents();
+    populateRows();
+}
+
+void KeyboardRemapDialog::onExportClicked() {
+    QString path = ui::widgets::StyledFileDialog::getSaveFileName(
+        this, tr("Export Keyboard Mapping"), QString(), tr("JSON (*.json)"));
+    if (path.isEmpty()) return;
+    KeyboardMapping tmp;
+    tmp.replaceAllBindings(m_working);
+    QJsonDocument doc(tmp.toJson());
+    QFile f(path);
+    if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+        ui::widgets::StyledMessageBox::warning(this, tr("Export failed"),
+            tr("Could not write %1.").arg(path));
+        return;
+    }
+    f.write(doc.toJson(QJsonDocument::Indented));
+}
+
+void KeyboardRemapDialog::onSaveClicked() {
+    KeyboardMapping::instance().replaceAllBindings(m_working);
+    KeyboardMapping::instance().save();
+    emit mappingChanged();
+    accept();
+}
+
+void KeyboardRemapDialog::onCancelClicked() {
+    reject();
+}
+
+} // namespace ui::dialogs

--- a/src/ui/dialogs/keyboard_remap_dialog.h
+++ b/src/ui/dialogs/keyboard_remap_dialog.h
@@ -1,0 +1,78 @@
+// 5250ng - A modern IBM TN5250 terminal emulator
+// Copyright (C) 2025-2026 Remi GASCOU (Podalirius)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include "core/keyboard_mapping.h"
+#include "ui/widgets/Frameless/BaseFramelessDialog.h"
+#include <QHash>
+#include <QLineEdit>
+#include <QTableWidget>
+
+namespace ui::dialogs {
+
+// Small line-edit that captures a single key chord when focused.
+// Emits chordCaptured() when the user presses a key; displays it as text.
+class KeyChordCaptureEdit : public QLineEdit {
+    Q_OBJECT
+  public:
+    explicit KeyChordCaptureEdit(QWidget *parent = nullptr);
+    void setChord(const core::KeyChord &chord);
+    core::KeyChord chord() const { return m_chord; }
+
+  signals:
+    void chordCaptured(const core::KeyChord &chord);
+
+  protected:
+    void keyPressEvent(QKeyEvent *event) override;
+
+  private:
+    core::KeyChord m_chord;
+};
+
+// Dialog that lets the user edit the {chord -> action} map. Changes are only
+// applied to the KeyboardMapping singleton when the user clicks "Save".
+class KeyboardRemapDialog : public ui::widgets::BaseFramelessDialog {
+    Q_OBJECT
+  public:
+    // Optional: pre-focus on a specific action (e.g. opened via right-click on
+    // the virtual keyboard). Pass MappedAction::None to skip.
+    explicit KeyboardRemapDialog(QWidget *parent = nullptr,
+                                 core::MappedAction focusOn = core::MappedAction::None);
+
+  signals:
+    // Emitted after the user clicks Save and the singleton has been updated.
+    void mappingChanged();
+
+  private slots:
+    void onResetDefaultsClicked();
+    void onImportClicked();
+    void onExportClicked();
+    void onSaveClicked();
+    void onCancelClicked();
+
+  private:
+    void buildUI();
+    void populateRows();
+    int rowForAction(core::MappedAction action) const;
+
+    QTableWidget *m_table = nullptr;
+    // Editable snapshot of bindings; flushed to the singleton on Save.
+    QHash<core::KeyChord, core::MappedAction> m_working;
+    core::MappedAction m_focusOn = core::MappedAction::None;
+};
+
+} // namespace ui::dialogs

--- a/src/ui/dialogs/keyboard_remap_dialog.h
+++ b/src/ui/dialogs/keyboard_remap_dialog.h
@@ -20,7 +20,12 @@
 #include "ui/widgets/Frameless/BaseFramelessDialog.h"
 #include <QHash>
 #include <QLineEdit>
+#include <QList>
+#include <QPushButton>
 #include <QTableWidget>
+#include <QWidget>
+
+class QHBoxLayout;
 
 namespace ui::dialogs {
 
@@ -41,6 +46,39 @@ class KeyChordCaptureEdit : public QLineEdit {
 
   private:
     core::KeyChord m_chord;
+};
+
+// Row editor showing every chord currently bound to a single action, with a
+// remove button next to each and a "+ Add chord" at the end. Emits
+// chordsChanged whenever the set of bound chords changes.
+class ChordListEditor : public QWidget {
+    Q_OBJECT
+  public:
+    explicit ChordListEditor(core::MappedAction action, QWidget *parent = nullptr);
+
+    core::MappedAction action() const { return m_action; }
+    QList<core::KeyChord> chords() const;
+
+    // Replace the set of bound chords. Does not emit chordsChanged.
+    void setChords(const QList<core::KeyChord> &chords);
+
+  signals:
+    void chordsChanged(core::MappedAction action, const QList<core::KeyChord> &chords);
+
+  private:
+    void addChip(const core::KeyChord &chord, bool startFocused);
+    void removeChipAt(int index);
+    void emitChords();
+
+    struct Entry {
+        KeyChordCaptureEdit *edit;
+        QPushButton *removeBtn;
+    };
+
+    core::MappedAction m_action;
+    QHBoxLayout *m_layout = nullptr;
+    QPushButton *m_addBtn = nullptr;
+    QList<Entry> m_entries;
 };
 
 // Dialog that lets the user edit the {chord -> action} map. Changes are only
@@ -68,6 +106,8 @@ class KeyboardRemapDialog : public ui::widgets::BaseFramelessDialog {
     void buildUI();
     void populateRows();
     int rowForAction(core::MappedAction action) const;
+    ChordListEditor *editorForAction(core::MappedAction action) const;
+    void onRowChordsChanged(core::MappedAction action, const QList<core::KeyChord> &chords);
 
     QTableWidget *m_table = nullptr;
     // Editable snapshot of bindings; flushed to the singleton on Save.

--- a/src/ui/main_window.h
+++ b/src/ui/main_window.h
@@ -27,6 +27,7 @@
 #include "session/worker.h"
 #include "ui/dialogs/connect_dialog.h"
 #include "ui/rendering/tn5250_command_handler.h"
+#include "ui/widgets/QVirtualKeyboardWidget/QVirtualKeyboardWidget.h"
 #include "ui/widgets/Frameless/BaseFramelessWindow.h"
 #include "ui/widgets/Q5250ScreenWidget/Q5250ScreenWidget.h"
 #include "ui/widgets/Q5250ScreenWidget/Q5250TerminalView.h"
@@ -115,6 +116,11 @@ class MainWindow : public ui::widgets::BaseFramelessWindow {
     void onEditMatchReplacePatterns();
     void rebuildQuickThemeMenu();
     void onQuickThemeChosen(QAction *action);
+    void onToggleVirtualKeyboard();
+    void onEditKeyboardMapping();
+    void onVirtualKeyboardAction(core::MappedAction action);
+    void onVirtualKeyboardCharacter(QChar ch);
+    void onVirtualKeyboardRemap(core::MappedAction action);
 
   private:
     void setupUI();
@@ -202,6 +208,8 @@ class MainWindow : public ui::widgets::BaseFramelessWindow {
     QAction *m_mcpEnableAction;
     QAction *m_mcpReadOnlyAction;
     QAction *m_matchReplaceEnableAction;
+    QAction *m_virtualKeyboardAction = nullptr;
+    ui::widgets::QVirtualKeyboardWidget *m_virtualKeyboard = nullptr;
     QLabel *m_cursorCoordinates; // Cursor position display (row/col)
     ui::widgets::QConnectionStatusWidget *m_globalConnectionStatus; // Global bottom-bar status
 

--- a/src/ui/main_window.h
+++ b/src/ui/main_window.h
@@ -121,6 +121,7 @@ class MainWindow : public ui::widgets::BaseFramelessWindow {
     void onVirtualKeyboardAction(core::MappedAction action);
     void onVirtualKeyboardCharacter(QChar ch);
     void onVirtualKeyboardRemap(core::MappedAction action);
+    void rebindVirtualKeyboardPulse();
 
   private:
     void setupUI();
@@ -210,6 +211,7 @@ class MainWindow : public ui::widgets::BaseFramelessWindow {
     QAction *m_matchReplaceEnableAction;
     QAction *m_virtualKeyboardAction = nullptr;
     ui::widgets::QVirtualKeyboardWidget *m_virtualKeyboard = nullptr;
+    QMetaObject::Connection m_virtualKeyboardPulseConnection;
     QLabel *m_cursorCoordinates; // Cursor position display (row/col)
     ui::widgets::QConnectionStatusWidget *m_globalConnectionStatus; // Global bottom-bar status
 

--- a/src/ui/setup/setupMenuBar.cpp
+++ b/src/ui/setup/setupMenuBar.cpp
@@ -129,6 +129,11 @@ void MainWindow::setupMenuBar() {
     m_sessionLoggingAction = toolsMenu->addAction("Session &Logging", this, &MainWindow::onToggleSessionLogging);
     m_sessionLoggingAction->setCheckable(true);
     toolsMenu->addSeparator();
+    m_virtualKeyboardAction = toolsMenu->addAction("Virtual &Keyboard",
+        this, &MainWindow::onToggleVirtualKeyboard);
+    m_virtualKeyboardAction->setCheckable(true);
+    toolsMenu->addAction("Remap Keyboard...", this, &MainWindow::onEditKeyboardMapping);
+    toolsMenu->addSeparator();
     // Match and Replace submenu
     QMenu *matchReplaceMenu = toolsMenu->addMenu("Match and &Replace");
     m_matchReplaceEnableAction = matchReplaceMenu->addAction("&Enable", this, &MainWindow::onToggleMatchReplace);

--- a/src/ui/widgets/Q5250ScreenWidget/Q5250ScreenWidget.h
+++ b/src/ui/widgets/Q5250ScreenWidget/Q5250ScreenWidget.h
@@ -20,6 +20,7 @@
 #include "core/hotspot_detector.h"
 #include "core/match_replace_engine.h"
 #include "core/keyboard_encoder.h"
+#include "core/keyboard_mapping.h"
 #include "core/screen_history.h"
 #include "screen_buffer.h"
 #include "ui/themes/terminal_theme.h"
@@ -160,6 +161,14 @@ class Q5250ScreenWidget : public QWidget {
     void moveCursorRight();
     void moveCursorUp();
     void moveCursorDown();
+
+    // Execute a logical 5250 action resolved either from a host key chord
+    // (via KeyboardMapping) or from a click on the on-screen virtual keyboard.
+    void dispatchMappedAction(core::MappedAction action);
+
+    // Inject a single character as if typed into the active field (used by
+    // the virtual keyboard widget). Respects read-only/keyboard-lock state.
+    void dispatchCharacter(QChar ch);
 
     void setReadType(uint8_t readType) { m_readType = readType; }
     uint8_t readType() const { return m_readType; }

--- a/src/ui/widgets/Q5250ScreenWidget/events.cpp
+++ b/src/ui/widgets/Q5250ScreenWidget/events.cpp
@@ -16,6 +16,7 @@
 
 #include "Q5250ScreenWidget.h"
 #include "core/ebcdic.h"
+#include "core/keyboard_mapping.h"
 #include "logger/logger.h"
 #include <climits>
 #include <QApplication>
@@ -127,22 +128,23 @@ void Q5250ScreenWidget::keyPressEvent(QKeyEvent *event) {
         }
     }
 
-    // Keyboard lock enforcement: when locked, only allow a few keys through
+    // Resolve the chord against the user-configurable keyboard mapping.
+    // Defaults mirror the previous hardcoded behavior (Shift+F1→PF13, Ctrl+End→
+    // FieldExit, Ctrl+Esc→Attn, …), so unmodified installations see no change.
+    Qt::KeyboardModifiers mods = event->modifiers() &
+        (Qt::ShiftModifier | Qt::ControlModifier | Qt::AltModifier | Qt::MetaModifier);
+    core::MappedAction mapped = core::KeyboardMapping::instance().lookup(event->key(), mods);
+
+    // Keyboard lock enforcement: only Attn and SysReq are allowed through.
     if (m_keyboardState == KeyboardState::Locked) {
-        // Allow only Attn (Ctrl+Escape) and SysReq - reject all other input
-        // Attn and SysReq are processed via processKeyEvent -> processEncodedInput
-        bool isAttn = (event->key() == Qt::Key_Escape && (event->modifiers() & Qt::ControlModifier));
-        bool isSysReq = (event->key() == Qt::Key_SysReq);
-        if (!isAttn && !isSysReq) {
+        if (mapped != core::MappedAction::Attn && mapped != core::MappedAction::SysReq) {
             event->accept();
             return;
         }
     }
     if (m_keyboardState == KeyboardState::ErrorLocked) {
-        // Only Error Reset (Escape, handled above), Attn, and Help are allowed
-        bool isAttn = (event->key() == Qt::Key_Escape && (event->modifiers() & Qt::ControlModifier));
-        bool isHelp = (event->key() == Qt::Key_F1 && (event->modifiers() & Qt::ControlModifier));
-        if (!isAttn && !isHelp) {
+        // Escape (Error Reset) was already consumed above; Attn and Help remain.
+        if (mapped != core::MappedAction::Attn && mapped != core::MappedAction::Help) {
             event->accept();
             return;
         }
@@ -151,108 +153,121 @@ void Q5250ScreenWidget::keyPressEvent(QKeyEvent *event) {
     // Emit key recording signal for macro capture (all terminal-relevant keys)
     emit keyRecorded(event->key(), event->modifiers(), event->text());
 
-    // Handle local-only keys (block-mode: these never go to the host)
-    if (m_screenBuffer) {
-        switch (event->key()) {
-        case Qt::Key_Left:
-            moveCursorLeft();
-            event->accept();
-            return;
-        case Qt::Key_Right:
-            moveCursorRight();
-            event->accept();
-            return;
-        case Qt::Key_Up:
-            moveCursorUp();
-            event->accept();
-            return;
-        case Qt::Key_Down:
-            moveCursorDown();
-            event->accept();
-            return;
-        case Qt::Key_Tab:
-            if (event->modifiers() & Qt::ShiftModifier) {
-                moveToPreviousField();
-            } else {
-                moveToNextField();
-            }
-            event->accept();
-            return;
-        case Qt::Key_Backtab:
-            moveToPreviousField();
-            event->accept();
-            return;
-        case Qt::Key_Home:
-            moveToFieldStart();
-            event->accept();
-            return;
-        case Qt::Key_End:
-            if (event->modifiers() & Qt::ControlModifier) {
-                // Ctrl+End = Field Exit
-                handleFieldExit();
-                event->accept();
-                return;
-            }
-            moveToFieldEnd();
-            event->accept();
-            return;
-        case Qt::Key_Backspace:
-            if (event->modifiers() & Qt::ControlModifier) {
-                // Ctrl+Backspace = Erase Field
-                handleEraseField();
-                event->accept();
-                return;
-            }
-            handleBackspace();
-            event->accept();
-            return;
-        case Qt::Key_Delete:
-            if (event->modifiers() & Qt::AltModifier) {
-                // Erase Input: clear all non-protected fields, reset MDT, move to IC
-                handleEraseInput();
-            } else if (event->modifiers() & Qt::ControlModifier) {
-                // EraseEOF: clear from cursor to end of field
-                handleEraseEOF();
-            } else {
-                handleDelete();
-            }
-            event->accept();
-            return;
-        case Qt::Key_Insert:
-            if (event->modifiers() & Qt::ShiftModifier) {
-                // Shift+Insert = Dup key
-                handleDup();
-            } else {
-                m_insertMode = !m_insertMode;
-                emit terminalStateChanged();
-            }
-            event->accept();
-            return;
-        case Qt::Key_Plus:
-            if (event->modifiers() & Qt::AltModifier) {
-                handleFieldPlus();
-                event->accept();
-                return;
-            }
-            break;
-        case Qt::Key_Minus:
-            if (event->modifiers() & Qt::AltModifier) {
-                handleFieldMinus();
-                event->accept();
-                return;
-            }
-            break;
-        default:
-            break;
-        }
+    if (mapped != core::MappedAction::None) {
+        LOG_DEBUG(QString("[Q5250Widget] keyPressEvent: chord key=0x%1 mods=0x%2 -> action=%3")
+            .arg(event->key(), 0, 16).arg(static_cast<int>(mods), 0, 16)
+            .arg(core::KeyboardMapping::actionName(mapped)));
+        dispatchMappedAction(mapped);
+        event->accept();
+        return;
     }
 
-    // Pass other keys to input handler (AID keys and characters)
+    // Unmapped chord: treat as character input (EBCDIC-encoded to the host).
     LOG_DEBUG(QString("[Q5250Widget] keyPressEvent: key=0x%1 mod=0x%2 text='%3'")
         .arg(event->key(), 0, 16).arg(static_cast<int>(event->modifiers()), 0, 16)
         .arg(event->text()));
     processKeyEvent(event);
     QWidget::keyPressEvent(event);
+}
+
+void Q5250ScreenWidget::dispatchMappedAction(core::MappedAction action) {
+    using core::MappedAction;
+
+    // PF1..PF24 are AID keys sent to the host.
+    if (action >= MappedAction::PF1 && action <= MappedAction::PF24) {
+        int pfNumber = static_cast<int>(action) - static_cast<int>(MappedAction::PF1) + 1;
+        if (m_encoder) {
+            QByteArray encoded = m_encoder->encodePFKey(pfNumber);
+            if (!encoded.isEmpty()) processEncodedInput(encoded, /*isAID=*/true);
+        }
+        return;
+    }
+
+    switch (action) {
+    case MappedAction::Enter:
+    case MappedAction::Clear:
+    case MappedAction::RollUp:
+    case MappedAction::RollDown:
+    case MappedAction::Attn:
+    case MappedAction::SysReq:
+    case MappedAction::Print: {
+        if (!m_encoder) return;
+        core::KeyboardAction kbd = core::KeyboardAction::Enter;
+        switch (action) {
+        case MappedAction::Enter:    kbd = core::KeyboardAction::Enter; break;
+        case MappedAction::Clear:    kbd = core::KeyboardAction::Clear; break;
+        case MappedAction::RollUp:   kbd = core::KeyboardAction::RollUp; break;
+        case MappedAction::RollDown: kbd = core::KeyboardAction::RollDown; break;
+        case MappedAction::Attn:     kbd = core::KeyboardAction::Attn; break;
+        case MappedAction::SysReq:   kbd = core::KeyboardAction::SysReq; break;
+        case MappedAction::Print:    kbd = core::KeyboardAction::Print; break;
+        default: return;
+        }
+        QByteArray encoded = m_encoder->encodeAction(kbd);
+        if (!encoded.isEmpty()) processEncodedInput(encoded, /*isAID=*/true);
+        return;
+    }
+    case MappedAction::Help: {
+        // 5250 Help AID (0xF3). KeyboardEncoder has no action enum for it yet,
+        // so emit the AID byte directly through the same AID response path.
+        QByteArray aid;
+        aid.append(static_cast<char>(0xF3));
+        processEncodedInput(aid, /*isAID=*/true);
+        return;
+    }
+
+    // Local (block-mode) actions — never go to the host.
+    case MappedAction::Tab:         moveToNextField(); return;
+    case MappedAction::BackTab:     moveToPreviousField(); return;
+    case MappedAction::Home:        moveToFieldStart(); return;
+    case MappedAction::End:         moveToFieldEnd(); return;
+    case MappedAction::FieldExit:   handleFieldExit(); return;
+    case MappedAction::FieldPlus:   handleFieldPlus(); return;
+    case MappedAction::FieldMinus:  handleFieldMinus(); return;
+    case MappedAction::ArrowUp:     moveCursorUp(); return;
+    case MappedAction::ArrowDown:   moveCursorDown(); return;
+    case MappedAction::ArrowLeft:   moveCursorLeft(); return;
+    case MappedAction::ArrowRight:  moveCursorRight(); return;
+    case MappedAction::Backspace:   handleBackspace(); return;
+    case MappedAction::Delete:      handleDelete(); return;
+    case MappedAction::EraseEOF:    handleEraseEOF(); return;
+    case MappedAction::EraseField:  handleEraseField(); return;
+    case MappedAction::EraseInput:  handleEraseInput(); return;
+    case MappedAction::Dup:         handleDup(); return;
+    case MappedAction::Insert:
+        m_insertMode = !m_insertMode;
+        emit terminalStateChanged();
+        return;
+    case MappedAction::Reset:
+        // Error Reset: if locked by an error, restore the error line and unlock.
+        if (m_keyboardState == KeyboardState::ErrorLocked) {
+            if (!m_savedErrorLine.isEmpty() && m_screenBuffer) {
+                int errRow = (m_errorLineRow >= 0) ? m_errorLineRow
+                                                    : (m_screenBuffer->rows() - 1);
+                for (int c = 0; c < m_screenBuffer->cols() && c < m_savedErrorLine.size(); ++c) {
+                    m_screenBuffer->cell(errRow, c) = m_savedErrorLine[c];
+                }
+                m_savedErrorLine.clear();
+            }
+            setKeyboardState(KeyboardState::Unlocked);
+        }
+        return;
+
+    case MappedAction::None:
+    default:
+        return;
+    }
+}
+
+void Q5250ScreenWidget::dispatchCharacter(QChar ch) {
+    if (!m_screenBuffer || !m_encoder) return;
+    if (m_readOnly && !m_mcpInjecting) return;
+    if (m_keyboardState == KeyboardState::Locked ||
+        m_keyboardState == KeyboardState::ErrorLocked) {
+        return;
+    }
+    QByteArray encoded = m_encoder->encodeCharacter(ch);
+    if (!encoded.isEmpty()) processEncodedInput(encoded, /*isAID=*/false);
 }
 
 void Q5250ScreenWidget::mousePressEvent(QMouseEvent *event) {

--- a/src/ui/widgets/QVirtualKeyboardWidget/QVirtualKeyboardWidget.cpp
+++ b/src/ui/widgets/QVirtualKeyboardWidget/QVirtualKeyboardWidget.cpp
@@ -1,0 +1,221 @@
+// 5250ng - A modern IBM TN5250 terminal emulator
+// Copyright (C) 2025-2026 Remi GASCOU (Podalirius)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include "QVirtualKeyboardWidget.h"
+
+#include <QAction>
+#include <QContextMenuEvent>
+#include <QGridLayout>
+#include <QLabel>
+#include <QMenu>
+#include <QString>
+#include <QVBoxLayout>
+
+namespace ui::widgets {
+
+using core::KeyboardMapping;
+using core::KeyChord;
+using core::MappedAction;
+
+QVirtualKeyboardWidget::QVirtualKeyboardWidget(QWidget *parent) : QWidget(parent) {
+    buildLayout();
+    refreshChordLabels();
+}
+
+QPushButton *QVirtualKeyboardWidget::addActionKey(QGridLayout *grid, int row, int col,
+                                                  int rowSpan, int colSpan,
+                                                  const QString &label, MappedAction action) {
+    QPushButton *btn = new QPushButton(label, this);
+    btn->setFocusPolicy(Qt::NoFocus);
+    btn->setMinimumSize(36, 28);
+    btn->setContextMenuPolicy(Qt::CustomContextMenu);
+    connect(btn, &QPushButton::clicked, this, [this, action]() {
+        emit actionTriggered(action);
+    });
+    connect(btn, &QPushButton::customContextMenuRequested, this, [this, btn, action](const QPoint &) {
+        QMenu menu(btn);
+        QAction *remap = menu.addAction(tr("Remap…"));
+        if (menu.exec(QCursor::pos()) == remap) {
+            emit remapRequested(action);
+        }
+    });
+    grid->addWidget(btn, row, col, rowSpan, colSpan);
+    m_actionButtons.append({btn, action, label});
+    return btn;
+}
+
+QPushButton *QVirtualKeyboardWidget::addCharKey(QGridLayout *grid, int row, int col,
+                                                int rowSpan, int colSpan,
+                                                QChar unshifted, QChar shifted) {
+    QPushButton *btn = new QPushButton(QString(unshifted), this);
+    btn->setFocusPolicy(Qt::NoFocus);
+    btn->setMinimumSize(32, 28);
+    connect(btn, &QPushButton::clicked, this, [this, btn, unshifted, shifted]() {
+        QChar ch = applyModifiers(unshifted, shifted);
+        emit characterTriggered(ch);
+        if (m_shiftHeld) {
+            m_shiftHeld = false;
+            if (m_shiftBtn) m_shiftBtn->setChecked(false);
+        }
+        btn->clearFocus();
+    });
+    grid->addWidget(btn, row, col, rowSpan, colSpan);
+    return btn;
+}
+
+QPushButton *QVirtualKeyboardWidget::addModifierKey(QGridLayout *grid, int row, int col,
+                                                    int rowSpan, int colSpan,
+                                                    const QString &label,
+                                                    Qt::KeyboardModifier mod) {
+    QPushButton *btn = new QPushButton(label, this);
+    btn->setFocusPolicy(Qt::NoFocus);
+    btn->setCheckable(true);
+    btn->setMinimumSize(48, 28);
+    connect(btn, &QPushButton::toggled, this, [this, mod](bool on) {
+        if (mod == Qt::ShiftModifier) m_shiftHeld = on;
+        else if (mod == Qt::ControlModifier) m_ctrlHeld = on;
+        else if (mod == Qt::AltModifier) m_altHeld = on;
+    });
+    grid->addWidget(btn, row, col, rowSpan, colSpan);
+    return btn;
+}
+
+QChar QVirtualKeyboardWidget::applyModifiers(QChar unshifted, QChar shifted) const {
+    if (m_shiftHeld && shifted != QChar(0)) return shifted;
+    if (m_shiftHeld && unshifted.isLetter()) return unshifted.toUpper();
+    return unshifted;
+}
+
+void QVirtualKeyboardWidget::buildLayout() {
+    QVBoxLayout *root = new QVBoxLayout(this);
+    root->setContentsMargins(6, 6, 6, 6);
+    root->setSpacing(4);
+
+    // --- Row of PF / command keys (Model M "F-row" extended) ----------------
+    QLabel *title = new QLabel(tr("Virtual 5250 Keyboard"), this);
+    title->setStyleSheet("font-weight: bold;");
+    root->addWidget(title);
+
+    QGridLayout *fnGrid = new QGridLayout();
+    fnGrid->setHorizontalSpacing(3);
+    fnGrid->setVerticalSpacing(3);
+    // PF1..PF24 on two short rows
+    for (int i = 0; i < 12; ++i) {
+        addActionKey(fnGrid, 0, i, 1, 1, QString("PF%1").arg(i + 1),
+                     static_cast<MappedAction>(static_cast<int>(MappedAction::PF1) + i));
+        addActionKey(fnGrid, 1, i, 1, 1, QString("PF%1").arg(i + 13),
+                     static_cast<MappedAction>(static_cast<int>(MappedAction::PF13) + i));
+    }
+    root->addLayout(fnGrid);
+
+    // --- Main typing area ---------------------------------------------------
+    QGridLayout *main = new QGridLayout();
+    main->setHorizontalSpacing(3);
+    main->setVerticalSpacing(3);
+
+    // Digit row
+    struct CK { const char *u; const char *s; };
+    const CK digitRow[] = {
+        {"`","~"},{"1","!"},{"2","@"},{"3","#"},{"4","$"},{"5","%"},
+        {"6","^"},{"7","&"},{"8","*"},{"9","("},{"0",")"},{"-","_"},{"=","+"},
+    };
+    for (int i = 0; i < 13; ++i) {
+        addCharKey(main, 0, i, 1, 1, QChar(digitRow[i].u[0]), QChar(digitRow[i].s[0]));
+    }
+    addActionKey(main, 0, 13, 1, 2, tr("Backspace"), MappedAction::Backspace);
+
+    // Q row
+    addActionKey(main, 1, 0, 1, 1, tr("Tab"), MappedAction::Tab);
+    const char qRow[] = "qwertyuiop";
+    for (int i = 0; i < 10; ++i) {
+        addCharKey(main, 1, 1 + i, 1, 1, QChar(qRow[i]), QChar(qRow[i]).toUpper());
+    }
+    addCharKey(main, 1, 11, 1, 1, '[', '{');
+    addCharKey(main, 1, 12, 1, 1, ']', '}');
+    addCharKey(main, 1, 13, 1, 2, '\\', '|');
+
+    // A row
+    addActionKey(main, 2, 0, 1, 1, tr("Reset"), MappedAction::Reset);
+    const char aRow[] = "asdfghjkl";
+    for (int i = 0; i < 9; ++i) {
+        addCharKey(main, 2, 1 + i, 1, 1, QChar(aRow[i]), QChar(aRow[i]).toUpper());
+    }
+    addCharKey(main, 2, 10, 1, 1, ';', ':');
+    addCharKey(main, 2, 11, 1, 1, '\'', '"');
+    addActionKey(main, 2, 12, 1, 3, tr("Enter"), MappedAction::Enter);
+
+    // Z row
+    m_shiftBtn = addModifierKey(main, 3, 0, 1, 1, tr("Shift"), Qt::ShiftModifier);
+    const char zRow[] = "zxcvbnm";
+    for (int i = 0; i < 7; ++i) {
+        addCharKey(main, 3, 1 + i, 1, 1, QChar(zRow[i]), QChar(zRow[i]).toUpper());
+    }
+    addCharKey(main, 3, 8, 1, 1, ',', '<');
+    addCharKey(main, 3, 9, 1, 1, '.', '>');
+    addCharKey(main, 3, 10, 1, 1, '/', '?');
+    addActionKey(main, 3, 11, 1, 1, tr("Field+"), MappedAction::FieldPlus);
+    addActionKey(main, 3, 12, 1, 1, tr("Field-"), MappedAction::FieldMinus);
+    addActionKey(main, 3, 13, 1, 2, tr("Field Exit"), MappedAction::FieldExit);
+
+    // Control row
+    m_ctrlBtn = addModifierKey(main, 4, 0, 1, 1, tr("Ctrl"), Qt::ControlModifier);
+    m_altBtn = addModifierKey(main, 4, 1, 1, 1, tr("Alt"), Qt::AltModifier);
+    addCharKey(main, 4, 2, 1, 9, QChar(' '), QChar(0));
+    addActionKey(main, 4, 11, 1, 1, tr("Ins"), MappedAction::Insert);
+    addActionKey(main, 4, 12, 1, 1, tr("Del"), MappedAction::Delete);
+    addActionKey(main, 4, 13, 1, 1, tr("Dup"), MappedAction::Dup);
+    addActionKey(main, 4, 14, 1, 1, tr("BckTab"), MappedAction::BackTab);
+
+    root->addLayout(main, 1);
+
+    // --- Navigation / AS-400 control cluster on the right ------------------
+    QGridLayout *nav = new QGridLayout();
+    nav->setHorizontalSpacing(3);
+    nav->setVerticalSpacing(3);
+    addActionKey(nav, 0, 0, 1, 1, tr("Attn"), MappedAction::Attn);
+    addActionKey(nav, 0, 1, 1, 1, tr("SysReq"), MappedAction::SysReq);
+    addActionKey(nav, 0, 2, 1, 1, tr("Clear"), MappedAction::Clear);
+    addActionKey(nav, 0, 3, 1, 1, tr("Help"), MappedAction::Help);
+    addActionKey(nav, 0, 4, 1, 1, tr("Print"), MappedAction::Print);
+    addActionKey(nav, 1, 0, 1, 1, tr("Home"), MappedAction::Home);
+    addActionKey(nav, 1, 1, 1, 1, tr("End"), MappedAction::End);
+    addActionKey(nav, 1, 2, 1, 1, tr("Roll↑"), MappedAction::RollUp);
+    addActionKey(nav, 1, 3, 1, 1, tr("Roll↓"), MappedAction::RollDown);
+    addActionKey(nav, 1, 4, 1, 1, tr("ErFld"), MappedAction::EraseField);
+    addActionKey(nav, 2, 0, 1, 1, tr("ErEOF"), MappedAction::EraseEOF);
+    addActionKey(nav, 2, 1, 1, 1, tr("ErInp"), MappedAction::EraseInput);
+    addActionKey(nav, 2, 2, 1, 1, tr("↑"), MappedAction::ArrowUp);
+    addActionKey(nav, 2, 3, 1, 1, tr("↓"), MappedAction::ArrowDown);
+    addActionKey(nav, 2, 4, 1, 1, tr("←"), MappedAction::ArrowLeft);
+    addActionKey(nav, 2, 5, 1, 1, tr("→"), MappedAction::ArrowRight);
+    root->addLayout(nav);
+}
+
+void QVirtualKeyboardWidget::refreshChordLabels() {
+    const auto &mapping = KeyboardMapping::instance();
+    for (const auto &entry : m_actionButtons) {
+        KeyChord c = mapping.chordFor(entry.action);
+        QString tip = QObject::tr("Click to send %1").arg(entry.baseLabel);
+        if (c.isValid()) {
+            tip += QObject::tr("\nHost chord: %1").arg(c.toString());
+        } else {
+            tip += QObject::tr("\nHost chord: (unbound)");
+        }
+        entry.button->setToolTip(tip);
+    }
+}
+
+} // namespace ui::widgets

--- a/src/ui/widgets/QVirtualKeyboardWidget/QVirtualKeyboardWidget.cpp
+++ b/src/ui/widgets/QVirtualKeyboardWidget/QVirtualKeyboardWidget.cpp
@@ -21,8 +21,10 @@
 #include <QGridLayout>
 #include <QLabel>
 #include <QMenu>
+#include <QPointer>
 #include <QString>
 #include <QStringList>
+#include <QTimer>
 #include <QVBoxLayout>
 
 namespace ui::widgets {
@@ -203,6 +205,32 @@ void QVirtualKeyboardWidget::buildLayout() {
     addActionKey(nav, 2, 4, 1, 1, tr("←"), MappedAction::ArrowLeft);
     addActionKey(nav, 2, 5, 1, 1, tr("→"), MappedAction::ArrowRight);
     root->addLayout(nav);
+}
+
+void QVirtualKeyboardWidget::pulseForChord(int key, Qt::KeyboardModifiers modifiers) {
+    // Only the modifiers the mapping cares about; strip keypad/num-lock noise.
+    Qt::KeyboardModifiers mods = modifiers &
+        (Qt::ShiftModifier | Qt::ControlModifier | Qt::AltModifier | Qt::MetaModifier);
+    core::MappedAction action = core::KeyboardMapping::instance().lookup(key, mods);
+    if (action == core::MappedAction::None) return;
+
+    QPushButton *target = nullptr;
+    for (const auto &entry : m_actionButtons) {
+        if (entry.action == action) { target = entry.button; break; }
+    }
+    if (!target) return;
+
+    // Use a dynamic property + stylesheet so the pulse restores cleanly without
+    // interfering with whatever base styling the host application provides.
+    target->setProperty("pulsing", true);
+    target->setStyleSheet(QStringLiteral(
+        "QPushButton[pulsing=\"true\"] { background-color: #f1c40f; color: #202020; }"));
+    QPointer<QPushButton> safe(target);
+    QTimer::singleShot(180, this, [safe]() {
+        if (!safe) return;
+        safe->setProperty("pulsing", false);
+        safe->setStyleSheet(QString());
+    });
 }
 
 void QVirtualKeyboardWidget::refreshChordLabels() {

--- a/src/ui/widgets/QVirtualKeyboardWidget/QVirtualKeyboardWidget.cpp
+++ b/src/ui/widgets/QVirtualKeyboardWidget/QVirtualKeyboardWidget.cpp
@@ -22,6 +22,7 @@
 #include <QLabel>
 #include <QMenu>
 #include <QString>
+#include <QStringList>
 #include <QVBoxLayout>
 
 namespace ui::widgets {
@@ -207,12 +208,15 @@ void QVirtualKeyboardWidget::buildLayout() {
 void QVirtualKeyboardWidget::refreshChordLabels() {
     const auto &mapping = KeyboardMapping::instance();
     for (const auto &entry : m_actionButtons) {
-        KeyChord c = mapping.chordFor(entry.action);
+        const QList<KeyChord> chords = mapping.chordsFor(entry.action);
         QString tip = QObject::tr("Click to send %1").arg(entry.baseLabel);
-        if (c.isValid()) {
-            tip += QObject::tr("\nHost chord: %1").arg(c.toString());
-        } else {
+        if (chords.isEmpty()) {
             tip += QObject::tr("\nHost chord: (unbound)");
+        } else {
+            QStringList names;
+            names.reserve(chords.size());
+            for (const auto &c : chords) names.append(c.toString());
+            tip += QObject::tr("\nHost chord: %1").arg(names.join(QStringLiteral(", ")));
         }
         entry.button->setToolTip(tip);
     }

--- a/src/ui/widgets/QVirtualKeyboardWidget/QVirtualKeyboardWidget.h
+++ b/src/ui/widgets/QVirtualKeyboardWidget/QVirtualKeyboardWidget.h
@@ -41,6 +41,12 @@ class QVirtualKeyboardWidget : public QWidget {
     // Re-label action keys after a remap so chord hints match current bindings.
     void refreshChordLabels();
 
+  public slots:
+    // Resolve the given host chord against the current KeyboardMapping and, if
+    // it matches an action key on the virtual keyboard, briefly highlight that
+    // key. Unmapped chords are ignored so this can be wired to keyRecorded().
+    void pulseForChord(int key, Qt::KeyboardModifiers modifiers);
+
   signals:
     void actionTriggered(core::MappedAction action);
     void characterTriggered(QChar ch);

--- a/src/ui/widgets/QVirtualKeyboardWidget/QVirtualKeyboardWidget.h
+++ b/src/ui/widgets/QVirtualKeyboardWidget/QVirtualKeyboardWidget.h
@@ -1,0 +1,76 @@
+// 5250ng - A modern IBM TN5250 terminal emulator
+// Copyright (C) 2025-2026 Remi GASCOU (Podalirius)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include "core/keyboard_mapping.h"
+#include <QChar>
+#include <QList>
+#include <QPushButton>
+#include <QString>
+#include <QWidget>
+
+class QGridLayout;
+
+namespace ui::widgets {
+
+// Clickable on-screen 5250 enhanced keyboard (IBM Model M style).
+//
+// Emits actionTriggered() when the user clicks a function / control key and
+// characterTriggered() for alphanumerics. The owning main window is expected
+// to route those signals to the active Q5250ScreenWidget.
+class QVirtualKeyboardWidget : public QWidget {
+    Q_OBJECT
+
+  public:
+    explicit QVirtualKeyboardWidget(QWidget *parent = nullptr);
+
+    // Re-label action keys after a remap so chord hints match current bindings.
+    void refreshChordLabels();
+
+  signals:
+    void actionTriggered(core::MappedAction action);
+    void characterTriggered(QChar ch);
+    void remapRequested(core::MappedAction action);
+
+  private:
+    void buildLayout();
+    QPushButton *addActionKey(QGridLayout *grid, int row, int col, int rowSpan, int colSpan,
+                              const QString &label, core::MappedAction action);
+    QPushButton *addCharKey(QGridLayout *grid, int row, int col, int rowSpan, int colSpan,
+                            QChar unshifted, QChar shifted);
+    QPushButton *addModifierKey(QGridLayout *grid, int row, int col, int rowSpan, int colSpan,
+                                const QString &label, Qt::KeyboardModifier mod);
+
+    QChar applyModifiers(QChar unshifted, QChar shifted) const;
+
+    // Track action buttons so we can refresh their chord sub-label.
+    struct ActionButton {
+        QPushButton *button;
+        core::MappedAction action;
+        QString baseLabel;
+    };
+    QList<ActionButton> m_actionButtons;
+
+    bool m_shiftHeld = false;
+    bool m_ctrlHeld = false;
+    bool m_altHeld = false;
+    QPushButton *m_shiftBtn = nullptr;
+    QPushButton *m_ctrlBtn = nullptr;
+    QPushButton *m_altBtn = nullptr;
+};
+
+} // namespace ui::widgets

--- a/tests/unit/test_keyboard_mapping.cpp
+++ b/tests/unit/test_keyboard_mapping.cpp
@@ -39,6 +39,9 @@ class TestKeyboardMapping : public QObject {
     void testJsonRoundTrip();
     void testFromJsonInvalidReturnsFalse();
     void testActionNameAndFromName();
+    void testChordsForReturnsAllBoundChords();
+    void testMultipleChordsCanBindSameAction();
+    void testMultipleChordsPersistViaQSettings();
 
   private:
     void resetMappingToDefaults() {
@@ -155,6 +158,47 @@ void TestKeyboardMapping::testActionNameAndFromName() {
     QCOMPARE(KeyboardMapping::actionFromName("Attn"), MappedAction::Attn);
     QCOMPARE(KeyboardMapping::actionFromName("definitely-not-a-real-action"),
              MappedAction::None);
+}
+
+void TestKeyboardMapping::testChordsForReturnsAllBoundChords() {
+    // Default: PF13 is bound to both Shift+F1 and F13.
+    auto chords = KeyboardMapping::instance().chordsFor(MappedAction::PF13);
+    QCOMPARE(chords.size(), 2);
+    QVERIFY(chords.contains(KeyChord{Qt::Key_F1, Qt::ShiftModifier}));
+    QVERIFY(chords.contains(KeyChord{Qt::Key_F13, Qt::NoModifier}));
+}
+
+void TestKeyboardMapping::testMultipleChordsCanBindSameAction() {
+    auto &m = KeyboardMapping::instance();
+    KeyChord primary{Qt::Key_Q, Qt::ControlModifier};
+    KeyChord secondary{Qt::Key_L, Qt::ControlModifier | Qt::AltModifier};
+    m.setBinding(primary, MappedAction::Clear);
+    m.setBinding(secondary, MappedAction::Clear);
+    auto chords = m.chordsFor(MappedAction::Clear);
+    QVERIFY(chords.contains(primary));
+    QVERIFY(chords.contains(secondary));
+    // Both chords resolve to the same action.
+    QCOMPARE(m.lookup(primary), MappedAction::Clear);
+    QCOMPARE(m.lookup(secondary), MappedAction::Clear);
+}
+
+void TestKeyboardMapping::testMultipleChordsPersistViaQSettings() {
+    auto &m = KeyboardMapping::instance();
+    KeyChord a{Qt::Key_Q, Qt::ControlModifier};
+    KeyChord b{Qt::Key_L, Qt::ControlModifier | Qt::AltModifier};
+    m.setBinding(a, MappedAction::Clear);
+    m.setBinding(b, MappedAction::Clear);
+    m.save();
+
+    m.resetToDefaults();
+    // After defaults reset, our custom chords no longer resolve.
+    QCOMPARE(m.lookup(a), MappedAction::None);
+    QCOMPARE(m.lookup(b), MappedAction::None);
+
+    m.load();
+    QCOMPARE(m.lookup(a), MappedAction::Clear);
+    QCOMPARE(m.lookup(b), MappedAction::Clear);
+    QCOMPARE(m.chordsFor(MappedAction::Clear).size(), 2);
 }
 
 QTEST_MAIN(TestKeyboardMapping)

--- a/tests/unit/test_keyboard_mapping.cpp
+++ b/tests/unit/test_keyboard_mapping.cpp
@@ -1,0 +1,161 @@
+// 5250ng - A modern IBM TN5250 terminal emulator
+// Copyright (C) 2025-2026 Remi GASCOU (Podalirius)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include "core/keyboard_mapping.h"
+#include <QCoreApplication>
+#include <QSettings>
+#include <QtTest/QtTest>
+
+using namespace core;
+
+class TestKeyboardMapping : public QObject {
+    Q_OBJECT
+
+  private slots:
+    void initTestCase();
+    void init();
+
+    void testDefaultsContainExpectedActions();
+    void testShiftF1IsPF13();
+    void testCtrlEscapeIsAttn();
+    void testSetAndLookup();
+    void testSetBindingReplacesOldAction();
+    void testClearAction();
+    void testKeyChordRoundTripString();
+    void testSaveLoadQSettingsRoundTrip();
+    void testJsonRoundTrip();
+    void testFromJsonInvalidReturnsFalse();
+    void testActionNameAndFromName();
+
+  private:
+    void resetMappingToDefaults() {
+        KeyboardMapping::instance().resetToDefaults();
+    }
+};
+
+void TestKeyboardMapping::initTestCase() {
+    // Use an isolated QSettings scope so the test never touches user settings.
+    QCoreApplication::setOrganizationName("5250ng-test");
+    QCoreApplication::setApplicationName("keyboard_mapping_test");
+    QSettings settings;
+    settings.clear();
+}
+
+void TestKeyboardMapping::init() {
+    resetMappingToDefaults();
+}
+
+void TestKeyboardMapping::testDefaultsContainExpectedActions() {
+    auto &m = KeyboardMapping::instance();
+    QVERIFY(!m.allBindings().isEmpty());
+    // Every PF key should have at least one chord bound by default.
+    for (int i = 1; i <= 24; ++i) {
+        auto action = static_cast<MappedAction>(
+            static_cast<int>(MappedAction::PF1) + (i - 1));
+        KeyChord c = m.chordFor(action);
+        QVERIFY2(c.isValid(), qPrintable(QString("PF%1 should have a default chord").arg(i)));
+    }
+}
+
+void TestKeyboardMapping::testShiftF1IsPF13() {
+    auto action = KeyboardMapping::instance().lookup(Qt::Key_F1, Qt::ShiftModifier);
+    QCOMPARE(action, MappedAction::PF13);
+}
+
+void TestKeyboardMapping::testCtrlEscapeIsAttn() {
+    auto action = KeyboardMapping::instance().lookup(Qt::Key_Escape, Qt::ControlModifier);
+    QCOMPARE(action, MappedAction::Attn);
+}
+
+void TestKeyboardMapping::testSetAndLookup() {
+    auto &m = KeyboardMapping::instance();
+    KeyChord c{Qt::Key_R, Qt::ControlModifier | Qt::AltModifier};
+    m.setBinding(c, MappedAction::Reset);
+    QCOMPARE(m.lookup(c), MappedAction::Reset);
+}
+
+void TestKeyboardMapping::testSetBindingReplacesOldAction() {
+    auto &m = KeyboardMapping::instance();
+    KeyChord c{Qt::Key_F1, Qt::ShiftModifier};
+    // Default: Shift+F1 -> PF13
+    QCOMPARE(m.lookup(c), MappedAction::PF13);
+    m.setBinding(c, MappedAction::PF1);
+    QCOMPARE(m.lookup(c), MappedAction::PF1);
+}
+
+void TestKeyboardMapping::testClearAction() {
+    auto &m = KeyboardMapping::instance();
+    m.clearAction(MappedAction::PF13);
+    QCOMPARE(m.lookup(Qt::Key_F1, Qt::ShiftModifier), MappedAction::None);
+    QVERIFY(!m.chordFor(MappedAction::PF13).isValid());
+}
+
+void TestKeyboardMapping::testKeyChordRoundTripString() {
+    KeyChord c{Qt::Key_F1, Qt::ShiftModifier};
+    QString s = c.toString();
+    QVERIFY(!s.isEmpty());
+    KeyChord back = KeyChord::fromString(s);
+    QCOMPARE(back, c);
+}
+
+void TestKeyboardMapping::testSaveLoadQSettingsRoundTrip() {
+    auto &m = KeyboardMapping::instance();
+    // Mutate the table: bind Ctrl+Alt+R to Reset.
+    KeyChord c{Qt::Key_R, Qt::ControlModifier | Qt::AltModifier};
+    m.setBinding(c, MappedAction::Reset);
+    // Remove a default to prove the save replaces, not merges.
+    m.clearAction(MappedAction::PF24);
+
+    m.save();
+
+    // Wipe the singleton back to a different state, then reload.
+    m.resetToDefaults();
+    QCOMPARE(m.lookup(c), MappedAction::None);
+    m.load();
+    QCOMPARE(m.lookup(c), MappedAction::Reset);
+    QVERIFY(!m.chordFor(MappedAction::PF24).isValid());
+}
+
+void TestKeyboardMapping::testJsonRoundTrip() {
+    auto &m = KeyboardMapping::instance();
+    KeyChord c{Qt::Key_Q, Qt::ControlModifier};
+    m.setBinding(c, MappedAction::Clear);
+    QJsonObject obj = m.toJson();
+
+    KeyboardMapping other;
+    other.resetToDefaults();
+    QVERIFY(other.fromJson(obj));
+    QCOMPARE(other.lookup(c), MappedAction::Clear);
+}
+
+void TestKeyboardMapping::testFromJsonInvalidReturnsFalse() {
+    KeyboardMapping other;
+    QJsonObject bogus;
+    bogus["entries"] = QJsonValue(42); // not an array
+    QVERIFY(!other.fromJson(bogus));
+    QJsonObject missing;
+    QVERIFY(!other.fromJson(missing));
+}
+
+void TestKeyboardMapping::testActionNameAndFromName() {
+    QCOMPARE(KeyboardMapping::actionName(MappedAction::PF13), QStringLiteral("PF13"));
+    QCOMPARE(KeyboardMapping::actionFromName("Attn"), MappedAction::Attn);
+    QCOMPARE(KeyboardMapping::actionFromName("definitely-not-a-real-action"),
+             MappedAction::None);
+}
+
+QTEST_MAIN(TestKeyboardMapping)
+#include "test_keyboard_mapping.moc"


### PR DESCRIPTION
### Linked Issue
Closes #85

### Motivation
The mapping between host keys and 5250 actions was hardcoded in `src/core/keyboard_encoder.cpp` and `src/ui/widgets/Q5250ScreenWidget/events.cpp`, so users on keyboards without dedicated 5250 keys (typically Mac laptops missing PF13-F24, SysReq, Attn, Field Exit, Clear, Erase EOF, etc.) could not reach those actions or rebind them to chords of their choosing. This PR generalizes the keyboard into a data-driven mapping, adds a visible on-screen 5250 keyboard, and a remap dialog.

### What Changed
- New `core::KeyboardMapping` (`src/core/keyboard_mapping.{h,cpp}`): singleton owning a `{ KeyChord -> MappedAction }` table. Loads/saves through `QSettings` under group `KeyboardMapping`, imports/exports JSON, and ships with defaults matching today's hardcoded behavior.
- New `ui::widgets::QVirtualKeyboardWidget` (`src/ui/widgets/QVirtualKeyboardWidget/`): clickable IBM Model M / 5250-enhanced layout covering PF1-PF24, Enter, Field+/-, Field Exit, Clear, Reset, Attn, SysReq, Help, Print, Roll Up/Down, Dup, Erase EOF/Field/Input, Home, End, arrows, Backspace, Delete, Tab, alphanumerics. Sticky Shift/Ctrl/Alt. Right-click a key opens the remap dialog pre-focused on that action. Tooltips show the current host chord.
- New `ui::dialogs::KeyboardRemapDialog` (`src/ui/dialogs/keyboard_remap_dialog.{h,cpp}`): table of Action vs. Chord with an inline `KeyChordCaptureEdit` that records a chord live on key press. Buttons for Clear, Reset to defaults, Import JSON, Export JSON, Save, Cancel. Changes are held in a working copy and only flushed to the singleton on Save.
- `Q5250ScreenWidget::keyPressEvent` now consults `KeyboardMapping::instance().lookup()` immediately after the keyboard-lock check; a match is dispatched through the new public `dispatchMappedAction()` method. The old multi-branch switch over `Qt::Key_*` was removed because it is now expressed in the default mapping. Unmapped chords fall through to the existing EBCDIC character path.
- New `dispatchCharacter()` so the virtual keyboard's click handler can inject a single character with the same guards (read-only, keyboard lock).
- Tools menu gains "Virtual Keyboard" (checkable dock toggle) and "Remap Keyboard..." (opens the dialog). Menu wiring in `src/ui/setup/setupMenuBar.cpp` and slot implementations in `src/ui/actions/onVirtualKeyboard.cpp`.
- `main.cpp` calls `core::KeyboardMapping::instance().load()` during startup alongside the other config loads.
- Unit test `tests/unit/test_keyboard_mapping.cpp` covers defaults, set/clear, chord string round-trip, `QSettings` save/load round-trip, JSON round-trip, and invalid JSON rejection.

### Design Notes
- `KeyboardEncoder` is unchanged. PF / AID handling still flows through `encodePFKey` and `encodeAction`; `dispatchMappedAction` just picks the right encoder call based on the resolved `MappedAction`. Help uses AID `0xF3` directly because `KeyboardEncoder::encodeAction` had no Help case.
- `KeyChord::toString()` / `fromString()` delegate to `QKeySequence(PortableText)` so saved mappings are human-readable and version-stable.
- The `KeyboardMapping::load()` early-return condition was switched from `settings.contains("entries")` (which returns false for child groups) to checking `beginReadArray("entries") <= 0`; `settings.contains` only matches leaf keys, so the previous form silently discarded saved mappings.
- Defaults replicate prior behavior exactly, including Shift+F1..F12 -> PF13..PF24, the native Qt F13..F24 keys -> PF13..PF24, Ctrl+Esc -> Attn, Ctrl+End -> Field Exit, Ctrl+Backspace -> Erase Field, Ctrl+Delete -> Erase EOF, Alt+Delete -> Erase Input, Shift+Insert -> Dup, Alt+Plus/Minus -> Field +/-.

### Acceptance Criteria Check
- Tools -> "Virtual Keyboard" toggles a dock showing a clickable 5250 keyboard. Clicking PF1 dispatches `MappedAction::PF1` -> `encodePFKey(1)` -> `processEncodedInput`, i.e. the same path as pressing F1. Implemented in `onVirtualKeyboard.cpp` + `events.cpp:dispatchMappedAction`.
- Tools -> "Remap Keyboard..." opens `KeyboardRemapDialog` with every action, Record (via `KeyChordCaptureEdit`), Clear, Reset to defaults, Import/Export, Save. See `keyboard_remap_dialog.cpp`.
- Rebinding `Shift+F1` to `PF1` then pressing `Shift+F1` produces PF1 rather than PF13: `setBinding` overwrites the chord and `lookup` returns the new action (covered by `TestKeyboardMapping::testSetBindingReplacesOldAction`).
- Mappings persist via `QSettings` under group `KeyboardMapping`: `save()` and `load()` round-trip is covered by `TestKeyboardMapping::testSaveLoadQSettingsRoundTrip`.
- `test_keyboard_mapping` covers defaults, round-trip, lookup — all 12 test cases pass.
- No regressions in `test_keyboard_encoder` or `test_decoder`; entire test suite (15 tests) passes.

### How Verified
- **Tests:** `ctest` — all 15 tests pass, including the new `test_keyboard_mapping` (12 test cases).
- **Build:** `cmake --build build` — `5250ng` target and every test binary build with the repository's default `-Wall -Wextra -Wpedantic` without new warnings.
- **Static:** `dispatchMappedAction` routes PF1-PF24 through `KeyboardEncoder::encodePFKey` and the AID actions through `KeyboardEncoder::encodeAction`, preserving the existing wire-byte output. Local-only actions (Tab, arrows, Home, End, Insert, etc.) call the same helpers that the removed switch statement called.

### Test Coverage
- **Added:** `tests/unit/test_keyboard_mapping.cpp` with `testDefaultsContainExpectedActions`, `testShiftF1IsPF13`, `testCtrlEscapeIsAttn`, `testSetAndLookup`, `testSetBindingReplacesOldAction`, `testClearAction`, `testKeyChordRoundTripString`, `testSaveLoadQSettingsRoundTrip`, `testJsonRoundTrip`, `testFromJsonInvalidReturnsFalse`, `testActionNameAndFromName`. GUI widgets (`QVirtualKeyboardWidget`, `KeyboardRemapDialog`) are not covered by automated tests because they require a live `QApplication` and user key events, consistent with the rest of the UI code in this repo.

### Scope of Change
- **Files changed:** `CMakeLists.txt`, `src/main.cpp`, `src/core/keyboard_mapping.{h,cpp}` (new), `src/ui/main_window.h`, `src/ui/setup/setupMenuBar.cpp`, `src/ui/actions/onVirtualKeyboard.cpp` (new), `src/ui/dialogs/keyboard_remap_dialog.{h,cpp}` (new), `src/ui/widgets/QVirtualKeyboardWidget/QVirtualKeyboardWidget.{h,cpp}` (new), `src/ui/widgets/Q5250ScreenWidget/Q5250ScreenWidget.h`, `src/ui/widgets/Q5250ScreenWidget/events.cpp`, `tests/unit/test_keyboard_mapping.cpp` (new).
- **Submodule pointer updated:** no.
- **Public API changes:** none (internal only; new UI entry points).
- **Behavioral changes outside the stated enhancement:** none.

### Risk and Rollout
Low. Default mapping replicates prior hardcoded behavior exactly, so users who never open the remap dialog see no change. `QSettings` stores the mapping under a new group (`KeyboardMapping`) so there is nothing to migrate. The virtual keyboard dock is off by default.

### Notes
The Help AID (0xF3) was not previously reachable through `KeyboardEncoder::encodeAction`; this PR sends it inline from `dispatchMappedAction`. A follow-up could add `KeyboardAction::Help` to the encoder for symmetry.
