### PR TITLE
[enhancement] Pulse the virtual keyboard for mapped host chords (#91)

### DIFF
--- a/src/ui/actions/onCurrentTabChanged.cpp
+++ b/src/ui/actions/onCurrentTabChanged.cpp
@@ -18,6 +18,9 @@
 
 void MainWindow::onCurrentTabChanged(int index) {
     setActiveSession(index);
+    // Re-route the virtual keyboard pulse feed onto the new active session so
+    // the on-screen keyboard keeps highlighting the right host chord.
+    rebindVirtualKeyboardPulse();
     if (index >= 0 && index < m_sessions.size()) {
         Session *s = m_sessions[index];
         // Clear activity indicator when the tab gains focus

--- a/src/ui/actions/onVirtualKeyboard.cpp
+++ b/src/ui/actions/onVirtualKeyboard.cpp
@@ -38,6 +38,22 @@ void MainWindow::onToggleVirtualKeyboard() {
     bool show = !m_virtualKeyboard->isVisible();
     m_virtualKeyboard->setVisible(show);
     if (m_virtualKeyboardAction) m_virtualKeyboardAction->setChecked(show);
+    rebindVirtualKeyboardPulse();
+}
+
+void MainWindow::rebindVirtualKeyboardPulse() {
+    // Drop the previous session's connection (harmless if it is already stale).
+    if (m_virtualKeyboardPulseConnection) {
+        QObject::disconnect(m_virtualKeyboardPulseConnection);
+        m_virtualKeyboardPulseConnection = QMetaObject::Connection();
+    }
+    if (!m_virtualKeyboard || !m_virtualKeyboard->isVisible() || !m_displayWidget) return;
+    m_virtualKeyboardPulseConnection = connect(
+        m_displayWidget, &ui::widgets::Q5250ScreenWidget::keyRecorded,
+        m_virtualKeyboard,
+        [this](int key, Qt::KeyboardModifiers mods, const QString &) {
+            m_virtualKeyboard->pulseForChord(key, mods);
+        });
 }
 
 void MainWindow::onEditKeyboardMapping() {

--- a/src/ui/main_window.h
+++ b/src/ui/main_window.h
@@ -121,6 +121,7 @@ class MainWindow : public ui::widgets::BaseFramelessWindow {
     void onVirtualKeyboardAction(core::MappedAction action);
     void onVirtualKeyboardCharacter(QChar ch);
     void onVirtualKeyboardRemap(core::MappedAction action);
+    void rebindVirtualKeyboardPulse();
 
   private:
     void setupUI();
@@ -210,6 +211,7 @@ class MainWindow : public ui::widgets::BaseFramelessWindow {
     QAction *m_matchReplaceEnableAction;
     QAction *m_virtualKeyboardAction = nullptr;
     ui::widgets::QVirtualKeyboardWidget *m_virtualKeyboard = nullptr;
+    QMetaObject::Connection m_virtualKeyboardPulseConnection;
     QLabel *m_cursorCoordinates; // Cursor position display (row/col)
     ui::widgets::QConnectionStatusWidget *m_globalConnectionStatus; // Global bottom-bar status
 

--- a/src/ui/widgets/QVirtualKeyboardWidget/QVirtualKeyboardWidget.cpp
+++ b/src/ui/widgets/QVirtualKeyboardWidget/QVirtualKeyboardWidget.cpp
@@ -21,8 +21,10 @@
 #include <QGridLayout>
 #include <QLabel>
 #include <QMenu>
+#include <QPointer>
 #include <QString>
 #include <QStringList>
+#include <QTimer>
 #include <QVBoxLayout>
 
 namespace ui::widgets {
@@ -203,6 +205,32 @@ void QVirtualKeyboardWidget::buildLayout() {
     addActionKey(nav, 2, 4, 1, 1, tr("←"), MappedAction::ArrowLeft);
     addActionKey(nav, 2, 5, 1, 1, tr("→"), MappedAction::ArrowRight);
     root->addLayout(nav);
+}
+
+void QVirtualKeyboardWidget::pulseForChord(int key, Qt::KeyboardModifiers modifiers) {
+    // Only the modifiers the mapping cares about; strip keypad/num-lock noise.
+    Qt::KeyboardModifiers mods = modifiers &
+        (Qt::ShiftModifier | Qt::ControlModifier | Qt::AltModifier | Qt::MetaModifier);
+    core::MappedAction action = core::KeyboardMapping::instance().lookup(key, mods);
+    if (action == core::MappedAction::None) return;
+
+    QPushButton *target = nullptr;
+    for (const auto &entry : m_actionButtons) {
+        if (entry.action == action) { target = entry.button; break; }
+    }
+    if (!target) return;
+
+    // Use a dynamic property + stylesheet so the pulse restores cleanly without
+    // interfering with whatever base styling the host application provides.
+    target->setProperty("pulsing", true);
+    target->setStyleSheet(QStringLiteral(
+        "QPushButton[pulsing=\"true\"] { background-color: #f1c40f; color: #202020; }"));
+    QPointer<QPushButton> safe(target);
+    QTimer::singleShot(180, this, [safe]() {
+        if (!safe) return;
+        safe->setProperty("pulsing", false);
+        safe->setStyleSheet(QString());
+    });
 }
 
 void QVirtualKeyboardWidget::refreshChordLabels() {

--- a/src/ui/widgets/QVirtualKeyboardWidget/QVirtualKeyboardWidget.h
+++ b/src/ui/widgets/QVirtualKeyboardWidget/QVirtualKeyboardWidget.h
@@ -41,6 +41,12 @@ class QVirtualKeyboardWidget : public QWidget {
     // Re-label action keys after a remap so chord hints match current bindings.
     void refreshChordLabels();
 
+  public slots:
+    // Resolve the given host chord against the current KeyboardMapping and, if
+    // it matches an action key on the virtual keyboard, briefly highlight that
+    // key. Unmapped chords are ignored so this can be wired to keyRecorded().
+    void pulseForChord(int key, Qt::KeyboardModifiers modifiers);
+
   signals:
     void actionTriggered(core::MappedAction action);
     void characterTriggered(QChar ch);


### PR DESCRIPTION
### Linked Issue
Closes #91

### Motivation
The virtual 5250 keyboard introduced in #86 only reacted to clicks. Since `Q5250ScreenWidget` already emits `keyRecorded(key, mods, text)` for every processed key, feeding that signal into the widget gives the operator a live preview of which on-screen key corresponds to the host chord just pressed — useful both for discovery (first-time AS/400 users) and for projected demos/training.

### What Changed
- Added `QVirtualKeyboardWidget::pulseForChord(int key, Qt::KeyboardModifiers)`. Looks the chord up via `KeyboardMapping::lookup`, finds the matching `ActionButton`, and applies a short stylesheet-based highlight (`background-color: #f1c40f`) for 180 ms via `QTimer::singleShot`. Unmapped chords are a no-op.
- Added `MainWindow::rebindVirtualKeyboardPulse()` which tracks a `QMetaObject::Connection` handle. It disconnects the previous session's connection (if any) and connects the currently active `m_displayWidget->keyRecorded` through a lambda into `pulseForChord`. Modifier noise (keypad, num-lock) is stripped before the lookup.
- `onToggleVirtualKeyboard` installs/removes the connection when the widget is shown or hidden.
- `onCurrentTabChanged` calls `rebindVirtualKeyboardPulse()` after `setActiveSession`, so pressing a host chord in a newly focused tab pulses the on-screen keyboard for that tab's display widget.

### Design Notes
- A single pulse connection is used (not one per session) because the widget itself is a shared singleton instance in `MainWindow`. Swapping the connection on tab change keeps the signal flow simple and avoids maintaining a per-session lambda cache.
- The pulse uses a dynamic `pulsing` property plus a scoped stylesheet so the effect clears without disturbing the host application's theming.
- Unmapped chords (typing in an input field) short-circuit early, so the pulse path costs one hash lookup per keystroke — cheaper than the mapping lookup that `keyPressEvent` already performs.

### Acceptance Criteria Check
- Pressing `Shift+F1` pulses the `PF13` button — `pulseForChord` resolves the chord to `PF13` via `KeyboardMapping::instance().lookup` and finds the matching button in `m_actionButtons`.
- Pressing an unmapped character chord does not alter the virtual keyboard — `if (action == MappedAction::None) return;` exits before any UI work.
- Tab switches re-route the feed — `onCurrentTabChanged` calls `rebindVirtualKeyboardPulse`, which disconnects the stale handle and connects the new `m_displayWidget`.
- High-frequency key entry does not churn — unmapped chords return early; the singleton lookup is O(1).
- `ctest` — all 15 tests pass; the change is purely additive UI.

### How Verified
- **Tests:** `ctest` — 15/15 pass.
- **Build:** `cmake --build build` — compiles cleanly with `-Wall -Wextra -Wpedantic`.
- **Static:** the pulse code is guarded by `if (!target) return;` after the action lookup, so an action without a corresponding button (shouldn't happen today, but future actions without a virtual-keyboard chip) degrades to a no-op. The stale-connection path uses `QMetaObject::Connection::operator bool()` to avoid calling `disconnect` on a never-initialized handle.

### Test Coverage
- **None:** pure UI animation. The chord-resolution path is already covered by `test_keyboard_mapping`.

### Scope of Change
- **Files changed:** `src/ui/widgets/QVirtualKeyboardWidget/QVirtualKeyboardWidget.{h,cpp}`, `src/ui/main_window.h`, `src/ui/actions/onVirtualKeyboard.cpp`, `src/ui/actions/onCurrentTabChanged.cpp`.
- **Submodule pointer updated:** no.
- **Public API changes:** additive — new slot on `QVirtualKeyboardWidget`; new private helper on `MainWindow`.
- **Behavioral changes outside the stated enhancement:** none.

### Risk and Rollout
Low. Everything downstream of `keyRecorded` is additive and local to the on-screen keyboard widget. Users who never open the virtual keyboard see no change — the connection is only installed when the widget becomes visible.

### Notes
Stacked on #90 (`enhancement-remap-dialog-conflict-warning`). Base will retarget to `main` automatically after #86, #88, and #90 merge.
