### PR TITLE
[bugfix] Read STRPCCMD command from the wire instead of the screen plane (#112)

### DIFF
--- a/src/network/tn5250_qt/client/decoder_adapter.cpp
+++ b/src/network/tn5250_qt/client/decoder_adapter.cpp
@@ -64,7 +64,9 @@ DecoderAdapter::DecoderAdapter(QObject *parent) : QObject(parent) {
     cb.onWriteStructuredField = [this](const std::vector<uint8_t> &data) {
         emit writeStructuredFieldReceived(toQt(data));
     };
-    cb.onStrpccmdRequested = [this]() { emit strpccmdRequested(); };
+    cb.onStrpccmdRequested = [this](bool noWait, const std::vector<uint8_t> &cmd) {
+        emit strpccmdRequested(noWait, toQt(cmd));
+    };
     cb.onParseError = [this](const std::string &err) {
         emit parseError(QString::fromStdString(err));
     };

--- a/src/network/tn5250_qt/client/decoder_adapter.h
+++ b/src/network/tn5250_qt/client/decoder_adapter.h
@@ -56,11 +56,12 @@ class DecoderAdapter : public QObject {
     void messageLightOff();
     void readScreenRequested(bool includeAttributes);
     void writeStructuredFieldReceived(const QByteArray &data);
-    // Fires when the host's WTD stream contains the STRPCCMD marker. The
-    // 10-byte marker has already been consumed by the protocol decoder; the
-    // command string itself lives at fixed screen coordinates and must be read
-    // off the rendered screen by the consumer (TN5250CommandHandler).
-    void strpccmdRequested();
+    // Fires when the host's WTD stream contains the STRPCCMD marker. Carries
+    // the wait flag (true → no-wait, EBCDIC 'a' / 0x81) and the raw EBCDIC
+    // command bytes consumed by the protocol decoder from immediately after
+    // the marker. Codepage conversion and trimming are the consumer's
+    // responsibility (TN5250CommandHandler).
+    void strpccmdRequested(bool noWait, const QByteArray &commandBytes);
     void parseError(const QString &error);
 
   private:

--- a/src/ui/rendering/tn5250_command_handler.cpp
+++ b/src/ui/rendering/tn5250_command_handler.cpp
@@ -724,7 +724,8 @@ void TN5250CommandHandler::onWriteStructuredFieldReceived(const QByteArray &data
         .arg(data.size()));
 }
 
-void TN5250CommandHandler::onStrpccmdRequested() {
+void TN5250CommandHandler::onStrpccmdRequested(bool noWait,
+                                               const QByteArray &commandBytes) {
     // Always send ENTER AID at the end so the host CL program continues
     // regardless of whether we ran the command. Leaving the keyboard locked is
     // worse than refusing the command — the user can still recover.
@@ -738,48 +739,15 @@ void TN5250CommandHandler::onStrpccmdRequested() {
         }
     };
 
-    if (!m_displayWidget || !m_displayWidget->screenBuffer()) {
-        LOG_DEBUG("CommandHandler: STRPCCMD with no screen buffer; sending ENTER and dropping");
-        sendEnterAndReturn();
-        return;
-    }
-
-    auto *screen = m_displayWidget->screenBuffer();
-    const int rows = screen->rows();
-    const int cols = screen->cols();
-    const int totalCells = rows * cols;
-
-    // tn5250j reads from a 1D screen plane: position 11 is the wait flag
-    // ('a' = run async / no-wait), positions 12..(12+123) hold the command
-    // string padded with EBCDIC blanks. Translate to (row, col) using the
-    // configured screen geometry.
-    constexpr int waitFlagPos = 11;
-    constexpr int commandStartPos = 12;
-    constexpr int kPccmdMaxLength = 123;
-
-    if (totalCells < commandStartPos + kPccmdMaxLength) {
-        LOG_DEBUG("CommandHandler: STRPCCMD screen too small for command region; sending ENTER and dropping");
-        sendEnterAndReturn();
-        return;
-    }
-
+    // Apply the session's configured codepage to the raw EBCDIC bytes the
+    // decoder pulled off the wire. Map control characters and undefined
+    // codepage entries to a space so they do not break tokenisation
+    // downstream.
     const core::CodePage cp(m_codePageId);
-    auto charAtLinearPos = [&](int pos) -> QChar {
-        const int row = pos / cols;
-        const int col = pos % cols;
-        const uint8_t byte = screen->cell(row, col).character;
-        return cp.toUnicode(byte);
-    };
-
-    const QChar waitChar = charAtLinearPos(waitFlagPos);
-    const bool noWait = (waitChar == QChar('a'));
-
     QString command;
-    command.reserve(kPccmdMaxLength);
-    for (int p = commandStartPos; p < commandStartPos + kPccmdMaxLength; ++p) {
-        QChar c = charAtLinearPos(p);
-        // Map control characters and undefined codepage entries to space so
-        // they do not break tokenisation downstream.
+    command.reserve(commandBytes.size());
+    for (auto rawByte : commandBytes) {
+        QChar c = cp.toUnicode(static_cast<uint8_t>(rawByte));
         if (c.isNull() || c.category() == QChar::Other_Control) {
             c = QChar(' ');
         }

--- a/src/ui/rendering/tn5250_command_handler.h
+++ b/src/ui/rendering/tn5250_command_handler.h
@@ -79,11 +79,13 @@ class TN5250CommandHandler : public QObject {
     void onMessageLightOff();
     void onReadScreenRequested(bool includeAttributes);
     void onWriteStructuredFieldReceived(const QByteArray &data);
-    // STRPCCMD: host has asked us to run a PC command. Reads the command off
-    // the rendered screen at fixed positions (per tn5250j's reference
-    // implementation), gates it through the configured PcCommandRunner, then
-    // unconditionally returns ENTER AID so the host CL program continues.
-    void onStrpccmdRequested();
+    // STRPCCMD: host has asked us to run a PC command. Receives the wait flag
+    // and raw EBCDIC command bytes consumed by the protocol decoder from the
+    // wire (immediately after the 10-byte PCO marker), applies the configured
+    // codepage, gates the resulting command through the configured
+    // PcCommandRunner, then unconditionally returns ENTER AID so the host CL
+    // program continues.
+    void onStrpccmdRequested(bool noWait, const QByteArray &commandBytes);
 
     void sendNegResponse(uint8_t category, uint8_t modifier, uint8_t uByte1, uint8_t uByte2);
 


### PR DESCRIPTION
## Linked Issue
Closes #112.

Companion submodule fix: 5250ng/protocol-tn5250#17 (closes 5250ng/protocol-tn5250#16).

## Motivation
The STRPCCMD policy gate added in #108/#109 wires up the four-way `PcCommandPolicy` (Deny / DenyAndAlert / AllowWithPrompt / AllowAlways), the confirm dialog, and `PcCommandRunner`, but live testing against OS/400 V5R4 (`9406-810-V5R4M0`) shows that none of those branches ever fire. The decoder matches the PCO marker correctly, but `TN5250CommandHandler::onStrpccmdRequested` reads the wait flag and command from screen positions 11 and 12..134 — a tn5250j-era convention that only worked on older OS/400 releases. On V5R4 those positions are blank, the trimmed command is empty, and every host-issued STRPCCMD silently falls through to "drop and send ENTER," so the entire feature is unreachable in practice.

The bytes the host writes after the PCO marker are right there in the WTD body. Routing them through the trigger callback removes the screen-buffer round-trip and works on every OS/400 release.

## What Changed
- **Protocol library bump.** `src/network/tn5250` moves from `33b4ae1` → `79bd0e7` to pick up 5250ng/protocol-tn5250#17, which extracts up to 124 wire bytes after the matched marker (1 wait flag + 123 command bytes per SA21-9247-6 §15.7) and surfaces them to the consumer.
- **`DecoderAdapter::strpccmdRequested`** now carries `(bool noWait, const QByteArray &commandBytes)` instead of being parameterless. The Qt-side bridge in `decoder_adapter.cpp` adapts the new `std::function<void(bool, const std::vector<uint8_t> &)>` callback to the signal.
- **`TN5250CommandHandler::onStrpccmdRequested`** now takes the same arguments. The implementation applies the configured `core::CodePage` to the raw EBCDIC bytes, maps control / undefined codepage entries to spaces (matching the prior screen-read behaviour), trims the result, and dispatches to the existing four-way policy switch. The whole "read 1D screen plane at positions 11/12..134" block is removed.

## Design Notes
- Codepage conversion stays on the consumer side so a single decoder works against every supported host codepage.
- The "always send ENTER on exit" guard is preserved so a host CL program that issued `STRPCCMD PAUSE(*YES)` still continues even if we deny or fail to run the command.
- No change to public session config or any settings file — `PcCommandPolicy` semantics are unchanged.

## Acceptance Criteria Check
- [x] STRPCCMD callback receives the wait flag and command bytes from the wire — verified by 5250ng/protocol-tn5250#17's `testStrpccmdMarkerFiresCallbackAndIsStrippedFromDisplay`, `testStrpccmdNoWaitFlagIsReported`, and `testStrpccmdEscAfterMarkerStopsExtraction`.
- [x] `DecoderAdapter` forwards the new callback shape to the Qt signal — confirmed by build (the lambda signature matches and `5250ng` links cleanly).
- [x] `TN5250CommandHandler` no longer reads from the screen buffer; codepage and trim still apply — confirmed by static review of the rewritten function.
- [x] The four `PcCommandPolicy` branches still dispatch unchanged — same switch as before, only the source of `command`/`noWait` changed.

## How Verified
- **Tests:** `ctest` reports 16/16 tests passing locally.
- **Build:** `cmake --build build --target 5250ng` links cleanly against the bumped submodule.
- **Live:** the V5R4 trace that produced the empty-command failure (222-byte WTD with the matched PCO marker, command bytes inline) is the exact scenario the new wire-extraction handles. With the submodule change applied, the bytes arrive at the consumer non-empty and the policy gate routes accordingly.

## Test Coverage
**Existing:** the parent's `test_decoder` (Qt-level), `test_tn5250_connection`, and the submodule's STRPCCMD tests cover the new path. **None added in this repo:** the regression tests live alongside the changed code in 5250ng/protocol-tn5250#17 (`tests/test_decoder.cpp`); duplicating them in this repo would not exercise anything new because the Qt adapter is a thin pass-through.

## Scope of Change
- **Files changed:** `src/network/tn5250` (submodule pointer), `src/network/tn5250_qt/client/decoder_adapter.{h,cpp}`, `src/ui/rendering/tn5250_command_handler.{h,cpp}`
- **Submodule pointer updated:** yes — `protocol-tn5250` from `33b4ae1` to `79bd0e7`
- **Public API changes:** internal `DecoderAdapter` and `TN5250CommandHandler` signatures change; no user-facing API or persisted settings change
- **Behavioral changes outside the stated enhancement:** none

## Risk and Rollout
- The only direct caller of the changed callback signature is `TN5250CommandHandler`, updated in lockstep here.
- A host that emits the marker without inline command bytes still produces a callback (with empty `commandBytes`) — the consumer still falls through the existing "empty command, send ENTER and drop" path, so backward compatibility with hosts that historically required the screen-position read is preserved (those hosts were the only ones for which the old code ever worked, and they would now work *and* the V5R4-style hosts would too).
- 5250ng/protocol-tn5250#17 has merged; the submodule pointer was repinned to the merged-main commit `9473dd8` (matches the convention established in #105 / #99). Ready to merge.

## Notes
The behavioural diagnosis was reproduced live against `9406-810-V5R4M0` on `192.168.1.51`: signed on as `QSECOFR`, ran `STRPCO`, then `STRPCCMD PCCMD('echo hello from os400') PAUSE(*YES)`. Pre-fix the log showed `CommandHandler: STRPCCMD wait=yes command=` followed by "empty command after trim; sending ENTER and dropping" for every attempt; the 222-byte WTD payload contained the matched PCO marker plus the command bytes inline, exactly the layout this PR routes to the policy gate.