### PR TITLE
[bugfix] Fix testStructuredField to exercise a real WSF (#106)

### DIFF
--- a/tests/unit/test_decoder.cpp
+++ b/tests/unit/test_decoder.cpp
@@ -47,6 +47,7 @@ class TestDecoder : public QObject {
   private slots:
     void onCommandReceived(TN5250Command cmd, const QByteArray &data);
     void onStructuredFieldReceived(StructuredFieldType type, const QByteArray &data);
+    void onWriteStructuredFieldReceived(const QByteArray &data);
     void onParseError(const QString &error);
     void onRawScreenDataReceived(const QByteArray &data);
     void onClearScreenRequested();
@@ -62,6 +63,8 @@ void TestDecoder::init() {
     connect(m_parser, &DecoderAdapter::commandReceived, this, &TestDecoder::onCommandReceived);
     connect(m_parser, &DecoderAdapter::structuredFieldReceived,
             this, &TestDecoder::onStructuredFieldReceived);
+    connect(m_parser, &DecoderAdapter::writeStructuredFieldReceived,
+            this, &TestDecoder::onWriteStructuredFieldReceived);
     connect(m_parser, &DecoderAdapter::parseError, this, &TestDecoder::onParseError);
     connect(m_parser, &DecoderAdapter::rawScreenDataReceived,
             this, &TestDecoder::onRawScreenDataReceived);
@@ -90,6 +93,10 @@ void TestDecoder::onCommandReceived(TN5250Command cmd, const QByteArray &data) {
 void TestDecoder::onStructuredFieldReceived(StructuredFieldType type,
                                             const QByteArray &data) {
     m_lastSFType = type;
+    m_lastSFData = data;
+}
+
+void TestDecoder::onWriteStructuredFieldReceived(const QByteArray &data) {
     m_lastSFData = data;
 }
 
@@ -173,10 +180,17 @@ void TestDecoder::testCommandWithData() {
 }
 
 void TestDecoder::testStructuredField() {
+    // Build a real Write Structured Field per RFC 1205 §12.5.1:
+    //   ESC F3 [LL LL] [class] [type] [data]
+    // where LL LL is the big-endian total SF length (length + class + type
+    // + data). Length 6 = 2 (length) + 2 (class/type) + 2 (data).
     QByteArray sfPayload;
     sfPayload.append('\x04');
-    sfPayload.append('\x12');
-    sfPayload.append(static_cast<char>(StructuredFieldType::OUTBOUND_5250_DS));
+    sfPayload.append('\xF3');
+    sfPayload.append('\x00');
+    sfPayload.append('\x06');
+    sfPayload.append('\xD9');
+    sfPayload.append('\x70');
     sfPayload.append('\xAA');
     sfPayload.append('\xBB');
 
@@ -185,6 +199,13 @@ void TestDecoder::testStructuredField() {
 
     QCOMPARE(m_parser->state(), ParserState::WaitingForCommand);
     QVERIFY(m_lastError.isEmpty());
+    QCOMPARE(m_lastSFData.size(), 6);
+    QCOMPARE(static_cast<uint8_t>(m_lastSFData[0]), static_cast<uint8_t>(0x00));
+    QCOMPARE(static_cast<uint8_t>(m_lastSFData[1]), static_cast<uint8_t>(0x06));
+    QCOMPARE(static_cast<uint8_t>(m_lastSFData[2]), static_cast<uint8_t>(0xD9));
+    QCOMPARE(static_cast<uint8_t>(m_lastSFData[3]), static_cast<uint8_t>(0x70));
+    QCOMPARE(static_cast<uint8_t>(m_lastSFData[4]), static_cast<uint8_t>(0xAA));
+    QCOMPARE(static_cast<uint8_t>(m_lastSFData[5]), static_cast<uint8_t>(0xBB));
 }
 
 void TestDecoder::testInvalidLength() {


### PR DESCRIPTION
## Linked Issue
Closes #106.

Follow-up to #103 / protocol-tn5250#12 / protocol-tn5250#13.

## Root Cause
`TestDecoder::testStructuredField` built payload `04 12 02 AA BB` and asserted that the decoder reported no parse error. `0x12` is not the Write Structured Field command code — `0xF3` is — so the test was always exercising the unknown-ESC-command path, not the WSF path. Under the previous decoder, unknown ESC commands were silently swallowed, so the broken test passed for the wrong reason. With the decoder now reporting unknown commands via `onParseError` (#103), the test correctly fails.

## Fix Description
Rewrite the test to construct a properly framed WSF per RFC 1205 §12.5.1:

- `ESC F3` followed by a big-endian 2-byte SF length (here `00 06`), the SF class (`D9`), the SF type (`70`), and two bytes of SF data.
- Connect to the existing `DecoderAdapter::writeStructuredFieldReceived` signal (the right callback for WSF, as opposed to the never-fired `structuredFieldReceived` the test had been wired to before).
- Assert the WSF callback delivers the full 6-byte SF body, including the length prefix and class/type, in order.

This is what the test's name implies and the path the issue calling for length-prefixed WSF parsing actually walks.

## How Verified
- **Tests:** `./build/test_decoder` reports 10/10 PASS, including `testStructuredField`.
- **Full suite:** `ctest` reports 15/15 tests passing locally.
- **Static:** Confirmed `DecoderAdapter::writeStructuredFieldReceived` is wired to `Decoder::onWriteStructuredField`, which is the callback the protocol library actually fires (`structuredFieldReceived` is dead code on a never-invoked callback — out of scope for this PR).

## Test Coverage
**Existing:** `testStructuredField` itself, now actually exercising WSF instead of an unknown ESC command.

## Scope of Change
- **Files changed:** `tests/unit/test_decoder.cpp`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

## Notes
The dormant `DecoderAdapter::structuredFieldReceived` signal remains — it is wired to a callback (`onStructuredFieldReceived`) that the protocol library never invokes. Cleaning that up is unrelated to this fix and should be done in a separate PR if desired.