### PR TITLE
[bugfix] Fix testNoWaitLaunchesDetachedAndReturnsImmediately on macOS/Qt 6.11 (#110)

### DIFF
--- a/tests/unit/test_pc_command_runner.cpp
+++ b/tests/unit/test_pc_command_runner.cpp
@@ -100,10 +100,15 @@ void TestPcCommandRunner::testNoWaitLaunchesDetachedAndReturnsImmediately() {
     runner.setEnabled(true);
     runner.setConfirmCallback([](const QString &, const QString &) { return true; });
 
+    // Use a command that lives long enough for QProcess::startDetached to
+    // confirm the launch on every supported platform. macOS Qt 6.11 uses
+    // posix_spawn followed by a non-blocking waitpid; sub-millisecond
+    // commands like /bin/true can exit before that check and produce a
+    // false StartFailed result. A short sleep is reliable everywhere.
 #ifdef Q_OS_WIN
-    const QString cmd = "cmd /c exit 0";
+    const QString cmd = "ping -n 2 127.0.0.1";
 #else
-    const QString cmd = "/bin/true";
+    const QString cmd = "/bin/sleep 1";
 #endif
 
     auto result = runner.run(cmd, PcCommandRunner::Mode::NoWait);


### PR DESCRIPTION
## Linked Issue
Closes #110.

## Root Cause
`testNoWaitLaunchesDetachedAndReturnsImmediately` runs `/bin/true` in `Mode::NoWait`, which calls `QProcess::startDetached`. On macOS Qt 6.11, `startDetached` is implemented via `posix_spawn` followed by a non-blocking `waitpid` that confirms the child is still alive. `/bin/true` exits in microseconds, so the `waitpid` often runs after the child has already terminated and Qt reports the launch as failed — `Outcome::StartFailed` (2) — even though the process did execute. Linux Qt's fork+exec path does not have the same race, which is why the test passes locally on Linux Qt 6.4.2 and only fails on the macOS Qt 6.11.0 GitHub Actions runner.

The defect is in the test fixture's choice of command, not in `PcCommandRunner` (which faithfully reports what `QProcess::startDetached` returns) and not in the reachable production behaviour (real STRPCCMD payloads target user commands, not sub-millisecond binaries like `/bin/true`).

## Fix Description
Swap the test command for one that lives long enough to survive Qt's launch-confirmation window on every supported platform:

- POSIX: `/bin/sleep 1`
- Windows: `ping -n 2 127.0.0.1` (the existing `cmd /c exit 0` is similarly short-lived and would hit the same kind of race if Qt's Windows path ever evolved to do an equivalent post-spawn check)

The test still asserts exactly what its name says — NoWait returns `Outcome::Launched` without blocking. The child sleeps in the background after the runner returns and is reaped by init; total test runtime stays in the millisecond range.

A short comment captures the rationale so the next person reaching for `/bin/true` understands why we picked a slower fixture.

## How Verified
- **Tests:** `./build/test_pc_command_runner` reports 8/8 PASS, including `testNoWaitLaunchesDetachedAndReturnsImmediately` with `launched detached pid=…: /bin/sleep 1` in the log.
- **Full suite:** `ctest` reports 16/16 tests passing locally on Linux/Qt 6.4.2.
- **Static:** Confirmed `PcCommandRunner::run` returns `Outcome::Launched` only when `QProcess::startDetached` returns `true` — the fix removes the race that triggered the false-negative path on macOS Qt 6.11.

## Test Coverage
**Existing:** `testNoWaitLaunchesDetachedAndReturnsImmediately`, now stable across macOS Qt 6.11 in addition to Linux Qt 6.4.

## Scope of Change
- **Files changed:** `tests/unit/test_pc_command_runner.cpp`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

## Notes
The underlying Qt behaviour (false-negative `startDetached` for fast-exiting processes on macOS) is a Qt limitation, not something `PcCommandRunner` can paper over without changing its semantics. If a real STRPCCMD use case ever surfaces a sub-millisecond command, we would treat that as a follow-up bug against the runner itself rather than against this test.