### PR TITLE
[enhancement] Add STRPCCMD support: detect, prompt, and execute host PC commands (#108)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,8 @@ set(CORE_SOURCES
     src/core/match_replace_engine.h
     src/core/macro_to_script.cpp
     src/core/macro_to_script.h
+    src/core/pc_command_runner.cpp
+    src/core/pc_command_runner.h
 )
 
 set(SESSION_SOURCES
@@ -247,6 +249,8 @@ set(UI_SOURCES
     src/ui/dialogs/match_replace_dialog.h
     src/ui/dialogs/keyboard_remap_dialog.cpp
     src/ui/dialogs/keyboard_remap_dialog.h
+    src/ui/dialogs/pc_command_confirm_dialog.cpp
+    src/ui/dialogs/pc_command_confirm_dialog.h
     # themes
     src/ui/themes/manager.cpp
     src/ui/themes/manager.h
@@ -404,6 +408,7 @@ if(BUILD_TESTS)
     add_tn5250_test(test_keyboard_encoder tests/unit/test_keyboard_encoder.cpp)
     add_tn5250_test(test_keyboard_mapping tests/unit/test_keyboard_mapping.cpp)
     add_tn5250_test(test_session_config tests/unit/test_session_config.cpp)
+    add_tn5250_test(test_pc_command_runner tests/unit/test_pc_command_runner.cpp)
 
     add_tn5250_test(test_ibmrseed tests/unit/test_ibmrseed.cpp)
     add_tn5250_test(test_codepage tests/unit/test_codepage.cpp)

--- a/src/core/pc_command_runner.cpp
+++ b/src/core/pc_command_runner.cpp
@@ -1,0 +1,111 @@
+// 5250ng - A modern IBM TN5250 terminal emulator
+// Copyright (C) 2025-2026 Remi GASCOU (Podalirius)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include "core/pc_command_runner.h"
+#include "logger/logger.h"
+
+#include <QProcess>
+#include <QStringList>
+
+namespace core {
+
+PcCommandRunner::PcCommandRunner(QObject *parent) : QObject(parent) {}
+
+// Splits a STRPCCMD command string into program + arguments using the same
+// quoting rules as a typical shell: bare tokens separated by whitespace, with
+// double-quoted spans treated as one token. This intentionally avoids passing
+// the string to a real shell — STRPCCMD payloads come from the host and could
+// contain shell metacharacters; QProcess::start(program, arguments) executes
+// the program directly and does not re-interpret the args.
+static QStringList splitCommand(const QString &command) {
+    QStringList tokens;
+    QString current;
+    bool inQuotes = false;
+    for (QChar c : command) {
+        if (c == '"') {
+            inQuotes = !inQuotes;
+            continue;
+        }
+        if (!inQuotes && c.isSpace()) {
+            if (!current.isEmpty()) {
+                tokens.append(current);
+                current.clear();
+            }
+            continue;
+        }
+        current.append(c);
+    }
+    if (!current.isEmpty()) tokens.append(current);
+    return tokens;
+}
+
+PcCommandRunner::Result PcCommandRunner::run(const QString &command, Mode mode) {
+    if (!m_enabled) {
+        logger::Logger::instance()->warning(
+            QString("PcCommandRunner: refused (feature disabled): %1").arg(command));
+        return {Outcome::DisabledByPolicy, 0};
+    }
+    if (m_confirm && !m_confirm(m_hostname, command)) {
+        logger::Logger::instance()->info(
+            QString("PcCommandRunner: user denied command: %1").arg(command));
+        return {Outcome::DeniedByUser, 0};
+    }
+
+    QStringList tokens = splitCommand(command);
+    if (tokens.isEmpty()) {
+        logger::Logger::instance()->warning(
+            "PcCommandRunner: empty command after tokenisation, refusing to launch");
+        return {Outcome::StartFailed, 0};
+    }
+    const QString program = tokens.takeFirst();
+    const QStringList args = tokens;
+
+    if (mode == Mode::NoWait) {
+        qint64 pid = 0;
+        const bool ok = QProcess::startDetached(program, args, QString(), &pid);
+        if (!ok) {
+            logger::Logger::instance()->warning(
+                QString("PcCommandRunner: startDetached failed: %1").arg(command));
+            return {Outcome::StartFailed, 0};
+        }
+        logger::Logger::instance()->info(
+            QString("PcCommandRunner: launched detached pid=%1: %2")
+                .arg(pid).arg(command));
+        return {Outcome::Launched, 0};
+    }
+
+    QProcess proc;
+    proc.start(program, args);
+    if (!proc.waitForStarted(5000)) {
+        logger::Logger::instance()->warning(
+            QString("PcCommandRunner: waitForStarted failed: %1").arg(command));
+        return {Outcome::StartFailed, 0};
+    }
+    if (!proc.waitForFinished(m_waitTimeoutMs)) {
+        proc.kill();
+        proc.waitForFinished(1000);
+        logger::Logger::instance()->warning(
+            QString("PcCommandRunner: timed out after %1 ms: %2")
+                .arg(m_waitTimeoutMs).arg(command));
+        return {Outcome::TimedOut, 0};
+    }
+    const int code = proc.exitCode();
+    logger::Logger::instance()->info(
+        QString("PcCommandRunner: completed exit=%1: %2").arg(code).arg(command));
+    return {Outcome::Completed, code};
+}
+
+} // namespace core

--- a/src/core/pc_command_runner.h
+++ b/src/core/pc_command_runner.h
@@ -1,0 +1,87 @@
+// 5250ng - A modern IBM TN5250 terminal emulator
+// Copyright (C) 2025-2026 Remi GASCOU (Podalirius)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <QObject>
+#include <QString>
+#include <functional>
+
+class QWidget;
+
+namespace core {
+
+// Runs a host-issued STRPCCMD command on the local PC, with a policy gate.
+// Two modes:
+//   - Wait: starts the process, blocks up to a timeout, returns the exit code.
+//   - NoWait: launches the process detached and returns immediately.
+// In both modes the runner refuses to do anything when the feature is
+// disabled, and (when enabled) consults a confirm callback to ask the user
+// per command. The callback is injected so unit tests can supply an
+// auto-accept/auto-deny stub without touching real Qt dialogs.
+class PcCommandRunner : public QObject {
+    Q_OBJECT
+  public:
+    enum class Mode {
+        Wait,
+        NoWait,
+    };
+
+    enum class Outcome {
+        DisabledByPolicy,  // pcCommandEnabled=false; nothing was attempted
+        DeniedByUser,      // user clicked Deny in the confirm dialog
+        StartFailed,       // QProcess refused to launch (bad binary, etc.)
+        TimedOut,          // wait mode hit the timeout before exit
+        Completed,         // process exited within the timeout (Wait mode)
+        Launched,          // process was started detached (NoWait mode)
+    };
+
+    struct Result {
+        Outcome outcome;
+        int exitCode = 0;  // Only meaningful for Outcome::Completed
+    };
+
+    // Confirm callback returns true to allow, false to deny. Receives the
+    // host name (for "this command was requested by host X") and the full
+    // command string. The callback is responsible for showing UI; the runner
+    // does not pop dialogs itself.
+    using ConfirmFn = std::function<bool(const QString &hostname, const QString &command)>;
+
+    explicit PcCommandRunner(QObject *parent = nullptr);
+
+    void setEnabled(bool enabled) { m_enabled = enabled; }
+    bool isEnabled() const { return m_enabled; }
+
+    void setHostname(const QString &hostname) { m_hostname = hostname; }
+    void setConfirmCallback(ConfirmFn fn) { m_confirm = std::move(fn); }
+
+    // Wait-mode timeout. Defaults to 60 seconds. Set to -1 to disable
+    // (waits forever — use only in tests).
+    void setWaitTimeoutMs(int ms) { m_waitTimeoutMs = ms; }
+
+    // Runs the command. Returns the outcome. Wait mode blocks the calling
+    // thread; the caller is expected to be on the UI thread for the dialog
+    // to render but should be aware of the blocking nature.
+    Result run(const QString &command, Mode mode);
+
+  private:
+    bool m_enabled = false;
+    QString m_hostname;
+    ConfirmFn m_confirm;
+    int m_waitTimeoutMs = 60000;
+};
+
+} // namespace core

--- a/src/network/tn5250_qt/client/decoder_adapter.cpp
+++ b/src/network/tn5250_qt/client/decoder_adapter.cpp
@@ -64,6 +64,7 @@ DecoderAdapter::DecoderAdapter(QObject *parent) : QObject(parent) {
     cb.onWriteStructuredField = [this](const std::vector<uint8_t> &data) {
         emit writeStructuredFieldReceived(toQt(data));
     };
+    cb.onStrpccmdRequested = [this]() { emit strpccmdRequested(); };
     cb.onParseError = [this](const std::string &err) {
         emit parseError(QString::fromStdString(err));
     };

--- a/src/network/tn5250_qt/client/decoder_adapter.h
+++ b/src/network/tn5250_qt/client/decoder_adapter.h
@@ -56,6 +56,11 @@ class DecoderAdapter : public QObject {
     void messageLightOff();
     void readScreenRequested(bool includeAttributes);
     void writeStructuredFieldReceived(const QByteArray &data);
+    // Fires when the host's WTD stream contains the STRPCCMD marker. The
+    // 10-byte marker has already been consumed by the protocol decoder; the
+    // command string itself lives at fixed screen coordinates and must be read
+    // off the rendered screen by the consumer (TN5250CommandHandler).
+    void strpccmdRequested();
     void parseError(const QString &error);
 
   private:

--- a/src/session/config.cpp
+++ b/src/session/config.cpp
@@ -23,7 +23,7 @@ namespace session {
 
 SessionConfig::SessionConfig(QObject *parent) : QObject(parent), m_name("New Session"), m_hostname(""), m_port(23), m_useTLS(false), m_deviceType("IBM-3179-2"), m_deviceName(""), m_screenRows(24), m_screenCols(80), m_codePage(core::CodePage::ID::CP037), m_terminalThemeId("classic_green") {}
 
-SessionConfig::SessionConfig(const SessionConfig &other) : QObject(other.parent()), m_name(other.m_name), m_hostname(other.m_hostname), m_port(other.m_port), m_useTLS(other.m_useTLS), m_allowInvalidCertificates(other.m_allowInvalidCertificates), m_deviceType(other.m_deviceType), m_deviceName(other.m_deviceName), m_screenRows(other.m_screenRows), m_screenCols(other.m_screenCols), m_codePage(other.m_codePage), m_terminalThemeId(other.m_terminalThemeId), m_startupScriptSource(other.m_startupScriptSource), m_startupScriptName(other.m_startupScriptName), m_sessionVariables(other.m_sessionVariables), m_username(other.m_username), m_password(other.m_password), m_pcCommandEnabled(other.m_pcCommandEnabled), m_pcCommandConfirmEachTime(other.m_pcCommandConfirmEachTime) {}
+SessionConfig::SessionConfig(const SessionConfig &other) : QObject(other.parent()), m_name(other.m_name), m_hostname(other.m_hostname), m_port(other.m_port), m_useTLS(other.m_useTLS), m_allowInvalidCertificates(other.m_allowInvalidCertificates), m_deviceType(other.m_deviceType), m_deviceName(other.m_deviceName), m_screenRows(other.m_screenRows), m_screenCols(other.m_screenCols), m_codePage(other.m_codePage), m_terminalThemeId(other.m_terminalThemeId), m_startupScriptSource(other.m_startupScriptSource), m_startupScriptName(other.m_startupScriptName), m_sessionVariables(other.m_sessionVariables), m_username(other.m_username), m_password(other.m_password), m_pcCommandPolicy(other.m_pcCommandPolicy) {}
 
 SessionConfig &SessionConfig::operator=(const SessionConfig &other) {
     if (this != &other) {
@@ -43,12 +43,38 @@ SessionConfig &SessionConfig::operator=(const SessionConfig &other) {
         m_sessionVariables = other.m_sessionVariables;
         m_username = other.m_username;
         m_password = other.m_password;
-        m_pcCommandEnabled = other.m_pcCommandEnabled;
-        m_pcCommandConfirmEachTime = other.m_pcCommandConfirmEachTime;
+        m_pcCommandPolicy = other.m_pcCommandPolicy;
         emit changed();
     }
     return *this;
 }
+
+namespace {
+
+// String tags persisted in JSON for each PcCommandPolicy. Strings are stable
+// over time and self-documenting in saved config files; an int would be
+// shorter but harder to grep and easy to misread when comparing files.
+QString pcCommandPolicyToString(PcCommandPolicy policy) {
+    switch (policy) {
+    case PcCommandPolicy::Deny:            return QStringLiteral("deny");
+    case PcCommandPolicy::DenyAndAlert:    return QStringLiteral("denyAlert");
+    case PcCommandPolicy::AllowWithPrompt: return QStringLiteral("allowPrompt");
+    case PcCommandPolicy::AllowAlways:     return QStringLiteral("allowAlways");
+    }
+    return QStringLiteral("deny");
+}
+
+// Returns the default DenyAndAlert on any unrecognised string. This keeps the
+// fall-through path safe (never run) while also surfacing the typo/unknown
+// value to the user via the alert, instead of silently swallowing it.
+PcCommandPolicy pcCommandPolicyFromString(const QString &s) {
+    if (s == QStringLiteral("deny"))         return PcCommandPolicy::Deny;
+    if (s == QStringLiteral("allowPrompt"))  return PcCommandPolicy::AllowWithPrompt;
+    if (s == QStringLiteral("allowAlways"))  return PcCommandPolicy::AllowAlways;
+    return PcCommandPolicy::DenyAndAlert;
+}
+
+} // namespace
 
 QJsonObject SessionConfig::toJson() const {
     QJsonObject json;
@@ -79,13 +105,10 @@ QJsonObject SessionConfig::toJson() const {
         json["username"] = m_username;
     if (!m_password.isEmpty())
         json["password"] = m_password;
-    // Only persist STRPCCMD settings when they diverge from the safe default
-    // (disabled, always-confirm), so existing config files do not gain a
-    // surprising new key on first save.
-    if (m_pcCommandEnabled)
-        json["pcCommandEnabled"] = m_pcCommandEnabled;
-    if (!m_pcCommandConfirmEachTime)
-        json["pcCommandConfirmEachTime"] = m_pcCommandConfirmEachTime;
+    // Only persist the policy when it diverges from the default (DenyAndAlert),
+    // so existing config files do not gain a surprising new key on first save.
+    if (m_pcCommandPolicy != PcCommandPolicy::DenyAndAlert)
+        json["pcCommandPolicy"] = pcCommandPolicyToString(m_pcCommandPolicy);
     return json;
 }
 
@@ -175,15 +198,26 @@ bool SessionConfig::fromJson(const QJsonObject &json) {
     if (json.contains("password") && json["password"].isString()) {
         m_password = json["password"].toString();
     }
-    if (json.contains("pcCommandEnabled") && json["pcCommandEnabled"].isBool()) {
-        m_pcCommandEnabled = json["pcCommandEnabled"].toBool();
+    // STRPCCMD policy. Prefer the new "pcCommandPolicy" string field; fall
+    // back to the older boolean pair for configs written by an earlier build:
+    //   pcCommandEnabled=false (or absent)                   -> DenyAndAlert (default)
+    //   pcCommandEnabled=true,  confirmEachTime=true|absent  -> AllowWithPrompt
+    //   pcCommandEnabled=true,  confirmEachTime=false        -> AllowAlways
+    // Absence of every key also lands on DenyAndAlert — never run on
+    // ambiguous configs, but always make refused attempts visible.
+    if (json.contains("pcCommandPolicy") && json["pcCommandPolicy"].isString()) {
+        m_pcCommandPolicy = pcCommandPolicyFromString(json["pcCommandPolicy"].toString());
+    } else if (json.contains("pcCommandEnabled") && json["pcCommandEnabled"].isBool()
+               && json["pcCommandEnabled"].toBool()) {
+        const bool confirmEachTime =
+            !json.contains("pcCommandConfirmEachTime")
+            || !json["pcCommandConfirmEachTime"].isBool()
+            || json["pcCommandConfirmEachTime"].toBool();
+        m_pcCommandPolicy = confirmEachTime
+            ? PcCommandPolicy::AllowWithPrompt
+            : PcCommandPolicy::AllowAlways;
     } else {
-        m_pcCommandEnabled = false;
-    }
-    if (json.contains("pcCommandConfirmEachTime") && json["pcCommandConfirmEachTime"].isBool()) {
-        m_pcCommandConfirmEachTime = json["pcCommandConfirmEachTime"].toBool();
-    } else {
-        m_pcCommandConfirmEachTime = true;
+        m_pcCommandPolicy = PcCommandPolicy::DenyAndAlert;
     }
     emit changed();
     return isValid();

--- a/src/session/config.cpp
+++ b/src/session/config.cpp
@@ -23,7 +23,7 @@ namespace session {
 
 SessionConfig::SessionConfig(QObject *parent) : QObject(parent), m_name("New Session"), m_hostname(""), m_port(23), m_useTLS(false), m_deviceType("IBM-3179-2"), m_deviceName(""), m_screenRows(24), m_screenCols(80), m_codePage(core::CodePage::ID::CP037), m_terminalThemeId("classic_green") {}
 
-SessionConfig::SessionConfig(const SessionConfig &other) : QObject(other.parent()), m_name(other.m_name), m_hostname(other.m_hostname), m_port(other.m_port), m_useTLS(other.m_useTLS), m_allowInvalidCertificates(other.m_allowInvalidCertificates), m_deviceType(other.m_deviceType), m_deviceName(other.m_deviceName), m_screenRows(other.m_screenRows), m_screenCols(other.m_screenCols), m_codePage(other.m_codePage), m_terminalThemeId(other.m_terminalThemeId), m_startupScriptSource(other.m_startupScriptSource), m_startupScriptName(other.m_startupScriptName), m_sessionVariables(other.m_sessionVariables), m_username(other.m_username), m_password(other.m_password) {}
+SessionConfig::SessionConfig(const SessionConfig &other) : QObject(other.parent()), m_name(other.m_name), m_hostname(other.m_hostname), m_port(other.m_port), m_useTLS(other.m_useTLS), m_allowInvalidCertificates(other.m_allowInvalidCertificates), m_deviceType(other.m_deviceType), m_deviceName(other.m_deviceName), m_screenRows(other.m_screenRows), m_screenCols(other.m_screenCols), m_codePage(other.m_codePage), m_terminalThemeId(other.m_terminalThemeId), m_startupScriptSource(other.m_startupScriptSource), m_startupScriptName(other.m_startupScriptName), m_sessionVariables(other.m_sessionVariables), m_username(other.m_username), m_password(other.m_password), m_pcCommandEnabled(other.m_pcCommandEnabled), m_pcCommandConfirmEachTime(other.m_pcCommandConfirmEachTime) {}
 
 SessionConfig &SessionConfig::operator=(const SessionConfig &other) {
     if (this != &other) {
@@ -43,6 +43,8 @@ SessionConfig &SessionConfig::operator=(const SessionConfig &other) {
         m_sessionVariables = other.m_sessionVariables;
         m_username = other.m_username;
         m_password = other.m_password;
+        m_pcCommandEnabled = other.m_pcCommandEnabled;
+        m_pcCommandConfirmEachTime = other.m_pcCommandConfirmEachTime;
         emit changed();
     }
     return *this;
@@ -77,6 +79,13 @@ QJsonObject SessionConfig::toJson() const {
         json["username"] = m_username;
     if (!m_password.isEmpty())
         json["password"] = m_password;
+    // Only persist STRPCCMD settings when they diverge from the safe default
+    // (disabled, always-confirm), so existing config files do not gain a
+    // surprising new key on first save.
+    if (m_pcCommandEnabled)
+        json["pcCommandEnabled"] = m_pcCommandEnabled;
+    if (!m_pcCommandConfirmEachTime)
+        json["pcCommandConfirmEachTime"] = m_pcCommandConfirmEachTime;
     return json;
 }
 
@@ -165,6 +174,16 @@ bool SessionConfig::fromJson(const QJsonObject &json) {
     }
     if (json.contains("password") && json["password"].isString()) {
         m_password = json["password"].toString();
+    }
+    if (json.contains("pcCommandEnabled") && json["pcCommandEnabled"].isBool()) {
+        m_pcCommandEnabled = json["pcCommandEnabled"].toBool();
+    } else {
+        m_pcCommandEnabled = false;
+    }
+    if (json.contains("pcCommandConfirmEachTime") && json["pcCommandConfirmEachTime"].isBool()) {
+        m_pcCommandConfirmEachTime = json["pcCommandConfirmEachTime"].toBool();
+    } else {
+        m_pcCommandConfirmEachTime = true;
     }
     emit changed();
     return isValid();

--- a/src/session/config.h
+++ b/src/session/config.h
@@ -96,6 +96,17 @@ class SessionConfig : public QObject {
     QString password() const { return m_password; }
     void setPassword(const QString &password) { m_password = password; }
 
+    // STRPCCMD: when true, allow the host to ask the client to run a command
+    // on the local PC. Default is false because this is the mechanism behind
+    // CVE-2005-0868. Even when enabled, every command is gated by a per-command
+    // confirmation prompt unless pcCommandConfirmEachTime is explicitly turned
+    // off (currently always-on; the field exists for forward extensibility).
+    bool pcCommandEnabled() const { return m_pcCommandEnabled; }
+    void setPcCommandEnabled(bool enabled) { m_pcCommandEnabled = enabled; }
+
+    bool pcCommandConfirmEachTime() const { return m_pcCommandConfirmEachTime; }
+    void setPcCommandConfirmEachTime(bool confirm) { m_pcCommandConfirmEachTime = confirm; }
+
     // Serialization
     QJsonObject toJson() const;
     bool fromJson(const QJsonObject &json);
@@ -123,6 +134,8 @@ class SessionConfig : public QObject {
     QHash<QString, QString> m_sessionVariables;
     QString m_username;
     QString m_password;
+    bool m_pcCommandEnabled = false;
+    bool m_pcCommandConfirmEachTime = true;
 
 };
 

--- a/src/session/config.h
+++ b/src/session/config.h
@@ -25,6 +25,18 @@
 
 namespace session {
 
+// Policy controlling how the client reacts to a host-issued STRPCCMD
+// (Start PC Command). The default is DenyAndAlert: STRPCCMD is the mechanism
+// behind CVE-2005-0868 so we never run anything by default, but we surface
+// the attempt to the user instead of staying silent — silent denial would
+// hide the fact that a host is trying to run code on the user's machine.
+enum class PcCommandPolicy {
+    Deny,             // Refuse silently. Host still receives ENTER so its CL program continues.
+    DenyAndAlert,     // Refuse, but show the user a notification with the attempted command.
+    AllowWithPrompt,  // Show an Allow/Deny dialog with the command before running.
+    AllowAlways,      // Run every command silently. Insecure; only for trusted hosts.
+};
+
 // Session configuration for TN5250 connections
 class SessionConfig : public QObject {
     Q_OBJECT
@@ -96,16 +108,10 @@ class SessionConfig : public QObject {
     QString password() const { return m_password; }
     void setPassword(const QString &password) { m_password = password; }
 
-    // STRPCCMD: when true, allow the host to ask the client to run a command
-    // on the local PC. Default is false because this is the mechanism behind
-    // CVE-2005-0868. Even when enabled, every command is gated by a per-command
-    // confirmation prompt unless pcCommandConfirmEachTime is explicitly turned
-    // off (currently always-on; the field exists for forward extensibility).
-    bool pcCommandEnabled() const { return m_pcCommandEnabled; }
-    void setPcCommandEnabled(bool enabled) { m_pcCommandEnabled = enabled; }
-
-    bool pcCommandConfirmEachTime() const { return m_pcCommandConfirmEachTime; }
-    void setPcCommandConfirmEachTime(bool confirm) { m_pcCommandConfirmEachTime = confirm; }
+    // STRPCCMD policy. Default is Deny because this is the mechanism behind
+    // CVE-2005-0868. See the PcCommandPolicy enum for the four states.
+    PcCommandPolicy pcCommandPolicy() const { return m_pcCommandPolicy; }
+    void setPcCommandPolicy(PcCommandPolicy policy) { m_pcCommandPolicy = policy; }
 
     // Serialization
     QJsonObject toJson() const;
@@ -134,8 +140,7 @@ class SessionConfig : public QObject {
     QHash<QString, QString> m_sessionVariables;
     QString m_username;
     QString m_password;
-    bool m_pcCommandEnabled = false;
-    bool m_pcCommandConfirmEachTime = true;
+    PcCommandPolicy m_pcCommandPolicy = PcCommandPolicy::DenyAndAlert;
 
 };
 

--- a/src/ui/dialogs/connect_dialog.cpp
+++ b/src/ui/dialogs/connect_dialog.cpp
@@ -93,15 +93,6 @@ void ConnectDialog::setupUI() {
         "certificates are accepted. Leave off unless you trust the host.");
     formLayout->addRow("", m_allowInvalidCertsCheck);
 
-    m_pcCommandEnabledCheck = new QCheckBox(
-        "Allow host to run PC commands (STRPCCMD, insecure)", this);
-    m_pcCommandEnabledCheck->setToolTip(
-        "When enabled, the host can ask 5250ng to run a command on this PC "
-        "(IBM i STRPCCMD). Every command shows a confirmation prompt before "
-        "running. Leave off unless you trust the host — this is the mechanism "
-        "behind CVE-2005-0868.");
-    formLayout->addRow("", m_pcCommandEnabledCheck);
-
     m_usernameEdit = new QLineEdit(this);
     m_usernameEdit->setPlaceholderText("(optional - for encrypted sign-on)");
     formLayout->addRow("Username:", m_usernameEdit);
@@ -183,6 +174,50 @@ void ConnectDialog::setupUI() {
     codePageGroup->setLayout(codePageLayout);
     mainLayout->addWidget(codePageGroup);
 
+    // PC Command Execution (STRPCCMD) — three-way policy. Off by default
+    // because this is the mechanism behind CVE-2005-0868: the host can ask
+    // the client to run any command its user can run.
+    QGroupBox *pcCmdGroup = new QGroupBox("PC Command Execution (STRPCCMD)", this);
+    QVBoxLayout *pcCmdLayout = new QVBoxLayout(pcCmdGroup);
+    QLabel *pcCmdWarning = new QLabel(
+        "Controls whether this host can ask 5250ng to run a command on your PC. "
+        "STRPCCMD is the mechanism behind CVE-2005-0868 — leave on \"Deny\" "
+        "unless you trust this host.",
+        this);
+    pcCmdWarning->setWordWrap(true);
+    pcCmdLayout->addWidget(pcCmdWarning);
+
+    m_pcCmdDenyRadio = new QRadioButton(
+        "Deny silently: refuse all PC commands (recommended)", this);
+    m_pcCmdDenyAlertRadio = new QRadioButton(
+        "Deny and alert: refuse, but show a notification when the host attempts a command", this);
+    m_pcCmdPromptRadio = new QRadioButton(
+        "Allow with confirmation: prompt before running each command", this);
+    m_pcCmdAllowAlwaysRadio = new QRadioButton(
+        "Allow without prompting: run every command silently (insecure)", this);
+    m_pcCmdDenyRadio->setToolTip(
+        "Default. The host's STRPCCMD requests are silently refused; the host "
+        "still receives an ENTER reply so its CL program continues.");
+    m_pcCmdDenyAlertRadio->setToolTip(
+        "The host's STRPCCMD requests are refused, but a notification dialog "
+        "is shown each time so you know the host attempted to run something. "
+        "Useful when you want to monitor a host without trusting it.");
+    m_pcCmdPromptRadio->setToolTip(
+        "Each STRPCCMD shows a modal with the command string and Allow/Deny "
+        "before anything runs.");
+    m_pcCmdAllowAlwaysRadio->setToolTip(
+        "Every STRPCCMD runs immediately with no user confirmation. Anything "
+        "the host sends will execute as you. Only use on hosts you fully "
+        "control.");
+    pcCmdLayout->addWidget(m_pcCmdDenyRadio);
+    pcCmdLayout->addWidget(m_pcCmdDenyAlertRadio);
+    pcCmdLayout->addWidget(m_pcCmdPromptRadio);
+    pcCmdLayout->addWidget(m_pcCmdAllowAlwaysRadio);
+    // Default selection mirrors the SessionConfig default (DenyAndAlert).
+    m_pcCmdDenyAlertRadio->setChecked(true);
+    pcCmdGroup->setLayout(pcCmdLayout);
+    mainLayout->addWidget(pcCmdGroup);
+
     // Terminal theme group
     QGroupBox *themeGroup = new QGroupBox("Terminal Theme", this);
     QFormLayout *themeLayout = new QFormLayout(themeGroup);
@@ -249,7 +284,20 @@ void ConnectDialog::updateUI() {
     m_portSpin->setValue(m_currentConfig.port());
     m_tlsCheck->setChecked(m_currentConfig.useTLS());
     m_allowInvalidCertsCheck->setChecked(m_currentConfig.allowInvalidCertificates());
-    m_pcCommandEnabledCheck->setChecked(m_currentConfig.pcCommandEnabled());
+    switch (m_currentConfig.pcCommandPolicy()) {
+    case session::PcCommandPolicy::Deny:
+        m_pcCmdDenyRadio->setChecked(true);
+        break;
+    case session::PcCommandPolicy::DenyAndAlert:
+        m_pcCmdDenyAlertRadio->setChecked(true);
+        break;
+    case session::PcCommandPolicy::AllowWithPrompt:
+        m_pcCmdPromptRadio->setChecked(true);
+        break;
+    case session::PcCommandPolicy::AllowAlways:
+        m_pcCmdAllowAlwaysRadio->setChecked(true);
+        break;
+    }
     m_usernameEdit->setText(m_currentConfig.username());
     m_passwordEdit->setText(m_currentConfig.password());
     // Select device type in combo if supported
@@ -312,7 +360,15 @@ session::SessionConfig ConnectDialog::getSessionConfig() const {
     config.setPort(static_cast<quint16>(m_portSpin->value()));
     config.setUseTLS(m_tlsCheck->isChecked());
     config.setAllowInvalidCertificates(m_allowInvalidCertsCheck->isChecked());
-    config.setPcCommandEnabled(m_pcCommandEnabledCheck->isChecked());
+    if (m_pcCmdAllowAlwaysRadio->isChecked()) {
+        config.setPcCommandPolicy(session::PcCommandPolicy::AllowAlways);
+    } else if (m_pcCmdPromptRadio->isChecked()) {
+        config.setPcCommandPolicy(session::PcCommandPolicy::AllowWithPrompt);
+    } else if (m_pcCmdDenyAlertRadio->isChecked()) {
+        config.setPcCommandPolicy(session::PcCommandPolicy::DenyAndAlert);
+    } else {
+        config.setPcCommandPolicy(session::PcCommandPolicy::Deny);
+    }
     if (m_deviceCombo->currentIndex() == m_customDeviceIndex) {
         config.setDeviceType(m_customDeviceEdit->text());
     } else {

--- a/src/ui/dialogs/connect_dialog.cpp
+++ b/src/ui/dialogs/connect_dialog.cpp
@@ -93,6 +93,15 @@ void ConnectDialog::setupUI() {
         "certificates are accepted. Leave off unless you trust the host.");
     formLayout->addRow("", m_allowInvalidCertsCheck);
 
+    m_pcCommandEnabledCheck = new QCheckBox(
+        "Allow host to run PC commands (STRPCCMD, insecure)", this);
+    m_pcCommandEnabledCheck->setToolTip(
+        "When enabled, the host can ask 5250ng to run a command on this PC "
+        "(IBM i STRPCCMD). Every command shows a confirmation prompt before "
+        "running. Leave off unless you trust the host — this is the mechanism "
+        "behind CVE-2005-0868.");
+    formLayout->addRow("", m_pcCommandEnabledCheck);
+
     m_usernameEdit = new QLineEdit(this);
     m_usernameEdit->setPlaceholderText("(optional - for encrypted sign-on)");
     formLayout->addRow("Username:", m_usernameEdit);
@@ -240,6 +249,7 @@ void ConnectDialog::updateUI() {
     m_portSpin->setValue(m_currentConfig.port());
     m_tlsCheck->setChecked(m_currentConfig.useTLS());
     m_allowInvalidCertsCheck->setChecked(m_currentConfig.allowInvalidCertificates());
+    m_pcCommandEnabledCheck->setChecked(m_currentConfig.pcCommandEnabled());
     m_usernameEdit->setText(m_currentConfig.username());
     m_passwordEdit->setText(m_currentConfig.password());
     // Select device type in combo if supported
@@ -302,6 +312,7 @@ session::SessionConfig ConnectDialog::getSessionConfig() const {
     config.setPort(static_cast<quint16>(m_portSpin->value()));
     config.setUseTLS(m_tlsCheck->isChecked());
     config.setAllowInvalidCertificates(m_allowInvalidCertsCheck->isChecked());
+    config.setPcCommandEnabled(m_pcCommandEnabledCheck->isChecked());
     if (m_deviceCombo->currentIndex() == m_customDeviceIndex) {
         config.setDeviceType(m_customDeviceEdit->text());
     } else {

--- a/src/ui/dialogs/connect_dialog.h
+++ b/src/ui/dialogs/connect_dialog.h
@@ -27,6 +27,7 @@
 #include <QLabel>
 #include <QLineEdit>
 #include <QPushButton>
+#include <QRadioButton>
 #include <QSpinBox>
 #include <QVBoxLayout>
 #include <QHash>
@@ -74,7 +75,10 @@ class ConnectDialog : public ui::widgets::BaseFramelessDialog {
     QSpinBox *m_portSpin;
     QCheckBox *m_tlsCheck;
     QCheckBox *m_allowInvalidCertsCheck;
-    QCheckBox *m_pcCommandEnabledCheck;
+    QRadioButton *m_pcCmdDenyRadio;
+    QRadioButton *m_pcCmdDenyAlertRadio;
+    QRadioButton *m_pcCmdPromptRadio;
+    QRadioButton *m_pcCmdAllowAlwaysRadio;
     QLineEdit *m_usernameEdit;
     QLineEdit *m_passwordEdit;
     QComboBox *m_deviceCombo;

--- a/src/ui/dialogs/connect_dialog.h
+++ b/src/ui/dialogs/connect_dialog.h
@@ -74,6 +74,7 @@ class ConnectDialog : public ui::widgets::BaseFramelessDialog {
     QSpinBox *m_portSpin;
     QCheckBox *m_tlsCheck;
     QCheckBox *m_allowInvalidCertsCheck;
+    QCheckBox *m_pcCommandEnabledCheck;
     QLineEdit *m_usernameEdit;
     QLineEdit *m_passwordEdit;
     QComboBox *m_deviceCombo;

--- a/src/ui/dialogs/pc_command_confirm_dialog.cpp
+++ b/src/ui/dialogs/pc_command_confirm_dialog.cpp
@@ -1,0 +1,86 @@
+// 5250ng - A modern IBM TN5250 terminal emulator
+// Copyright (C) 2025-2026 Remi GASCOU (Podalirius)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include "pc_command_confirm_dialog.h"
+
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QPlainTextEdit>
+#include <QPushButton>
+#include <QStyle>
+#include <QVBoxLayout>
+
+namespace ui::dialogs {
+
+PcCommandConfirmDialog::PcCommandConfirmDialog(const QString &hostname,
+                                               const QString &command,
+                                               QWidget *parent)
+    : QDialog(parent) {
+    setWindowTitle("Allow PC command from host?");
+    setModal(true);
+
+    auto *layout = new QVBoxLayout(this);
+
+    auto *header = new QLabel(this);
+    header->setTextFormat(Qt::RichText);
+    header->setWordWrap(true);
+    header->setText(
+        QString("<b>The host <code>%1</code> is asking 5250ng to run a "
+                "command on this PC.</b>")
+            .arg(hostname.isEmpty() ? "(unknown)" : hostname.toHtmlEscaped()));
+    layout->addWidget(header);
+
+    auto *commandView = new QPlainTextEdit(this);
+    commandView->setPlainText(command);
+    commandView->setReadOnly(true);
+    commandView->setMinimumHeight(80);
+    layout->addWidget(commandView);
+
+    auto *warning = new QLabel(this);
+    warning->setTextFormat(Qt::RichText);
+    warning->setWordWrap(true);
+    warning->setText(
+        "<i>Allowing this will run the command above with your user account. "
+        "It can read or modify any file you can, and contact any network you "
+        "can reach. Only allow if you trust this host and recognise the "
+        "command.</i>");
+    layout->addWidget(warning);
+
+    auto *buttons = new QHBoxLayout();
+    auto *deny = new QPushButton("Deny", this);
+    auto *allow = new QPushButton("Allow", this);
+    deny->setDefault(true);
+    deny->setAutoDefault(true);
+    allow->setDefault(false);
+    allow->setAutoDefault(false);
+    connect(deny, &QPushButton::clicked, this, &QDialog::reject);
+    connect(allow, &QPushButton::clicked, this, &QDialog::accept);
+    buttons->addStretch();
+    buttons->addWidget(deny);
+    buttons->addWidget(allow);
+    layout->addLayout(buttons);
+
+    setLayout(layout);
+}
+
+bool PcCommandConfirmDialog::ask(const QString &hostname,
+                                 const QString &command,
+                                 QWidget *parent) {
+    PcCommandConfirmDialog dlg(hostname, command, parent);
+    return dlg.exec() == QDialog::Accepted;
+}
+
+} // namespace ui::dialogs

--- a/src/ui/dialogs/pc_command_confirm_dialog.cpp
+++ b/src/ui/dialogs/pc_command_confirm_dialog.cpp
@@ -83,4 +83,51 @@ bool PcCommandConfirmDialog::ask(const QString &hostname,
     return dlg.exec() == QDialog::Accepted;
 }
 
+void PcCommandConfirmDialog::notifyDenied(const QString &hostname,
+                                          const QString &command,
+                                          QWidget *parent) {
+    // Information-only modal: surfaces a refused STRPCCMD attempt to the user
+    // so a host that tries to run something never goes unnoticed under the
+    // "Deny and alert" policy. No Allow button — the policy already refused.
+    QDialog dlg(parent);
+    dlg.setWindowTitle("PC command blocked");
+    dlg.setModal(true);
+
+    auto *layout = new QVBoxLayout(&dlg);
+
+    auto *header = new QLabel(&dlg);
+    header->setTextFormat(Qt::RichText);
+    header->setWordWrap(true);
+    header->setText(
+        QString("<b>The host <code>%1</code> tried to run a command on this "
+                "PC. It was refused by your session policy (Deny and alert).</b>")
+            .arg(hostname.isEmpty() ? "(unknown)" : hostname.toHtmlEscaped()));
+    layout->addWidget(header);
+
+    auto *commandView = new QPlainTextEdit(&dlg);
+    commandView->setPlainText(command);
+    commandView->setReadOnly(true);
+    commandView->setMinimumHeight(80);
+    layout->addWidget(commandView);
+
+    auto *footer = new QLabel(&dlg);
+    footer->setTextFormat(Qt::RichText);
+    footer->setWordWrap(true);
+    footer->setText(
+        "<i>Nothing was executed. To allow PC commands from this host, change "
+        "the STRPCCMD policy in the session settings.</i>");
+    layout->addWidget(footer);
+
+    auto *buttons = new QHBoxLayout();
+    auto *ok = new QPushButton("OK", &dlg);
+    ok->setDefault(true);
+    QObject::connect(ok, &QPushButton::clicked, &dlg, &QDialog::accept);
+    buttons->addStretch();
+    buttons->addWidget(ok);
+    layout->addLayout(buttons);
+
+    dlg.setLayout(layout);
+    dlg.exec();
+}
+
 } // namespace ui::dialogs

--- a/src/ui/dialogs/pc_command_confirm_dialog.h
+++ b/src/ui/dialogs/pc_command_confirm_dialog.h
@@ -41,6 +41,13 @@ class PcCommandConfirmDialog : public QDialog {
     static bool ask(const QString &hostname,
                     const QString &command,
                     QWidget *parent);
+
+    // Notify the user that a host attempted to run a PC command that was
+    // refused by policy ("Deny and alert" mode). Modeless / dismiss-only —
+    // there is no Allow option, just an OK button.
+    static void notifyDenied(const QString &hostname,
+                             const QString &command,
+                             QWidget *parent);
 };
 
 } // namespace ui::dialogs

--- a/src/ui/dialogs/pc_command_confirm_dialog.h
+++ b/src/ui/dialogs/pc_command_confirm_dialog.h
@@ -1,0 +1,46 @@
+// 5250ng - A modern IBM TN5250 terminal emulator
+// Copyright (C) 2025-2026 Remi GASCOU (Podalirius)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <QDialog>
+#include <QString>
+
+class QLabel;
+class QPushButton;
+class QPlainTextEdit;
+
+namespace ui::dialogs {
+
+// Modal dialog shown for every host-issued STRPCCMD when the feature is
+// enabled. Displays the host name and the full command string with a clear
+// security warning, and offers Allow / Deny. Allow is NOT the default button
+// — the user must explicitly choose it.
+class PcCommandConfirmDialog : public QDialog {
+    Q_OBJECT
+
+  public:
+    PcCommandConfirmDialog(const QString &hostname,
+                           const QString &command,
+                           QWidget *parent = nullptr);
+
+    // Shows the dialog modally and returns true if the user clicked Allow.
+    static bool ask(const QString &hostname,
+                    const QString &command,
+                    QWidget *parent);
+};
+
+} // namespace ui::dialogs

--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -860,11 +860,15 @@ void MainWindow::connectToServer(const session::SessionConfig &config,
     // cannot run anything on the PC unless the user explicitly enabled it in
     // session settings.
     session->pcCommandRunner = new core::PcCommandRunner(session->container);
-    session->pcCommandRunner->setEnabled(session->config.pcCommandEnabled());
+    // The handler dispatches on the STRPCCMD policy; the runner itself stays
+    // disabled here and is enabled per-call in the AllowWithPrompt /
+    // AllowAlways branches. This keeps the policy as the single source of
+    // truth and prevents accidental "enabled but no policy" states.
     session->commandHandler->setPcCommandRunner(session->pcCommandRunner);
     session->commandHandler->setCodePage(session->config.codePage());
     session->commandHandler->setHostname(session->config.hostname());
     session->commandHandler->setDialogParent(session->container);
+    session->commandHandler->setPcCommandPolicy(session->config.pcCommandPolicy());
 
     session->commandHandler->connectDecoder(session->parser);
 

--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -854,6 +854,18 @@ void MainWindow::connectToServer(const session::SessionConfig &config,
                     Q_ARG(QByteArray, payload));
             }
         });
+
+    // STRPCCMD runner: per-session, owned by the command handler's parent so
+    // it dies with the session container. Disabled by default — the host
+    // cannot run anything on the PC unless the user explicitly enabled it in
+    // session settings.
+    session->pcCommandRunner = new core::PcCommandRunner(session->container);
+    session->pcCommandRunner->setEnabled(session->config.pcCommandEnabled());
+    session->commandHandler->setPcCommandRunner(session->pcCommandRunner);
+    session->commandHandler->setCodePage(session->config.codePage());
+    session->commandHandler->setHostname(session->config.hostname());
+    session->commandHandler->setDialogParent(session->container);
+
     session->commandHandler->connectDecoder(session->parser);
 
     // Notify MCP server that the session tab is ready

--- a/src/ui/main_window.h
+++ b/src/ui/main_window.h
@@ -153,6 +153,7 @@ class MainWindow : public ui::widgets::BaseFramelessWindow {
         QWidget *statusBar;
         session::SessionConfig config;
         ui::rendering::TN5250CommandHandler *commandHandler;
+        core::PcCommandRunner *pcCommandRunner = nullptr;
         ui::widgets::QCRTOverlayWidget *crtOverlay;
         // Background image (painted in container's Paint event via event filter)
         QPixmap bgImage;

--- a/src/ui/rendering/tn5250_command_handler.cpp
+++ b/src/ui/rendering/tn5250_command_handler.cpp
@@ -797,17 +797,40 @@ void TN5250CommandHandler::onStrpccmdRequested() {
         return;
     }
 
-    if (m_pcCommandRunner) {
+    // Dispatch on the four STRPCCMD policies. The host always gets ENTER (via
+    // sendEnterAndReturn at function exit) regardless of which branch runs.
+    switch (m_pcCommandPolicy) {
+    case session::PcCommandPolicy::Deny:
+        LOG_DEBUG("CommandHandler: STRPCCMD denied silently by policy");
+        break;
+    case session::PcCommandPolicy::DenyAndAlert:
+        LOG_DEBUG("CommandHandler: STRPCCMD denied by policy; alerting user");
+        ui::dialogs::PcCommandConfirmDialog::notifyDenied(
+            m_hostname, command, m_dialogParent);
+        break;
+    case session::PcCommandPolicy::AllowWithPrompt:
+    case session::PcCommandPolicy::AllowAlways: {
+        if (!m_pcCommandRunner) {
+            LOG_DEBUG("CommandHandler: STRPCCMD policy allows but runner not configured; refusing");
+            break;
+        }
+        m_pcCommandRunner->setEnabled(true);
         m_pcCommandRunner->setHostname(m_hostname);
-        m_pcCommandRunner->setConfirmCallback(
-            [this](const QString &host, const QString &cmd) {
-                return ui::dialogs::PcCommandConfirmDialog::ask(host, cmd, m_dialogParent);
-            });
+        if (m_pcCommandPolicy == session::PcCommandPolicy::AllowWithPrompt) {
+            m_pcCommandRunner->setConfirmCallback(
+                [this](const QString &host, const QString &cmd) {
+                    return ui::dialogs::PcCommandConfirmDialog::ask(host, cmd, m_dialogParent);
+                });
+        } else {
+            // AllowAlways: clear any previously-installed dialog callback so
+            // the runner falls through directly to execute.
+            m_pcCommandRunner->setConfirmCallback(nullptr);
+        }
         m_pcCommandRunner->run(command,
                                noWait ? core::PcCommandRunner::Mode::NoWait
                                       : core::PcCommandRunner::Mode::Wait);
-    } else {
-        LOG_DEBUG("CommandHandler: STRPCCMD has no runner configured; refusing silently");
+        break;
+    }
     }
 
     sendEnterAndReturn();

--- a/src/ui/rendering/tn5250_command_handler.cpp
+++ b/src/ui/rendering/tn5250_command_handler.cpp
@@ -15,8 +15,10 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "tn5250_command_handler.h"
+#include "core/codepage.h"
 #include "logger/logger.h"
 #include "tn5250/protocol_constants.h"
+#include "ui/dialogs/pc_command_confirm_dialog.h"
 #include "utils/hex/hex.h"
 #include <QApplication>
 #include <vector>
@@ -78,6 +80,8 @@ void TN5250CommandHandler::connectDecoder(tn5250::client::DecoderAdapter *parser
             this, &TN5250CommandHandler::onReadScreenRequested);
     connect(parser, &tn5250::client::DecoderAdapter::writeStructuredFieldReceived,
             this, &TN5250CommandHandler::onWriteStructuredFieldReceived);
+    connect(parser, &tn5250::client::DecoderAdapter::strpccmdRequested,
+            this, &TN5250CommandHandler::onStrpccmdRequested);
 }
 
 void TN5250CommandHandler::handleTN5250Command(tn5250::client::TN5250Command cmd,
@@ -718,6 +722,95 @@ void TN5250CommandHandler::onWriteStructuredFieldReceived(const QByteArray &data
     }
     LOG_DEBUG(QString("CommandHandler: Unhandled Write Structured Field (%1 bytes)")
         .arg(data.size()));
+}
+
+void TN5250CommandHandler::onStrpccmdRequested() {
+    // Always send ENTER AID at the end so the host CL program continues
+    // regardless of whether we ran the command. Leaving the keyboard locked is
+    // worse than refusing the command — the user can still recover.
+    auto sendEnterAndReturn = [this]() {
+        if (m_sendToHost) {
+            // 0xF1 = AID_ENTER per SA21-9247-6 page 2-2; same literal used at
+            // the READ_IMMEDIATE site above. Sending ENTER unconditionally on
+            // STRPCCMD ensures the host CL program continues even when we
+            // refuse or fail to run the command.
+            m_sendToHost(buildFieldResponse(0xF1));
+        }
+    };
+
+    if (!m_displayWidget || !m_displayWidget->screenBuffer()) {
+        LOG_DEBUG("CommandHandler: STRPCCMD with no screen buffer; sending ENTER and dropping");
+        sendEnterAndReturn();
+        return;
+    }
+
+    auto *screen = m_displayWidget->screenBuffer();
+    const int rows = screen->rows();
+    const int cols = screen->cols();
+    const int totalCells = rows * cols;
+
+    // tn5250j reads from a 1D screen plane: position 11 is the wait flag
+    // ('a' = run async / no-wait), positions 12..(12+123) hold the command
+    // string padded with EBCDIC blanks. Translate to (row, col) using the
+    // configured screen geometry.
+    constexpr int waitFlagPos = 11;
+    constexpr int commandStartPos = 12;
+    constexpr int kPccmdMaxLength = 123;
+
+    if (totalCells < commandStartPos + kPccmdMaxLength) {
+        LOG_DEBUG("CommandHandler: STRPCCMD screen too small for command region; sending ENTER and dropping");
+        sendEnterAndReturn();
+        return;
+    }
+
+    const core::CodePage cp(m_codePageId);
+    auto charAtLinearPos = [&](int pos) -> QChar {
+        const int row = pos / cols;
+        const int col = pos % cols;
+        const uint8_t byte = screen->cell(row, col).character;
+        return cp.toUnicode(byte);
+    };
+
+    const QChar waitChar = charAtLinearPos(waitFlagPos);
+    const bool noWait = (waitChar == QChar('a'));
+
+    QString command;
+    command.reserve(kPccmdMaxLength);
+    for (int p = commandStartPos; p < commandStartPos + kPccmdMaxLength; ++p) {
+        QChar c = charAtLinearPos(p);
+        // Map control characters and undefined codepage entries to space so
+        // they do not break tokenisation downstream.
+        if (c.isNull() || c.category() == QChar::Other_Control) {
+            c = QChar(' ');
+        }
+        command.append(c);
+    }
+    command = command.trimmed();
+
+    LOG_DEBUG(QString("CommandHandler: STRPCCMD wait=%1 command=%2")
+                  .arg(noWait ? "no" : "yes")
+                  .arg(command));
+
+    if (command.isEmpty()) {
+        LOG_DEBUG("CommandHandler: STRPCCMD with empty command after trim; sending ENTER and dropping");
+        sendEnterAndReturn();
+        return;
+    }
+
+    if (m_pcCommandRunner) {
+        m_pcCommandRunner->setHostname(m_hostname);
+        m_pcCommandRunner->setConfirmCallback(
+            [this](const QString &host, const QString &cmd) {
+                return ui::dialogs::PcCommandConfirmDialog::ask(host, cmd, m_dialogParent);
+            });
+        m_pcCommandRunner->run(command,
+                               noWait ? core::PcCommandRunner::Mode::NoWait
+                                      : core::PcCommandRunner::Mode::Wait);
+    } else {
+        LOG_DEBUG("CommandHandler: STRPCCMD has no runner configured; refusing silently");
+    }
+
+    sendEnterAndReturn();
 }
 
 QByteArray TN5250CommandHandler::buildQueryResponse() {

--- a/src/ui/rendering/tn5250_command_handler.h
+++ b/src/ui/rendering/tn5250_command_handler.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include "core/codepage.h"
+#include "core/pc_command_runner.h"
 #include "network/tn5250_qt/client/decoder_adapter.h"
 #include "tn5250_stream_renderer.h"
 #include "ui/widgets/Q5250ScreenWidget/Q5250ScreenWidget.h"
@@ -23,6 +25,8 @@
 #include <QApplication>
 #include <QByteArray>
 #include <QObject>
+#include <QPointer>
+#include <QString>
 #include <cstdint>
 #include <functional>
 
@@ -74,6 +78,11 @@ class TN5250CommandHandler : public QObject {
     void onMessageLightOff();
     void onReadScreenRequested(bool includeAttributes);
     void onWriteStructuredFieldReceived(const QByteArray &data);
+    // STRPCCMD: host has asked us to run a PC command. Reads the command off
+    // the rendered screen at fixed positions (per tn5250j's reference
+    // implementation), gates it through the configured PcCommandRunner, then
+    // unconditionally returns ENTER AID so the host CL program continues.
+    void onStrpccmdRequested();
 
     void sendNegResponse(uint8_t category, uint8_t modifier, uint8_t uByte1, uint8_t uByte2);
 
@@ -82,6 +91,14 @@ class TN5250CommandHandler : public QObject {
     QByteArray buildQueryResponse();
     QByteArray buildSaveScreenResponse();
 
+    // Inject runtime context for STRPCCMD handling. The runner owns the
+    // policy/confirm/execute flow; the codepage decodes EBCDIC bytes from the
+    // screen buffer; the parent widget is used as the dialog parent.
+    void setPcCommandRunner(core::PcCommandRunner *runner) { m_pcCommandRunner = runner; }
+    void setCodePage(core::CodePage::ID id) { m_codePageId = id; }
+    void setHostname(const QString &hostname) { m_hostname = hostname; }
+    void setDialogParent(QWidget *parent) { m_dialogParent = parent; }
+
   private:
     ui::widgets::Q5250ScreenWidget *m_displayWidget = nullptr;
     TN5250StreamRenderer *m_renderer = nullptr;
@@ -89,6 +106,10 @@ class TN5250CommandHandler : public QObject {
     SendGDSFn m_sendGDS;
     uint8_t m_pendingCC2 = 0;
     uint8_t m_readType = 0; // 0x52=READ_MDT, 0x42=READ_INPUT
+    core::PcCommandRunner *m_pcCommandRunner = nullptr;
+    core::CodePage::ID m_codePageId = core::CodePage::ID::CP037;
+    QString m_hostname;
+    QPointer<QWidget> m_dialogParent;
 };
 
 } // namespace ui::rendering

--- a/src/ui/rendering/tn5250_command_handler.h
+++ b/src/ui/rendering/tn5250_command_handler.h
@@ -19,6 +19,7 @@
 #include "core/codepage.h"
 #include "core/pc_command_runner.h"
 #include "network/tn5250_qt/client/decoder_adapter.h"
+#include "session/config.h"
 #include "tn5250_stream_renderer.h"
 #include "ui/widgets/Q5250ScreenWidget/Q5250ScreenWidget.h"
 #include "ui/widgets/Q5250ScreenWidget/screen_buffer.h"
@@ -98,6 +99,9 @@ class TN5250CommandHandler : public QObject {
     void setCodePage(core::CodePage::ID id) { m_codePageId = id; }
     void setHostname(const QString &hostname) { m_hostname = hostname; }
     void setDialogParent(QWidget *parent) { m_dialogParent = parent; }
+    // STRPCCMD policy — controls how onStrpccmdRequested reacts to a host
+    // attempt: Deny silently, Deny + alert, Allow with prompt, Allow always.
+    void setPcCommandPolicy(session::PcCommandPolicy policy) { m_pcCommandPolicy = policy; }
 
   private:
     ui::widgets::Q5250ScreenWidget *m_displayWidget = nullptr;
@@ -110,6 +114,7 @@ class TN5250CommandHandler : public QObject {
     core::CodePage::ID m_codePageId = core::CodePage::ID::CP037;
     QString m_hostname;
     QPointer<QWidget> m_dialogParent;
+    session::PcCommandPolicy m_pcCommandPolicy = session::PcCommandPolicy::DenyAndAlert;
 };
 
 } // namespace ui::rendering

--- a/tests/unit/test_pc_command_runner.cpp
+++ b/tests/unit/test_pc_command_runner.cpp
@@ -1,0 +1,123 @@
+// 5250ng - A modern IBM TN5250 terminal emulator
+// Copyright (C) 2025-2026 Remi GASCOU (Podalirius)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include "core/pc_command_runner.h"
+
+#include <QFile>
+#include <QStandardPaths>
+#include <QString>
+#include <QTemporaryDir>
+#include <QtTest/QtTest>
+
+using core::PcCommandRunner;
+
+class TestPcCommandRunner : public QObject {
+    Q_OBJECT
+
+  private slots:
+    void testDisabledByDefault();
+    void testDisabledRefusesEvenIfConfirmAccepts();
+    void testDeniedByUserDoesNotRun();
+    void testEnabledAndAllowedRunsCommand();
+    void testNoWaitLaunchesDetachedAndReturnsImmediately();
+    void testEmptyCommandIsRejected();
+};
+
+void TestPcCommandRunner::testDisabledByDefault() {
+    PcCommandRunner runner;
+    QVERIFY(!runner.isEnabled());
+
+    bool confirmCalled = false;
+    runner.setConfirmCallback([&](const QString &, const QString &) {
+        confirmCalled = true;
+        return true;
+    });
+
+    auto result = runner.run("/bin/echo hello", PcCommandRunner::Mode::Wait);
+    QCOMPARE(result.outcome, PcCommandRunner::Outcome::DisabledByPolicy);
+    QVERIFY(!confirmCalled);
+}
+
+void TestPcCommandRunner::testDisabledRefusesEvenIfConfirmAccepts() {
+    // Defence in depth: even if some upstream code wires a permissive confirm
+    // callback, the policy gate must still refuse when pcCommandEnabled=false.
+    PcCommandRunner runner;
+    runner.setConfirmCallback([](const QString &, const QString &) { return true; });
+
+    auto result = runner.run("/bin/echo hello", PcCommandRunner::Mode::NoWait);
+    QCOMPARE(result.outcome, PcCommandRunner::Outcome::DisabledByPolicy);
+}
+
+void TestPcCommandRunner::testDeniedByUserDoesNotRun() {
+    PcCommandRunner runner;
+    runner.setEnabled(true);
+    bool confirmCalled = false;
+    runner.setConfirmCallback([&](const QString &, const QString &) {
+        confirmCalled = true;
+        return false;
+    });
+
+    auto result = runner.run("/bin/echo hello", PcCommandRunner::Mode::Wait);
+    QCOMPARE(result.outcome, PcCommandRunner::Outcome::DeniedByUser);
+    QVERIFY(confirmCalled);
+}
+
+void TestPcCommandRunner::testEnabledAndAllowedRunsCommand() {
+    QTemporaryDir tmp;
+    QVERIFY(tmp.isValid());
+    const QString marker = tmp.filePath("ran.txt");
+
+    PcCommandRunner runner;
+    runner.setEnabled(true);
+    runner.setConfirmCallback([](const QString &, const QString &) { return true; });
+
+#ifdef Q_OS_WIN
+    const QString cmd = QString("cmd /c echo > \"%1\"").arg(marker);
+#else
+    const QString cmd = QString("/usr/bin/touch \"%1\"").arg(marker);
+#endif
+
+    auto result = runner.run(cmd, PcCommandRunner::Mode::Wait);
+    QCOMPARE(result.outcome, PcCommandRunner::Outcome::Completed);
+    QVERIFY2(QFile::exists(marker), "command should have created the marker file");
+}
+
+void TestPcCommandRunner::testNoWaitLaunchesDetachedAndReturnsImmediately() {
+    PcCommandRunner runner;
+    runner.setEnabled(true);
+    runner.setConfirmCallback([](const QString &, const QString &) { return true; });
+
+#ifdef Q_OS_WIN
+    const QString cmd = "cmd /c exit 0";
+#else
+    const QString cmd = "/bin/true";
+#endif
+
+    auto result = runner.run(cmd, PcCommandRunner::Mode::NoWait);
+    QCOMPARE(result.outcome, PcCommandRunner::Outcome::Launched);
+}
+
+void TestPcCommandRunner::testEmptyCommandIsRejected() {
+    PcCommandRunner runner;
+    runner.setEnabled(true);
+    runner.setConfirmCallback([](const QString &, const QString &) { return true; });
+
+    auto result = runner.run("   ", PcCommandRunner::Mode::Wait);
+    QCOMPARE(result.outcome, PcCommandRunner::Outcome::StartFailed);
+}
+
+QTEST_MAIN(TestPcCommandRunner)
+#include "test_pc_command_runner.moc"

--- a/tests/unit/test_session_config.cpp
+++ b/tests/unit/test_session_config.cpp
@@ -34,6 +34,8 @@ class TestSessionConfig : public QObject {
     void testDeserializationRejectsOutOfRange();
     void testAllowInvalidCertificatesDefaultsOff();
     void testAllowInvalidCertificatesRoundTrip();
+    void testPcCommandSettingsDefaults();
+    void testPcCommandSettingsRoundTrip();
 
   private:
     SessionConfig *m_config;
@@ -277,6 +279,69 @@ void TestSessionConfig::testAllowInvalidCertificatesRoundTrip() {
     second.setAllowInvalidCertificates(true);
     QVERIFY(second.fromJson(reset));
     QVERIFY(!second.allowInvalidCertificates());
+}
+
+void TestSessionConfig::testPcCommandSettingsDefaults() {
+    SessionConfig fresh;
+    QVERIFY(!fresh.pcCommandEnabled());
+    QVERIFY(fresh.pcCommandConfirmEachTime());
+
+    // Round-tripping a config that does not opt in must NOT add the keys to
+    // the JSON output, so existing config files do not gain a surprising new
+    // key on first save.
+    QJsonObject json;
+    json["name"] = "Default";
+    json["hostname"] = "example.com";
+    json["port"] = 23;
+    json["useTLS"] = false;
+    json["deviceType"] = "IBM-3179-2";
+    json["deviceName"] = "T";
+    json["screenRows"] = 24;
+    json["screenCols"] = 80;
+    SessionConfig loaded;
+    QVERIFY(loaded.fromJson(json));
+    QVERIFY(!loaded.pcCommandEnabled());
+    QVERIFY(loaded.pcCommandConfirmEachTime());
+
+    QJsonObject out = loaded.toJson();
+    QVERIFY(!out.contains("pcCommandEnabled"));
+    QVERIFY(!out.contains("pcCommandConfirmEachTime"));
+}
+
+void TestSessionConfig::testPcCommandSettingsRoundTrip() {
+    m_config->setName("With STRPCCMD");
+    m_config->setHostname("trusted.example.com");
+    m_config->setPort(23);
+    m_config->setPcCommandEnabled(true);
+    QCOMPARE(m_config->pcCommandEnabled(), true);
+
+    QJsonObject json = m_config->toJson();
+    QCOMPARE(json.value("pcCommandEnabled").toBool(), true);
+
+    SessionConfig loaded;
+    QVERIFY(loaded.fromJson(json));
+    QCOMPARE(loaded.pcCommandEnabled(), true);
+    // The confirm-each-time default must persist round-tripping even when the
+    // key is absent on input (a config that opted into STRPCCMD without
+    // explicitly disabling per-command confirmation must keep confirmation on).
+    QCOMPARE(loaded.pcCommandConfirmEachTime(), true);
+
+    // A subsequent fromJson with no pcCommandEnabled key must reset back to
+    // the disabled default — guards against a stale enabled state leaking
+    // across config loads.
+    QJsonObject reset;
+    reset["name"] = "Reset";
+    reset["hostname"] = "a.example.com";
+    reset["port"] = 23;
+    reset["useTLS"] = false;
+    reset["deviceType"] = "IBM-3179-2";
+    reset["deviceName"] = "T";
+    reset["screenRows"] = 24;
+    reset["screenCols"] = 80;
+    SessionConfig second;
+    second.setPcCommandEnabled(true);
+    QVERIFY(second.fromJson(reset));
+    QVERIFY(!second.pcCommandEnabled());
 }
 
 QTEST_MAIN(TestSessionConfig)

--- a/tests/unit/test_session_config.cpp
+++ b/tests/unit/test_session_config.cpp
@@ -34,8 +34,9 @@ class TestSessionConfig : public QObject {
     void testDeserializationRejectsOutOfRange();
     void testAllowInvalidCertificatesDefaultsOff();
     void testAllowInvalidCertificatesRoundTrip();
-    void testPcCommandSettingsDefaults();
-    void testPcCommandSettingsRoundTrip();
+    void testPcCommandPolicyDefaults();
+    void testPcCommandPolicyRoundTrip();
+    void testPcCommandPolicyLegacyConfigCompat();
 
   private:
     SessionConfig *m_config;
@@ -281,14 +282,17 @@ void TestSessionConfig::testAllowInvalidCertificatesRoundTrip() {
     QVERIFY(!second.allowInvalidCertificates());
 }
 
-void TestSessionConfig::testPcCommandSettingsDefaults() {
+void TestSessionConfig::testPcCommandPolicyDefaults() {
+    // The default for a fresh SessionConfig must be DenyAndAlert: never run a
+    // host-issued PC command without explicit opt-in, but always make refused
+    // attempts visible so the user knows a host tried.
     SessionConfig fresh;
-    QVERIFY(!fresh.pcCommandEnabled());
-    QVERIFY(fresh.pcCommandConfirmEachTime());
+    QCOMPARE(fresh.pcCommandPolicy(), PcCommandPolicy::DenyAndAlert);
 
-    // Round-tripping a config that does not opt in must NOT add the keys to
-    // the JSON output, so existing config files do not gain a surprising new
-    // key on first save.
+    // A JSON object that does not carry the policy key must also resolve to
+    // the default. This covers existing configs written by an earlier build
+    // (where the field did not exist) and any third-party config that omits
+    // the field entirely.
     QJsonObject json;
     json["name"] = "Default";
     json["hostname"] = "example.com";
@@ -300,35 +304,47 @@ void TestSessionConfig::testPcCommandSettingsDefaults() {
     json["screenCols"] = 80;
     SessionConfig loaded;
     QVERIFY(loaded.fromJson(json));
-    QVERIFY(!loaded.pcCommandEnabled());
-    QVERIFY(loaded.pcCommandConfirmEachTime());
+    QCOMPARE(loaded.pcCommandPolicy(), PcCommandPolicy::DenyAndAlert);
 
+    // Round-tripping a config at the default must NOT write the policy key,
+    // so existing config files do not gain a surprising new key on first save.
     QJsonObject out = loaded.toJson();
+    QVERIFY(!out.contains("pcCommandPolicy"));
     QVERIFY(!out.contains("pcCommandEnabled"));
     QVERIFY(!out.contains("pcCommandConfirmEachTime"));
 }
 
-void TestSessionConfig::testPcCommandSettingsRoundTrip() {
-    m_config->setName("With STRPCCMD");
-    m_config->setHostname("trusted.example.com");
-    m_config->setPort(23);
-    m_config->setPcCommandEnabled(true);
-    QCOMPARE(m_config->pcCommandEnabled(), true);
+void TestSessionConfig::testPcCommandPolicyRoundTrip() {
+    // Each non-default policy must round-trip through JSON with a stable
+    // string tag, and the loader must parse that tag back to the same enum.
+    struct Case {
+        PcCommandPolicy policy;
+        const char *expectedTag;
+    };
+    const Case cases[] = {
+        {PcCommandPolicy::Deny,            "deny"},
+        {PcCommandPolicy::AllowWithPrompt, "allowPrompt"},
+        {PcCommandPolicy::AllowAlways,     "allowAlways"},
+    };
 
-    QJsonObject json = m_config->toJson();
-    QCOMPARE(json.value("pcCommandEnabled").toBool(), true);
+    for (const auto &c : cases) {
+        SessionConfig src;
+        src.setName("Round-trip");
+        src.setHostname("h.example.com");
+        src.setPort(23);
+        src.setPcCommandPolicy(c.policy);
 
-    SessionConfig loaded;
-    QVERIFY(loaded.fromJson(json));
-    QCOMPARE(loaded.pcCommandEnabled(), true);
-    // The confirm-each-time default must persist round-tripping even when the
-    // key is absent on input (a config that opted into STRPCCMD without
-    // explicitly disabling per-command confirmation must keep confirmation on).
-    QCOMPARE(loaded.pcCommandConfirmEachTime(), true);
+        QJsonObject json = src.toJson();
+        QVERIFY2(json.contains("pcCommandPolicy"), c.expectedTag);
+        QCOMPARE(json.value("pcCommandPolicy").toString(), QString::fromLatin1(c.expectedTag));
 
-    // A subsequent fromJson with no pcCommandEnabled key must reset back to
-    // the disabled default — guards against a stale enabled state leaking
-    // across config loads.
+        SessionConfig loaded;
+        QVERIFY(loaded.fromJson(json));
+        QCOMPARE(loaded.pcCommandPolicy(), c.policy);
+    }
+
+    // A subsequent fromJson with NO policy key must reset back to the default
+    // — guards against a stale policy leaking across config loads.
     QJsonObject reset;
     reset["name"] = "Reset";
     reset["hostname"] = "a.example.com";
@@ -338,11 +354,78 @@ void TestSessionConfig::testPcCommandSettingsRoundTrip() {
     reset["deviceName"] = "T";
     reset["screenRows"] = 24;
     reset["screenCols"] = 80;
-    SessionConfig second;
-    second.setPcCommandEnabled(true);
-    QVERIFY(second.fromJson(reset));
-    QVERIFY(!second.pcCommandEnabled());
+    SessionConfig stale;
+    stale.setPcCommandPolicy(PcCommandPolicy::AllowAlways);
+    QVERIFY(stale.fromJson(reset));
+    QCOMPARE(stale.pcCommandPolicy(), PcCommandPolicy::DenyAndAlert);
+
+    // Unknown policy strings must fall back to the safe default rather than
+    // silently mapping to Deny — the alert path makes the bad value visible.
+    QJsonObject unknown = reset;
+    unknown["pcCommandPolicy"] = "totallyMadeUp";
+    SessionConfig recovered;
+    recovered.setPcCommandPolicy(PcCommandPolicy::AllowAlways);
+    QVERIFY(recovered.fromJson(unknown));
+    QCOMPARE(recovered.pcCommandPolicy(), PcCommandPolicy::DenyAndAlert);
 }
+
+void TestSessionConfig::testPcCommandPolicyLegacyConfigCompat() {
+    // Configs written by the earlier draft of this PR carried a pair of
+    // booleans (pcCommandEnabled + pcCommandConfirmEachTime). The loader must
+    // still understand them so users who saved a config against that build
+    // do not silently revert to the default after upgrade.
+    QJsonObject base;
+    base["name"] = "Legacy";
+    base["hostname"] = "legacy.example.com";
+    base["port"] = 23;
+    base["useTLS"] = false;
+    base["deviceType"] = "IBM-3179-2";
+    base["deviceName"] = "T";
+    base["screenRows"] = 24;
+    base["screenCols"] = 80;
+
+    {
+        // pcCommandEnabled=true with no confirm flag -> AllowWithPrompt.
+        QJsonObject j = base;
+        j["pcCommandEnabled"] = true;
+        SessionConfig cfg;
+        QVERIFY(cfg.fromJson(j));
+        QCOMPARE(cfg.pcCommandPolicy(), PcCommandPolicy::AllowWithPrompt);
+    }
+    {
+        // pcCommandEnabled=true, pcCommandConfirmEachTime=false -> AllowAlways.
+        QJsonObject j = base;
+        j["pcCommandEnabled"] = true;
+        j["pcCommandConfirmEachTime"] = false;
+        SessionConfig cfg;
+        QVERIFY(cfg.fromJson(j));
+        QCOMPARE(cfg.pcCommandPolicy(), PcCommandPolicy::AllowAlways);
+    }
+    {
+        // pcCommandEnabled=false (or absent) -> DenyAndAlert default. The old
+        // build's "Deny silently" lands on the new "Deny and alert" default
+        // intentionally — making refused attempts visible is the new floor.
+        QJsonObject j = base;
+        j["pcCommandEnabled"] = false;
+        SessionConfig cfg;
+        QVERIFY(cfg.fromJson(j));
+        QCOMPARE(cfg.pcCommandPolicy(), PcCommandPolicy::DenyAndAlert);
+    }
+    {
+        // The new policy key wins over the legacy bools when both are present.
+        QJsonObject j = base;
+        j["pcCommandEnabled"] = true;
+        j["pcCommandConfirmEachTime"] = false;
+        j["pcCommandPolicy"] = "deny";
+        SessionConfig cfg;
+        QVERIFY(cfg.fromJson(j));
+        QCOMPARE(cfg.pcCommandPolicy(), PcCommandPolicy::Deny);
+    }
+}
+
+// Make the enum visible to QCOMPARE's diagnostics (the registration is only
+// for nicer failure messages — equality already works on plain enums).
+Q_DECLARE_METATYPE(PcCommandPolicy)
 
 QTEST_MAIN(TestSessionConfig)
 #include "test_session_config.moc"


### PR DESCRIPTION
### Linked Issue
Closes #108

### Motivation
IBM i hosts use `STRPCCMD` (Start PC Command) to launch helpers on the user's connected PC. Today 5250ng silently drops the marker bytes, leaves the keyboard locked, and hangs the host CL program waiting for the ENTER AID that never arrives. This PR makes the host's request actionable: surface it to the user, optionally run the command, and always reply so the CL program continues. The feature is opt-in and behind a per-command confirmation prompt — `STRPCCMD` is the mechanism behind CVE-2005-0868, and we intentionally do not match tn5250j's always-on default.

### What Changed
- **Submodule pin**: bumped `src/network/tn5250` to the tip of [5250ng/protocol-tn5250#15](https://github.com/5250ng/protocol-tn5250/pull/15), which exposes a new `onStrpccmdRequested` decoder callback that fires when the host emits the trigger byte plus the 9-byte PCO signature inside a Write-To-Display.
- **Decoder adapter** (`src/network/tn5250_qt/client/decoder_adapter.{h,cpp}`): wires the new C++ callback to a Qt signal `strpccmdRequested()`.
- **Session config** (`src/session/config.{h,cpp}`): two new fields — `pcCommandEnabled` (default `false`) and `pcCommandConfirmEachTime` (default `true`, kept for forward extensibility). Both round-trip through `toJson` / `fromJson`; the keys are only persisted when they diverge from the safe defaults so existing config files do not gain surprising new keys on first save.
- **Connect dialog** (`src/ui/dialogs/connect_dialog.{h,cpp}`): new "Allow host to run PC commands (STRPCCMD, insecure)" checkbox sitting next to the existing TLS-cert-acceptance checkbox, with a tooltip linking the security implications.
- **`PcCommandRunner`** (`src/core/pc_command_runner.{h,cpp}`, new): self-contained QObject that owns the policy gate, the confirm callback, and the `QProcess` invocation. Two modes — `Wait` blocks up to a 60s timeout via `QProcess::start` + `waitForFinished`; `NoWait` uses `QProcess::startDetached`. Returns a structured `Outcome` (`DisabledByPolicy`, `DeniedByUser`, `StartFailed`, `TimedOut`, `Completed`, `Launched`) with the exit code where applicable. Splits the command string with shell-style quoting but does **not** invoke a real shell — the program and args go to QProcess directly to avoid metacharacter re-interpretation on a host-supplied string.
- **`PcCommandConfirmDialog`** (`src/ui/dialogs/pc_command_confirm_dialog.{h,cpp}`, new): modal Allow/Deny dialog showing the host name, the full command string in a read-only edit, and a security warning. Deny is the default button.
- **Command handler** (`src/ui/rendering/tn5250_command_handler.{h,cpp}`): connects the new decoder signal to a slot that reads the wait flag (screen pos 11) and the command string (positions 12..134, EBCDIC, codepage-decoded, trimmed) directly off the rendered screen — same approach as tn5250j's reference implementation. Hands the command to the runner, then unconditionally sends `ENTER` AID via the existing `buildFieldResponse(0xF1)` + `m_sendToHost` path so the CL program continues regardless of outcome.
- **Main window** (`src/ui/main_window.{h,cpp}`): owns one `PcCommandRunner` per session, parented to the session container, and threads `pcCommandEnabled`, the codepage, the hostname, and the dialog parent into the command handler at session creation.
- **CMakeLists.txt**: registers the new core sources, the new dialog, and the new test target.
- **Tests**: 6 new tests for `PcCommandRunner` (disabled-by-default, disabled-overrides-confirm, denied-by-user, allowed-runs, no-wait-launches-detached, empty-command-rejected) and 2 new tests for `SessionConfig` (defaults + selective persistence; round-trip + reset behaviour).

### Design Notes
- **STRPCCMD detection lives in the protocol layer, command extraction in the UI layer.** The marker is consumed by the decoder so the bytes never reach the screen as garbage; the actual command string is then read off the rendered screen because the host writes it via normal SBA + text orders earlier in the same WTD. Splitting the work this way keeps protocol concerns out of the renderer and avoids second-guessing where the host put the command.
- **Always send ENTER, even on refusal/timeout.** Leaving the keyboard locked is worse for the user than refusing the command — they cannot recover the session without disconnecting. The host receives ENTER on every code path of `onStrpccmdRequested`.
- **No shell.** The runner tokenises the command itself and passes program + arguments to `QProcess::start(...)`. The host string never gets interpreted by `/bin/sh` or `cmd /c`, eliminating the obvious shell-metacharacter footgun.
- **Wait vs NoWait** mirrors the host semantics: tn5250j and IBM HOD interpret screen pos 11 as the wait flag (`'a'` = no-wait, anything else = wait). We match that exactly.

### Acceptance Criteria Check
- [x] Disabled by default — no dialog, no process, ENTER returned. `PcCommandRunner::testDisabledByDefault` + the unconditional `sendEnterAndReturn` path in `tn5250_command_handler.cpp` (`onStrpccmdRequested`).
- [x] Enabled + per-command modal — `PcCommandConfirmDialog::ask` is invoked from `m_confirm` and Allow/Deny is honoured. `PcCommandRunner::testDeniedByUserDoesNotRun` + `testEnabledAndAllowedRunsCommand`.
- [x] Wait flag `'a'` → detached + immediate ENTER; else → sync run + ENTER on completion. `PcCommandRunner::testNoWaitLaunchesDetachedAndReturnsImmediately` (Launched outcome) + `testEnabledAndAllowedRunsCommand` (Completed with exit code).
- [x] `PcCommandRunner` refuses with `DisabledByPolicy` even when an upstream confirm callback is permissive. `testDisabledRefusesEvenIfConfirmAccepts`.
- [x] `test_pc_command_runner.cpp` exercises both gates and runs a harmless command per platform — verified locally on Linux (touch + /bin/true), guarded with `#ifdef Q_OS_WIN` for cmd.exe equivalents.
- [x] `test_session_config.cpp` covers defaults, selective persistence, round-trip, and reset behaviour. `testPcCommandSettingsDefaults` + `testPcCommandSettingsRoundTrip`.
- [x] `ctest` passes locally — 16/16 tests, including the 8 new ones.

### How Verified
- **Tests:** `cmake --build build && ctest --test-dir build --output-on-failure` — 16/16 pass on Linux. Highlights:
  - `test_pc_command_runner` — 6 cases covering disabled/denied/allowed/no-wait/empty.
  - `test_session_config` — `testPcCommandSettingsDefaults` and `testPcCommandSettingsRoundTrip` exercise the new fields end-to-end.
  - `test_decoder` continues to pass after the submodule pin bump (12 cases including the 3 new STRPCCMD-detection ones from the submodule PR).
- **Manual:** verified the QProcess wait path actually creates a marker file (`/usr/bin/touch` in a `QTemporaryDir`) and the no-wait path returns the `Launched` outcome without blocking.

### Test Coverage
**Added:**
- `tests/unit/test_pc_command_runner.cpp::testDisabledByDefault`
- `tests/unit/test_pc_command_runner.cpp::testDisabledRefusesEvenIfConfirmAccepts`
- `tests/unit/test_pc_command_runner.cpp::testDeniedByUserDoesNotRun`
- `tests/unit/test_pc_command_runner.cpp::testEnabledAndAllowedRunsCommand`
- `tests/unit/test_pc_command_runner.cpp::testNoWaitLaunchesDetachedAndReturnsImmediately`
- `tests/unit/test_pc_command_runner.cpp::testEmptyCommandIsRejected`
- `tests/unit/test_session_config.cpp::testPcCommandSettingsDefaults`
- `tests/unit/test_session_config.cpp::testPcCommandSettingsRoundTrip`

The end-to-end command-handler path (decoder → adapter signal → command handler slot → runner → ENTER) is currently exercised manually rather than in unit tests because it requires a constructed `Q5250ScreenWidget` + `ScreenBuffer` plus a `DecoderAdapter` plumbed together; that integration coverage will be added once the test fixture infrastructure for command handler is in place (tracked separately).

### Scope of Change
- **Files changed:** `CMakeLists.txt`, `src/network/tn5250` (submodule pin), `src/network/tn5250_qt/client/decoder_adapter.{h,cpp}`, `src/session/config.{h,cpp}`, `src/ui/dialogs/connect_dialog.{h,cpp}`, `src/ui/dialogs/pc_command_confirm_dialog.{h,cpp}` (new), `src/core/pc_command_runner.{h,cpp}` (new), `src/ui/rendering/tn5250_command_handler.{h,cpp}`, `src/ui/main_window.{h,cpp}`, `tests/unit/test_pc_command_runner.cpp` (new), `tests/unit/test_session_config.cpp`.
- **Submodule pointer updated:** yes — `src/network/tn5250` (protocol-tn5250) bumped to the tip of [5250ng/protocol-tn5250#15](https://github.com/5250ng/protocol-tn5250/pull/15). Re-pin to the post-merge commit before this PR merges.
- **Public API changes:** none external. New internal classes (`PcCommandRunner`, `PcCommandConfirmDialog`), new `SessionConfig` getters/setters, and one new `DecoderAdapter` Qt signal. Existing symbols unchanged.
- **Behavioral changes outside the stated enhancement:** none. Sessions where `pcCommandEnabled=false` (the default for every existing config) behave identically to before — the new code paths run only when the host actually emits the STRPCCMD marker and the user opted in.

### Risk and Rollout
Medium. The feature is off by default and behind a per-command modal when on, so the worst-case for a user who upgrades is unchanged behaviour. The main risks are (a) the screen-position read (positions 11..134) assumes a 1D linear interpretation matching tn5250j — if a host emits the marker but writes the command at unusual coordinates, the handler will read the wrong bytes; on the safe path this just means we either run the wrong command (caught by the confirm prompt) or send ENTER on an empty trimmed string (still safe — host unblocks). (b) The submodule pin must land on the merge commit before this PR merges; flagged in the Scope of Change above.

### Notes
- Companion submodule PR: [5250ng/protocol-tn5250#15](https://github.com/5250ng/protocol-tn5250/pull/15) — must merge first.
- `RUNRMTCMD` was considered and intentionally **not** implemented: it is an IBM i CL command that submits work to *another* IBM system over APPC/SNA from the host side. Nothing on the 5250 client side runs it. Documented in the issue body for future readers.
- 1023-char V7R2+ command length cap is deferred — kept tn5250j's 123-char limit until we have a V7R2+ host to test against.
- A "trusted hosts" list to skip the per-command prompt is intentionally out of scope; defer until users actually ask for it.