### PR TITLE
[bugfix] Fix IAC IAC inside Telnet subnegotiation routing to app data (#118)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -411,6 +411,7 @@ if(BUILD_TESTS)
     add_tn5250_test(test_pc_command_runner tests/unit/test_pc_command_runner.cpp)
 
     add_tn5250_test(test_ibmrseed tests/unit/test_ibmrseed.cpp)
+    add_tn5250_test(test_telnet_subnegotiation tests/unit/test_telnet_subnegotiation.cpp)
     add_tn5250_test(test_codepage tests/unit/test_codepage.cpp)
 
     add_tn5250_test(test_terminal_theme tests/unit/test_terminal_theme.cpp)

--- a/src/network/tn5250_qt/client/client.h
+++ b/src/network/tn5250_qt/client/client.h
@@ -32,10 +32,17 @@
 class QSslSocket;
 class QSslError;
 
+// Forward-declared in the global namespace so the friend declaration below
+// names the test class defined at file scope in tests/unit/test_telnet_subnegotiation.cpp,
+// not a nested ::tn5250::client::TestTelnetSubnegotiation.
+class TestTelnetSubnegotiation;
+
 namespace tn5250::client {
 
 class TN5250Client : public QObject {
     Q_OBJECT
+
+    friend class ::TestTelnetSubnegotiation;
 
   public:
     enum class ConnectionState {

--- a/src/network/tn5250_qt/client/client_telnet.cpp
+++ b/src/network/tn5250_qt/client/client_telnet.cpp
@@ -45,9 +45,19 @@ void TN5250Client::processTelnetData(const QByteArray &data) {
 
             uint8_t next = static_cast<uint8_t>(m_receiveBuffer[i + 1]);
 
-            // Double IAC means literal IAC
+            // Double IAC means literal 0xFF.  When we are inside a
+            // subnegotiation (between IAC SB and IAC SE), that 0xFF belongs to
+            // the SB payload — routing it to the application stream both
+            // poisons the app data with a spurious 0xFF and silently drops the
+            // byte from the SB buffer (so e.g. a 0xFF byte in an IBMRSEED
+            // server seed would never reach handleSubnegotiation).
             if (next == static_cast<uint8_t>(TelnetCommand::IAC)) {
-                processed.append(static_cast<uint8_t>(TelnetCommand::IAC));
+                if (m_inSubnegotiation) {
+                    m_subnegotiationBuffer.append(
+                        static_cast<uint8_t>(TelnetCommand::IAC));
+                } else {
+                    processed.append(static_cast<uint8_t>(TelnetCommand::IAC));
+                }
                 i += 2;
                 continue;
             }

--- a/tests/unit/test_telnet_subnegotiation.cpp
+++ b/tests/unit/test_telnet_subnegotiation.cpp
@@ -1,0 +1,110 @@
+// 5250ng - A modern IBM TN5250 terminal emulator
+// Copyright (C) 2025-2026 Remi GASCOU (Podalirius)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include "network/tn5250_qt/client/client.h"
+#include "network/tn5250_qt/telnet/commands.h"
+#include "network/tn5250_qt/telnet/options.h"
+#include <QSignalSpy>
+#include <QtTest/QtTest>
+
+using namespace tn5250::client;
+using telnet::TelnetCommand;
+using telnet::TelnetOption;
+
+// Friend-declared in TN5250Client so it can poke the private telnet parser
+// and the subnegotiation buffer without exposing them in the public API.
+class TestTelnetSubnegotiation : public QObject {
+    Q_OBJECT
+
+  private slots:
+    void testEscapedIacInsideSubnegotiationStaysInSbBuffer();
+    void testEscapedIacOutsideSubnegotiationFlowsAsAppData();
+
+  private:
+    static QByteArray makeFrame(std::initializer_list<uint8_t> bytes) {
+        QByteArray b;
+        for (uint8_t x : bytes) b.append(static_cast<char>(x));
+        return b;
+    }
+};
+
+// Regression test for the IAC-IAC routing bug in
+// TN5250Client::processTelnetData: an escaped 0xFF inside an SB payload
+// must be appended to m_subnegotiationBuffer, not to the application data
+// stream emitted via dataReceived().
+void TestTelnetSubnegotiation::testEscapedIacInsideSubnegotiationStaysInSbBuffer() {
+    TN5250Client client;
+    client.m_handshakeComplete = true; // dataReceived() guarded on this flag
+
+    QSignalSpy spy(&client, &TN5250Client::dataReceived);
+
+    // Use NAWS as the SB option because handleSubnegotiation for NAWS only
+    // logs and returns — it doesn't try to write a reply through the (null)
+    // socket. The payload contains two IAC IAC pairs, each of which must
+    // decode to a single 0xFF byte inside the SB buffer.
+    const uint8_t IAC = static_cast<uint8_t>(TelnetCommand::IAC);
+    const uint8_t SB = static_cast<uint8_t>(TelnetCommand::SB);
+    const uint8_t SE = static_cast<uint8_t>(TelnetCommand::SE);
+    const uint8_t NAWS = static_cast<uint8_t>(TelnetOption::NEGOTIATE_ABOUT_WINDOW_SIZE);
+
+    QByteArray frame = makeFrame({
+        IAC, SB, NAWS,        // begin subnegotiation
+        0x00, IAC, IAC,       // width = 0x00FF
+        0x00, IAC, IAC,       // height = 0x00FF
+        IAC, SE,              // end subnegotiation
+        'A', 'B', 'C'         // application data that should flow through
+    });
+
+    client.processTelnetData(frame);
+
+    // 1. The SB buffer (snapshot just before clearing) contained the
+    //    correctly-unescaped 4-byte width/height payload.
+    //    handleSubnegotiation for NAWS doesn't expose the buffer to a
+    //    callback, so we verify the captured buffer was cleared and that
+    //    nothing leaked into the app stream.
+    QCOMPARE(client.m_inSubnegotiation, false);
+    QCOMPARE(client.m_subnegotiationBuffer.size(), 0);
+
+    // 2. The app-data path must contain ONLY "ABC" — no spurious 0xFF bytes
+    //    from the SB payload should have been emitted as application data.
+    QByteArray received;
+    for (const auto &args : spy) {
+        received.append(args.at(0).toByteArray());
+    }
+    QCOMPARE(received, QByteArray("ABC"));
+}
+
+// Sanity check: outside an SB, IAC IAC is still application data 0xFF.
+void TestTelnetSubnegotiation::testEscapedIacOutsideSubnegotiationFlowsAsAppData() {
+    TN5250Client client;
+    client.m_handshakeComplete = true;
+
+    QSignalSpy spy(&client, &TN5250Client::dataReceived);
+
+    const uint8_t IAC = static_cast<uint8_t>(TelnetCommand::IAC);
+    QByteArray frame = makeFrame({'X', IAC, IAC, 'Y'});
+
+    client.processTelnetData(frame);
+
+    QByteArray received;
+    for (const auto &args : spy) {
+        received.append(args.at(0).toByteArray());
+    }
+    QCOMPARE(received, QByteArray::fromHex("58FF59")); // X 0xFF Y
+}
+
+QTEST_MAIN(TestTelnetSubnegotiation)
+#include "test_telnet_subnegotiation.moc"


### PR DESCRIPTION
## Linked Issue
Closes #118.

## Root Cause
`TN5250Client::processTelnetData()` had a "double IAC means literal IAC" branch that predated the `m_inSubnegotiation` handling further down the function and was never updated to consult it. When the parser was between `IAC SB` and `IAC SE`, an escaped 0xFF byte from the SB payload was unconditionally appended to the application-data buffer `processed`. The byte was therefore both dropped from `m_subnegotiationBuffer` (so `handleSubnegotiation()` saw a truncated payload) and injected into the EBCDIC stream emitted via `dataReceived()`. The parallel state-machine implementation in `src/network/tn5250_qt/telnet/client.cpp` already implemented the correct routing — it just was not the parser wired into the active client.

## Fix Description
Route the escaped 0xFF based on the current parser state: if `m_inSubnegotiation`, append to `m_subnegotiationBuffer`; otherwise append to `processed`. Both legs consume two source bytes and continue, identical to the previous control flow. No other parser branches are changed.

## How Verified
- **Static:** Walked `IAC SB NAWS 0x00 IAC IAC 0x00 IAC IAC IAC SE` through the patched parser by hand. Both `IAC IAC` pairs now resolve to a single 0xFF in `m_subnegotiationBuffer`; nothing is appended to `processed`.
- **Tests:** New `test_telnet_subnegotiation` runs two cases — escaped IAC inside SB stays out of app data, and escaped IAC outside SB still flows as `0xFF` application data.
- **Full suite:** `cmake --build build && ctest --test-dir build` reports 17/17 PASS.

## Test Coverage
**Added:** `tests/unit/test_telnet_subnegotiation.cpp` with two test methods:
- `testEscapedIacInsideSubnegotiationStaysInSbBuffer`
- `testEscapedIacOutsideSubnegotiationFlowsAsAppData`

The test class is granted access to a small set of internals via a single forward-declared `friend class ::TestTelnetSubnegotiation` in `client.h`. No production API surface is added.

## Scope of Change
- **Files changed:**
  - `src/network/tn5250_qt/client/client_telnet.cpp` (fix)
  - `src/network/tn5250_qt/client/client.h` (friend declaration for the test)
  - `tests/unit/test_telnet_subnegotiation.cpp` (new test)
  - `CMakeLists.txt` (register the new test target)
- **Submodule pointer updated:** no — a companion fix for `src/network/tn5250/tn5250/client/protocol_handler.cpp` will land separately in 5250ng/protocol-tn5250; that copy is not currently invoked by this application.
- **Behavioral changes outside the bug fix:** none

## Risk and Rollout
Local to the Telnet framing path. The change is symmetric (one byte in, one byte out, two source bytes consumed) — only the destination buffer changes. Real-world impact is restricted to inbound traffic that carries `IAC IAC` inside an `SB ... SE`, which today is almost exclusively NEW_ENVIRON IBMRSEED seeds; servers that never sent such a seed are unaffected.

## Notes
The companion `protocol_handler.cpp` defect in the `protocol-tn5250` submodule is filed alongside but in a separate PR there, because the two parsers are independent C++ codebases.
