### PR TITLE
[bugfix] Fix Logger::setLogFile leaving m_logStream dangling on reopen failure (#93)

### DIFF
--- a/src/logger/logger.cpp
+++ b/src/logger/logger.cpp
@@ -68,10 +68,12 @@ void Logger::setLogFile(const QString &filePath) {
     if (m_logStream) {
         m_logStream->flush();
         delete m_logStream;
+        m_logStream = nullptr;
     }
     if (m_logFile) {
         m_logFile->close();
         delete m_logFile;
+        m_logFile = nullptr;
     }
 
     m_logFile = new QFile(filePath);


### PR DESCRIPTION
### Linked Issue
Closes #93

### Root Cause
`Logger::setLogFile` reconfigures the log file by tearing down the existing `QTextStream` and `QFile`, then allocating new ones. The teardown deleted the objects but never cleared the member pointers. On the failure path (open returned false), the function reset only `m_logFile` to `nullptr`; `m_logStream` still held the address of the `QTextStream` that had been freed in the teardown step. The next log call reached `Logger::writeLog`, whose guard `if (m_logStream)` stayed true on the dangling pointer, and writing through it was a use-after-free.

The bug is latent in today's code because `setLogFile` is only called once at startup (`src/main.cpp:115`) when `--debug` is passed, so no second call has ever observed the failure path. Any future second caller (rotating logs, reconfiguration, tests) would crash on the next log line.

### Fix Description
Set `m_logStream` and `m_logFile` to `nullptr` immediately after each `delete` in the teardown block. This keeps the nullptr-guards in `writeLog` and in the accessors (`logFilePath`, `Logger::~Logger`) truthful regardless of which branch `setLogFile` takes after that point. Two-line change, no behavior difference on the success path.

### How Verified
- **Static:** the failure branch in `setLogFile` now leaves `m_logStream == nullptr` because the teardown above cleared it. `writeLog`'s `if (m_logStream)` therefore correctly short-circuits instead of writing through freed memory. The destructor's `if (m_logStream)` / `if (m_logFile)` guards behave the same after repeated setLogFile calls.
- **Build:** `cmake --build build --target 5250ng` succeeds with no new warnings.

### Test Coverage
**None.** The logger is a Meyers singleton with no reset hook, so a deterministic regression test would require adding testability plumbing (reset method, injectable sinks) that is out of scope for a two-line memory-safety fix. The failure path is trivially verifiable by inspection: after the patch, `m_logStream` is guaranteed to be `nullptr` before the new-allocation block runs, so `writeLog`'s guard is correct on every exit path of `setLogFile`.

### Scope of Change
- **Files changed:** `src/logger/logger.cpp`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local, two-line change inside a single function guarded by the logger mutex. No callers observe a semantic difference — the pointers were already effectively nullptr on the success path; the patch only makes that invariant hold on the failure path as well. Safe to merge without staged rollout.