### PR TITLE
[bugfix] Fix DEVNAME value in NEW_ENVIRON SB not RFC 1572 ESC-escaped (#120)

### DIFF
--- a/src/network/tn5250_qt/client/client_handshake.cpp
+++ b/src/network/tn5250_qt/client/client_handshake.cpp
@@ -96,7 +96,12 @@ void TN5250Client::sendNewEnviron() {
     negotiation.append("DEVNAME");
     negotiation.append(static_cast<uint8_t>(0x01)); // VALUE
     if (!m_deviceNameSent && !m_deviceName.isEmpty()) {
-        negotiation.append(m_deviceName.toUtf8());
+        // RFC 1572 reserves 0x00 (VAR), 0x01 (VALUE), 0x02 (ESC), 0x03
+        // (USERVAR) and 0xFF (IAC) as in-band markers; user-supplied bytes
+        // must be ESC-escaped before being placed in the value, otherwise a
+        // NUL or SOH in the device name would prematurely terminate the
+        // value and confuse the host parser.
+        negotiation.append(IBMRSeed::escapeNewEnviron(m_deviceName.toUtf8()));
     } else if (m_deviceNameSent) {
         logger::Logger::instance()->debug(
             "[TN5250->Client]: Server re-requested DEVNAME, sending empty (auto-assign)");


### PR DESCRIPTION
## Linked Issue
Closes #120.

## Root Cause
`TN5250Client::sendNewEnviron()` builds an `IAC SB NEW_ENVIRON IS ... IAC SE` subnegotiation buffer one value at a time. It carefully wraps every user-controlled value in `IBMRSeed::escapeNewEnviron(...)` so RFC 1572 reserved bytes (`0x00 VAR`, `0x01 VALUE`, `0x02 ESC`, `0x03 USERVAR`, `0xFF IAC`) cannot leak into the wire as in-band markers — except for the `DEVNAME` value, which was appended via plain `m_deviceName.toUtf8()`. That append predated the `IBMRSEED` / `IBMSUBSPW` paths and was never retrofitted when those paths introduced the escaper.

## Fix Description
Apply `IBMRSeed::escapeNewEnviron(m_deviceName.toUtf8())` to the DEVNAME value the same way it is applied to the IBMRSEED client seed and the IBMSUBSPW encrypted password later in the same function. The change is local to one append and does not touch any other field of the SB payload.

## How Verified
- **Static:** Walked a `m_deviceName` of `"D\x01EV"` through the patched function. The four-byte value now serializes as `44 02 01 45 56` (each reserved byte prefixed with ESC `0x02`); the server's RFC 1572 parser recovers `"D\x01EV"` losslessly.
- **Tests:** `cmake --build build && ctest --test-dir build` reports 16/16 PASS. The escaper primitive itself is independently exercised by `TestIBMRSeed::testEscapeNewEnviron` (`tests/unit/test_ibmrseed.cpp`), which covers all five reserved bytes.

## Test Coverage
**Existing:** `TestIBMRSeed::testEscapeNewEnviron` covers the escaper for every reserved RFC 1572 byte. This PR uses that already-tested primitive in a previously-unguarded call site; the call site itself is a one-line plumbing change with no branching logic to exercise. A full end-to-end SB-construction test would require either mocking the inner `QAbstractSocket` or refactoring the SB builder out of `sendNewEnviron()`, which is out of scope for this single-line defect fix.

## Scope of Change
- **Files changed:** `src/network/tn5250_qt/client/client_handshake.cpp` (1 line of logic, 5 lines of comment)
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

## Risk and Rollout
Local to the NEW_ENVIRON SB build. Device names that contain only the conventional ASCII letter/digit/hyphen alphabet are byte-identical on the wire after this change. The only behavioral difference is that names containing 0x00–0x03 or 0xFF are now correctly escaped instead of corrupting the SB framing. Safe to merge without staging.

## Notes
`sendDeviceName()` writes `m_terminalType.toUtf8()` into a TERMINAL_TYPE SB without IAC-doubling. UTF-8 output of a valid `QString` can never produce a 0xFF byte, so that path is not currently exploitable and is intentionally not changed here.
