### PR TITLE
[enhancement] Redesign STRPCCMD confirm/alert dialogs to match the rest of the UI (#116)

### DIFF
--- a/src/ui/dialogs/pc_command_confirm_dialog.cpp
+++ b/src/ui/dialogs/pc_command_confirm_dialog.cpp
@@ -16,6 +16,7 @@
 
 #include "pc_command_confirm_dialog.h"
 
+#include <QApplication>
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QPlainTextEdit>
@@ -25,31 +26,74 @@
 
 namespace ui::dialogs {
 
+namespace {
+
+// Project-wide horizontal-rectangle dialog dimensions for STRPCCMD surfaces.
+// Picked so the displayed command fits a typical PCCMD payload (123 char max
+// per SA21-9247-6 §15.7) on one line at the project's default font.
+constexpr int kDialogWidth = 720;
+constexpr int kDialogHeight = 260;
+constexpr int kIconSize = 48;
+
+// Build the icon column shared by both surfaces (Allow/Deny and Deny/alert).
+// QStyle::SP_MessageBoxWarning matches the system "this needs your attention"
+// icon and keeps the dialog readable across platform themes.
+QLabel *makeWarningIcon(QWidget *parent) {
+    QLabel *icon = new QLabel(parent);
+    QStyle *style = parent ? parent->style() : QApplication::style();
+    QIcon stdIcon = style->standardIcon(QStyle::SP_MessageBoxWarning);
+    icon->setPixmap(stdIcon.pixmap(kIconSize, kIconSize));
+    icon->setAlignment(Qt::AlignTop | Qt::AlignHCenter);
+    icon->setFixedWidth(kIconSize + 8);
+    return icon;
+}
+
+QPlainTextEdit *makeCommandView(QWidget *parent, const QString &command) {
+    QPlainTextEdit *view = new QPlainTextEdit(parent);
+    view->setPlainText(command);
+    view->setReadOnly(true);
+    view->setLineWrapMode(QPlainTextEdit::NoWrap);
+    view->setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+    view->setMaximumHeight(70);
+    return view;
+}
+
+} // namespace
+
 PcCommandConfirmDialog::PcCommandConfirmDialog(const QString &hostname,
                                                const QString &command,
                                                QWidget *parent)
-    : QDialog(parent) {
+    : ui::widgets::BaseFramelessDialog(parent) {
     setWindowTitle("Allow PC command from host?");
     setModal(true);
+    resize(kDialogWidth, kDialogHeight);
 
-    auto *layout = new QVBoxLayout(this);
+    QVBoxLayout *content = contentLayout();
+    content->setContentsMargins(16, 12, 16, 12);
+    content->setSpacing(10);
 
-    auto *header = new QLabel(this);
+    // Top row: icon column on the left, header + command + warning stacked
+    // on the right. The icon column anchors the dialog as a horizontal
+    // rectangle and matches the rest of the warning-style modals.
+    QHBoxLayout *body = new QHBoxLayout();
+    body->setSpacing(12);
+    body->addWidget(makeWarningIcon(this));
+
+    QVBoxLayout *text = new QVBoxLayout();
+    text->setSpacing(8);
+
+    QLabel *header = new QLabel(this);
     header->setTextFormat(Qt::RichText);
     header->setWordWrap(true);
     header->setText(
         QString("<b>The host <code>%1</code> is asking 5250ng to run a "
                 "command on this PC.</b>")
             .arg(hostname.isEmpty() ? "(unknown)" : hostname.toHtmlEscaped()));
-    layout->addWidget(header);
+    text->addWidget(header);
 
-    auto *commandView = new QPlainTextEdit(this);
-    commandView->setPlainText(command);
-    commandView->setReadOnly(true);
-    commandView->setMinimumHeight(80);
-    layout->addWidget(commandView);
+    text->addWidget(makeCommandView(this, command));
 
-    auto *warning = new QLabel(this);
+    QLabel *warning = new QLabel(this);
     warning->setTextFormat(Qt::RichText);
     warning->setWordWrap(true);
     warning->setText(
@@ -57,23 +101,26 @@ PcCommandConfirmDialog::PcCommandConfirmDialog(const QString &hostname,
         "It can read or modify any file you can, and contact any network you "
         "can reach. Only allow if you trust this host and recognise the "
         "command.</i>");
-    layout->addWidget(warning);
+    text->addWidget(warning);
 
-    auto *buttons = new QHBoxLayout();
-    auto *deny = new QPushButton("Deny", this);
-    auto *allow = new QPushButton("Allow", this);
+    body->addLayout(text, 1);
+    content->addLayout(body, 1);
+
+    // Buttons row: right-aligned, Deny is the default. Allow remains opt-in
+    // — the user must explicitly select it.
+    QHBoxLayout *buttons = new QHBoxLayout();
+    buttons->addStretch();
+    QPushButton *deny = new QPushButton("Deny", this);
+    QPushButton *allow = new QPushButton("Allow", this);
     deny->setDefault(true);
     deny->setAutoDefault(true);
     allow->setDefault(false);
     allow->setAutoDefault(false);
     connect(deny, &QPushButton::clicked, this, &QDialog::reject);
     connect(allow, &QPushButton::clicked, this, &QDialog::accept);
-    buttons->addStretch();
     buttons->addWidget(deny);
     buttons->addWidget(allow);
-    layout->addLayout(buttons);
-
-    setLayout(layout);
+    content->addLayout(buttons);
 }
 
 bool PcCommandConfirmDialog::ask(const QString &hostname,
@@ -89,44 +136,52 @@ void PcCommandConfirmDialog::notifyDenied(const QString &hostname,
     // Information-only modal: surfaces a refused STRPCCMD attempt to the user
     // so a host that tries to run something never goes unnoticed under the
     // "Deny and alert" policy. No Allow button — the policy already refused.
-    QDialog dlg(parent);
+    ui::widgets::BaseFramelessDialog dlg(parent);
     dlg.setWindowTitle("PC command blocked");
     dlg.setModal(true);
+    dlg.resize(kDialogWidth, kDialogHeight);
 
-    auto *layout = new QVBoxLayout(&dlg);
+    QVBoxLayout *content = dlg.contentLayout();
+    content->setContentsMargins(16, 12, 16, 12);
+    content->setSpacing(10);
 
-    auto *header = new QLabel(&dlg);
+    QHBoxLayout *body = new QHBoxLayout();
+    body->setSpacing(12);
+    body->addWidget(makeWarningIcon(&dlg));
+
+    QVBoxLayout *text = new QVBoxLayout();
+    text->setSpacing(8);
+
+    QLabel *header = new QLabel(&dlg);
     header->setTextFormat(Qt::RichText);
     header->setWordWrap(true);
     header->setText(
         QString("<b>The host <code>%1</code> tried to run a command on this "
                 "PC. It was refused by your session policy (Deny and alert).</b>")
             .arg(hostname.isEmpty() ? "(unknown)" : hostname.toHtmlEscaped()));
-    layout->addWidget(header);
+    text->addWidget(header);
 
-    auto *commandView = new QPlainTextEdit(&dlg);
-    commandView->setPlainText(command);
-    commandView->setReadOnly(true);
-    commandView->setMinimumHeight(80);
-    layout->addWidget(commandView);
+    text->addWidget(makeCommandView(&dlg, command));
 
-    auto *footer = new QLabel(&dlg);
+    QLabel *footer = new QLabel(&dlg);
     footer->setTextFormat(Qt::RichText);
     footer->setWordWrap(true);
     footer->setText(
         "<i>Nothing was executed. To allow PC commands from this host, change "
         "the STRPCCMD policy in the session settings.</i>");
-    layout->addWidget(footer);
+    text->addWidget(footer);
 
-    auto *buttons = new QHBoxLayout();
-    auto *ok = new QPushButton("OK", &dlg);
+    body->addLayout(text, 1);
+    content->addLayout(body, 1);
+
+    QHBoxLayout *buttons = new QHBoxLayout();
+    buttons->addStretch();
+    QPushButton *ok = new QPushButton("OK", &dlg);
     ok->setDefault(true);
     QObject::connect(ok, &QPushButton::clicked, &dlg, &QDialog::accept);
-    buttons->addStretch();
     buttons->addWidget(ok);
-    layout->addLayout(buttons);
+    content->addLayout(buttons);
 
-    dlg.setLayout(layout);
     dlg.exec();
 }
 

--- a/src/ui/dialogs/pc_command_confirm_dialog.h
+++ b/src/ui/dialogs/pc_command_confirm_dialog.h
@@ -16,20 +16,18 @@
 
 #pragma once
 
-#include <QDialog>
+#include "ui/widgets/Frameless/BaseFramelessDialog.h"
 #include <QString>
-
-class QLabel;
-class QPushButton;
-class QPlainTextEdit;
 
 namespace ui::dialogs {
 
 // Modal dialog shown for every host-issued STRPCCMD when the feature is
 // enabled. Displays the host name and the full command string with a clear
 // security warning, and offers Allow / Deny. Allow is NOT the default button
-// — the user must explicitly choose it.
-class PcCommandConfirmDialog : public QDialog {
+// — the user must explicitly choose it. Renders with the project's frameless
+// title bar in a wide horizontal-rectangle layout matching the rest of the
+// dialogs in src/ui/dialogs/.
+class PcCommandConfirmDialog : public ui::widgets::BaseFramelessDialog {
     Q_OBJECT
 
   public:


### PR DESCRIPTION
## Linked Issue
Closes #116.

## Root Cause
\`PcCommandConfirmDialog\` predates the standardisation on \`ui::widgets::BaseFramelessDialog\`. The class inherited directly from \`QDialog\` and stacked the header label, the command view, the warning text, and the button row in a single \`QVBoxLayout\` with no explicit \`resize(...)\` call. The natural size hint from those stacked widgets produced a narrow / nearly-square shape that did not match the project's frameless title-bar style used by every other dialog in \`src/ui/dialogs/\` and forced the displayed PC command (up to 123 chars per SA21-9247-6 §15.7) to wrap mid-string. The \`notifyDenied\` static had a copy of the same layout pattern with the same problems.

## Fix Description
Port both surfaces to \`BaseFramelessDialog\`:

- **Title bar.** \`PcCommandConfirmDialog\` now inherits from \`ui::widgets::BaseFramelessDialog\`; \`notifyDenied\` builds a \`BaseFramelessDialog\` instance instead of a raw \`QDialog\`. Both surfaces now render with the project's frameless title bar (matching \`ConnectDialog\`, \`MatchReplaceDialog\`, \`KeyboardRemapDialog\`, \`SettingsDialog\`, \`StyledMessageBox\`).
- **Horizontal rectangle layout.** Fixed dimensions \`720×260\` (\`kDialogWidth × kDialogHeight\`) — clearly wider than tall.
- **Two-column body.** A 48-px \`QStyle::SP_MessageBoxWarning\` icon column on the left anchors the dialog as a horizontal rectangle and matches the rest of the warning-style modals; header text, command view, and warning paragraph stack on the right.
- **Command view.** \`QPlainTextEdit\` with \`NoWrap\` + \`ScrollBarAsNeeded\` so the full 123-char PCCMD payload reads naturally on one line instead of wrapping.
- **Button row.** Right-aligned, \`Deny\` is the default, \`Allow\` has \`autoDefault\` disabled — the security-relevant property that the user must explicitly opt in is preserved.

Two small helpers (\`makeWarningIcon\`, \`makeCommandView\`) factor out the bits shared between \`ask\` and \`notifyDenied\` to keep the two surfaces visually identical without duplicating widget setup.

## How Verified
- **Static:** confirmed both surfaces inherit from / instantiate \`BaseFramelessDialog\`, that \`resize(720, 260)\` lands a horizontal rectangle, and that \`Allow\` keeps \`setDefault(false)\` + \`setAutoDefault(false)\`.
- **Build:** \`cmake --build build --target 5250ng\` builds the changed translation unit and links cleanly.
- **Tests:** \`ctest\` reports 16/16 PASS — no test exercises this dialog directly (it's a UI-only surface), and no existing test changed behavior.

## Test Coverage
**None.** The change is purely UI-layer; the existing \`PcCommandRunner\` and \`TN5250CommandHandler\` tests cover the policy gate behind the dialog. Adding a Qt test that drives the dialog widget would not exercise anything currently uncovered (the policy gate is decided before the dialog is shown), and the project does not have a UI-snapshot test harness yet.

## Scope of Change
- **Files changed:** \`src/ui/dialogs/pc_command_confirm_dialog.h\`, \`src/ui/dialogs/pc_command_confirm_dialog.cpp\`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — \`ask\` still returns \`true\` only on Allow, \`notifyDenied\` is still dismiss-only, the policy gate in \`TN5250CommandHandler::onStrpccmdRequested\` is untouched.

## Risk and Rollout
Trivial and local. Both static call sites (\`ask\`, \`notifyDenied\`) keep their public signatures, and \`BaseFramelessDialog\` is the same class every other dialog already uses, so the new surface inherits the existing theme and event-handling path.