### PR TITLE
[bugfix] Fix stale connect-timeout lambda aborting later TN5250 reconnects (#95)

### DIFF
--- a/src/network/tn5250_qt/client/client.h
+++ b/src/network/tn5250_qt/client/client.h
@@ -95,6 +95,7 @@ class TN5250Client : public QObject {
     void onSocketDisconnected();
     void onSocketReadyRead();
     void onSocketError(QAbstractSocket::SocketError error);
+    void onConnectTimeout();
 #ifdef HAVE_QT6_SSL
     void onSslErrors(const QList<QSslError> &errors);
 #endif
@@ -160,6 +161,14 @@ class TN5250Client : public QObject {
     void startHeartbeat();
     void stopHeartbeat();
     void sendHeartbeat();
+
+    // Connect timeout: owned QTimer so each connect attempt can arm it and
+    // any later successful connect, user-initiated disconnect, or subsequent
+    // connectToHost() cancels it. A fire-and-forget QTimer::singleShot would
+    // leave stale timers live across reconnects and could abort an unrelated
+    // later attempt that happens to be in the Connecting state.
+    QTimer *m_connectTimeoutTimer = nullptr;
+    void armConnectTimeout();
 };
 
 } // namespace tn5250::client

--- a/src/network/tn5250_qt/client/client_connection.cpp
+++ b/src/network/tn5250_qt/client/client_connection.cpp
@@ -75,15 +75,7 @@ void TN5250Client::connectToHost(const QString &hostname, quint16 port, bool use
         // Start TLS after connection
         m_sslSocket->connectToHostEncrypted(hostname, port);
 
-        // Safety timeout: if TLS handshake doesn't complete within 30s, abort
-        QTimer::singleShot(30000, this, [this]() {
-            if (m_state == ConnectionState::Connecting) {
-                logger::Logger::instance()->error(
-                    "[TN5250->Client]: TLS handshake timed out after 30 seconds");
-                disconnectFromHost();
-                emit errorOccurred("TLS handshake timed out");
-            }
-        });
+        armConnectTimeout();
     } else {
 #else
     if (useTLS) {
@@ -112,20 +104,36 @@ void TN5250Client::connectToHost(const QString &hostname, quint16 port, bool use
 
         m_tcpSocket->connectToHost(hostname, port);
 
-        // Safety timeout: if TCP connection doesn't establish within 30s, abort
-        QTimer::singleShot(30000, this, [this]() {
-            if (m_state == ConnectionState::Connecting) {
-                logger::Logger::instance()->error(
-                    "[TN5250->Client]: TCP connection timed out after 30 seconds");
-                disconnectFromHost();
-                emit errorOccurred("Connection timed out");
-            }
-        });
+        armConnectTimeout();
     }
+}
+
+void TN5250Client::armConnectTimeout() {
+    if (!m_connectTimeoutTimer) {
+        m_connectTimeoutTimer = new QTimer(this);
+        m_connectTimeoutTimer->setSingleShot(true);
+        connect(m_connectTimeoutTimer, &QTimer::timeout,
+                this, &TN5250Client::onConnectTimeout);
+    }
+    m_connectTimeoutTimer->start(30000);
+}
+
+void TN5250Client::onConnectTimeout() {
+    if (m_state != ConnectionState::Connecting) return;
+    const char *what = m_useTLS ? "TLS handshake" : "TCP connection";
+    logger::Logger::instance()->error(
+        QString("[TN5250->Client]: %1 timed out after 30 seconds").arg(what));
+    disconnectFromHost();
+    emit errorOccurred(m_useTLS ? QStringLiteral("TLS handshake timed out")
+                                : QStringLiteral("Connection timed out"));
 }
 
 void TN5250Client::disconnectFromHost() {
     stopHeartbeat();
+
+    if (m_connectTimeoutTimer) {
+        m_connectTimeoutTimer->stop();
+    }
 
     if (m_socket) {
         // Abort instead of blocking - avoids freezing the thread for up to 3s

--- a/src/network/tn5250_qt/client/client_io.cpp
+++ b/src/network/tn5250_qt/client/client_io.cpp
@@ -22,6 +22,8 @@
 #include <QtNetwork/QSslSocket>
 #endif
 
+#include <QTimer>
+
 namespace tn5250::client {
 
 void TN5250Client::onSocketConnected() {
@@ -34,6 +36,7 @@ void TN5250Client::onSocketConnected() {
                 "[TN5250->Client]: TLS connection established"
             );
             m_tlsStarted = true;
+            if (m_connectTimeoutTimer) m_connectTimeoutTimer->stop();
             setState(ConnectionState::Negotiating);
             performHandshake();
         } else {
@@ -42,6 +45,7 @@ void TN5250Client::onSocketConnected() {
         }
     } else {
 #endif
+        if (m_connectTimeoutTimer) m_connectTimeoutTimer->stop();
         setState(ConnectionState::Negotiating);
         performHandshake();
 #ifdef HAVE_QT6_SSL


### PR DESCRIPTION
### Linked Issue
Closes #95

### Root Cause
`TN5250Client::connectToHost()` used `QTimer::singleShot(30000, this, [this](){ ... })` as a connection timeout. The lambda captured only `this` and distinguished attempts solely by the `m_state == Connecting` check, with no way to cancel a pending timer. After a successful connect followed by a user-initiated disconnect and a reconnect within 30 s, the stale timer from the first attempt fired while the new attempt was legitimately in the `Connecting` state and aborted it with a misleading `TLS handshake timed out` / `Connection timed out` error, 20 s into a still-valid window.

The defect was not in the 30 s value but in the lifecycle: a timeout that cannot be cancelled cannot be tied to a specific attempt.

### Fix Description
Replace the fire-and-forget `QTimer::singleShot` with a member `QTimer *m_connectTimeoutTimer` owned by the client and started on each `connectToHost()` call:

- `armConnectTimeout()` lazily constructs the timer on first use and starts a 30 s single-shot interval.
- `onConnectTimeout()` is a regular slot that reproduces the prior log/error semantics and dispatches on `m_useTLS` to keep the TLS-vs-TCP-specific messages intact.
- `disconnectFromHost()` stops the timer so a user-initiated disconnect cannot leave a pending timeout that would fire later.
- `onSocketConnected()` stops the timer on the first successful TCP connect (for plain TCP) and on the first `QSslSocket::encrypted` signal (for TLS), matching the moment the original code moved state to `Negotiating`.

The constructor parent ties the timer's lifetime to the client, so no explicit destruction is needed.

Alternative rejected: capturing a per-attempt `QPointer<QObject>` sentinel would also work but adds an allocation per connect and is strictly less flexible than an owned timer, which also covers the user-disconnect-before-timeout case cleanly.

### How Verified
**Static:** the new timer is started exactly in `armConnectTimeout()` (called once per `connectToHost()` attempt) and stopped in `disconnectFromHost()` (L134–L136) and at the transition out of the `Connecting` state in `onSocketConnected()` (`client_io.cpp` L39 TLS path, L47 TCP path). `onConnectTimeout()` itself re-checks `m_state == Connecting` as a belt-and-braces guard in case the stop and the timeout race.

**Runtime:** full existing test suite runs green:

```
100% tests passed, 0 tests failed out of 15
Total Test time (real) =   2.48 sec
```

The `test_tn5250_connection` integration cases (`testBasicConnection`, `testConnectionFailure`, `testTelnetNegotiation`, `testDataTransmission`) exercise the connect / disconnect paths the patch touches and continue to pass.

### Test Coverage
**None.** A deterministic regression test for the bug would need to wait >30 s for the stale timer to fire, which is not feasible for the standard test suite, and adding a configurable timeout knob purely for testing is out of scope. The existing integration tests still exercise the connect/disconnect plumbing and continue to pass.

### Scope of Change
- **Files changed:**
  - `src/network/tn5250_qt/client/client.h` — declare `m_connectTimeoutTimer`, `armConnectTimeout()`, and the `onConnectTimeout()` slot.
  - `src/network/tn5250_qt/client/client_connection.cpp` — replace the two inline `singleShot` lambdas with `armConnectTimeout()`; implement `onConnectTimeout()`; stop the timer in `disconnectFromHost()`.
  - `src/network/tn5250_qt/client/client_io.cpp` — stop the timer in `onSocketConnected()` on both the TLS-encrypted and plain-TCP paths.
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local to the TN5250 client connect path. The timer is created lazily with the client as parent, so there is no ordering hazard at construction or destruction. If the timeout fires during disconnect due to an event-loop race, `onConnectTimeout()`'s state re-check makes the call a no-op. Safe to merge without staged rollout.