### PR TITLE
[bugfix] Fix Windows MSVC build failing with CVT1100 duplicate MANIFEST (#101)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -443,6 +443,14 @@ if(WIN32)
     set_target_properties(5250ng PROPERTIES
         WIN32_EXECUTABLE TRUE
     )
+    # The .rc file embeds our custom manifest (DPI awareness, Win10/11 compat,
+    # UAC asInvoker, common-controls v6). MSVC's linker also auto-generates a
+    # manifest at id 1, language 0x0409 — the same slot — which causes
+    # CVT1100 "duplicate resource" at link time. Suppress the linker's
+    # manifest so only the .rc-embedded one ships.
+    if(MSVC)
+        target_link_options(5250ng PRIVATE "/MANIFEST:NO")
+    endif()
 endif()
 
 if(APPLE)


### PR DESCRIPTION
### Linked Issue
Closes #101

### Root Cause
`resources/windows/5250ng.rc.in` L5 embeds the project's custom manifest (`1 RT_MANIFEST "5250ng.manifest"`) — id `1`, language `0x0409`. MSVC's linker default is `/MANIFEST` (embed), which auto-generates *another* manifest at the same id/language. CVTRES detects the collision and aborts:

```
CVTRES : fatal error CVT1100: duplicate resource. type:MANIFEST, name:1, language:0x0409
LINK   : fatal error LNK1123: failure during conversion to COFF
```

CMake does not automatically disable the linker-generated manifest when the user supplies one via an `.rc`, so the collision is on us to resolve.

### Fix Description
Pass `/MANIFEST:NO` to the linker for the `5250ng` target, gated on `MSVC`. The project's custom manifest — which carries the `PerMonitorV2` DPI awareness, Windows 10/11 `supportedOS` ids, UAC `asInvoker` execution level, and common-controls v6 dependency — remains the sole manifest embedded via the `.rc` resource path.

Alternative of deleting the `1 RT_MANIFEST "5250ng.manifest"` line from the `.rc` was rejected: it would hand manifest generation entirely to MSVC and lose all of the custom manifest's settings. Alternative of `VS_MANIFEST_RESOURCE_FILE` / `/MANIFESTINPUT` was rejected as more invasive — it would require splitting the manifest out of the `.rc` flow and reorganising how the manifest file is located at link time. `/MANIFEST:NO` is the minimal fix that preserves the existing resource pipeline.

The MinGW / windres build path is unaffected because the flag is gated on `MSVC`.

### How Verified
- **Static:** confirmed the duplicate-manifest mechanism against the failing CI log for run [24780066370](https://github.com/5250ng/5250ng/actions/runs/24780066370): the `CVT1100` error names `type:MANIFEST, name:1, language:0x0409`, which is exactly the `.rc`-embedded id matched against MSVC's default-generated id.
- **Runtime (Linux, local):** `cmake -S . -B build` reconfigures cleanly and `cmake --build build --target 5250ng` still links — the `if(MSVC)` guard keeps the new block inert on non-MSVC toolchains.
- **Runtime (Windows):** the `Windows Build & Test` job in `.github/workflows/build.yml` on this PR is the authoritative verification; it will turn green when the linker flag takes effect.

### Test Coverage
**None.** This is a build-system fix with no runtime-library behavioural change. The authoritative regression check is the Windows CI job itself, which covers this change by re-running the failing link step.

### Scope of Change
- **Files changed:** `CMakeLists.txt` (8 lines added inside the existing `if(WIN32)` block, guarded by `if(MSVC)`)
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — non-MSVC toolchains see no change; MSVC sees a single manifest instead of a conflicting pair

### Risk and Rollout
Low: flag is scoped to one target and gated on `MSVC`. Failure mode on regression would show up immediately in the same CI job.

### Notes
Cross-platform CI for the other jobs (`Linux Build & Test`, `macOS Build & Test`) already passed on the failing run, so this fix is narrow to the MSVC link step.