### PR TITLE
[bugfix] Fix MCP HTTP parser reset() discarding pipelined/trailing bytes (#124)

### DIFF
--- a/src/mcp/McpHttpParser.cpp
+++ b/src/mcp/McpHttpParser.cpp
@@ -90,7 +90,23 @@ bool McpHttpParser::feed(const QByteArray &data) {
 }
 
 void McpHttpParser::reset() {
-    m_buffer.clear();
+    // "Reset for the next request" — drop only the bytes consumed by the
+    // just-parsed request, keeping any leftover that already sits in the
+    // buffer (e.g. a pipelined second request that arrived in the same
+    // TCP read as the first request body). Wiping m_buffer wholesale
+    // would silently discard those bytes.
+    if (m_headersParsed && m_bodyStart >= 0) {
+        const int consumed = m_bodyStart + m_contentLength;
+        if (consumed > 0 && consumed <= m_buffer.size()) {
+            m_buffer.remove(0, consumed);
+        } else {
+            // Parser state inconsistent (shouldn't happen on the success
+            // path that triggers reset); clear to recover safely.
+            m_buffer.clear();
+        }
+    } else {
+        m_buffer.clear();
+    }
     m_request = {};
     m_headersParsed = false;
     m_contentLength = 0;

--- a/src/mcp/McpServer.cpp
+++ b/src/mcp/McpServer.cpp
@@ -155,6 +155,23 @@ void McpServer::onClientData() {
         httpParser = reinterpret_cast<McpHttpParser *>(parser->property("ptr").value<quintptr>());
     }
 
+    // Local helper: write the same 413 error response and disconnect the
+    // socket. Used by both the first-request error branch and the
+    // pipelined-drain error branch so the two paths stay in sync.
+    auto sendParseError = [&]() {
+        MCP_ERROR(QString("HTTP parse error: %1").arg(httpParser->errorMessage()));
+        HttpResponse resp;
+        resp.statusCode = 413;
+        resp.statusText = QStringLiteral("Payload Too Large");
+        resp.headers["Content-Type"] = "application/json";
+        QJsonObject err;
+        err["error"] = httpParser->errorMessage();
+        resp.body = QJsonDocument(err).toJson(QJsonDocument::Compact);
+        socket->write(resp.toBytes());
+        socket->flush();
+        socket->disconnectFromHost();
+    };
+
     if (httpParser->feed(socket->readAll())) {
         handleHttpRequest(socket);
         // The socket (and its httpParser) may have been destroyed during
@@ -171,18 +188,16 @@ void McpServer::onClientData() {
             handleHttpRequest(socket);
             if (!socket.isNull()) httpParser->reset();
         }
+        // A malformed pipelined request (oversized header, bad
+        // Content-Length, oversized body) leaves the parser in error
+        // state and breaks out of the drain loop. Respond with the same
+        // 413 + close as the first-request error branch, otherwise the
+        // client is left waiting for a response that never comes.
+        if (!socket.isNull() && httpParser->hasError()) {
+            sendParseError();
+        }
     } else if (httpParser->hasError()) {
-        MCP_ERROR(QString("HTTP parse error: %1").arg(httpParser->errorMessage()));
-        HttpResponse resp;
-        resp.statusCode = 413;
-        resp.statusText = QStringLiteral("Payload Too Large");
-        resp.headers["Content-Type"] = "application/json";
-        QJsonObject err;
-        err["error"] = httpParser->errorMessage();
-        resp.body = QJsonDocument(err).toJson(QJsonDocument::Compact);
-        socket->write(resp.toBytes());
-        socket->flush();
-        socket->disconnectFromHost();
+        sendParseError();
     }
 }
 

--- a/src/mcp/McpServer.cpp
+++ b/src/mcp/McpServer.cpp
@@ -162,6 +162,15 @@ void McpServer::onClientData() {
         // disconnected.  Only reset the parser if the socket is still alive.
         if (!socket.isNull())
             httpParser->reset();
+        // Drain any additional requests that arrived in the same TCP read.
+        // Now that reset() preserves the parser's leftover bytes (everything
+        // past the just-parsed body), feed(empty) re-runs the state machine
+        // on what is already buffered and returns true once another full
+        // request is available.
+        while (!socket.isNull() && httpParser->feed(QByteArray())) {
+            handleHttpRequest(socket);
+            if (!socket.isNull()) httpParser->reset();
+        }
     } else if (httpParser->hasError()) {
         MCP_ERROR(QString("HTTP parse error: %1").arg(httpParser->errorMessage()));
         HttpResponse resp;

--- a/tests/unit/test_mcp_http_parser.cpp
+++ b/tests/unit/test_mcp_http_parser.cpp
@@ -99,6 +99,37 @@ class TestMcpHttpParser : public QObject {
         QVERIFY(!p.hasError());
         QCOMPARE(p.errorMessage(), QString());
     }
+
+    // Regression: reset() previously cleared the buffer wholesale, so a
+    // pipelined second request that arrived in the same TCP read as the
+    // first request body was silently discarded.
+    void resetPreservesLeftoverForPipelinedRequest() {
+        McpHttpParser p;
+        const QByteArray first = "POST /mcp HTTP/1.1\r\n"
+                                 "Content-Length: 2\r\n"
+                                 "\r\n"
+                                 "{}";
+        const QByteArray second = "POST /mcp HTTP/1.1\r\n"
+                                  "Content-Length: 4\r\n"
+                                  "\r\n"
+                                  "[12]";
+        // Feed both requests in a single buffer, as readAll() would deliver
+        // them on a busy socket.
+        QVERIFY(p.feed(first + second));
+        QCOMPARE(p.request().body, QByteArray("{}"));
+
+        // After reset, the parser should still have the second request
+        // buffered and feed(empty) should immediately return true.
+        p.reset();
+        QVERIFY(!p.hasError());
+        QVERIFY(p.feed(QByteArray()));
+        QCOMPARE(p.request().body, QByteArray("[12]"));
+
+        // No third request → feed(empty) returns false without erroring.
+        p.reset();
+        QVERIFY(!p.feed(QByteArray()));
+        QVERIFY(!p.hasError());
+    }
 };
 
 QTEST_MAIN(TestMcpHttpParser)

--- a/tests/unit/test_mcp_http_parser.cpp
+++ b/tests/unit/test_mcp_http_parser.cpp
@@ -130,6 +130,31 @@ class TestMcpHttpParser : public QObject {
         QVERIFY(!p.feed(QByteArray()));
         QVERIFY(!p.hasError());
     }
+
+    // Regression: a malformed pipelined second request must leave the
+    // parser in an observable error state after reset(), so the server
+    // can respond with the same 413 + disconnect path it uses on a
+    // first-request error. Before this fix, reset() wiped the buffer and
+    // the malformed bytes disappeared entirely.
+    void resetExposesErrorOnMalformedPipelinedRequest() {
+        McpHttpParser p;
+        const QByteArray good = "POST /mcp HTTP/1.1\r\n"
+                                "Content-Length: 2\r\n"
+                                "\r\n"
+                                "{}";
+        const QByteArray bad = "POST /mcp HTTP/1.1\r\n"
+                               "Content-Length: -7\r\n\r\n";
+        QVERIFY(p.feed(good + bad));
+        QCOMPARE(p.request().body, QByteArray("{}"));
+
+        p.reset();
+        QVERIFY(!p.hasError());
+
+        // feed(empty) drains the buffered malformed request; the parser
+        // must surface the error rather than silently swallow the bytes.
+        QVERIFY(!p.feed(QByteArray()));
+        QVERIFY(p.hasError());
+    }
 };
 
 QTEST_MAIN(TestMcpHttpParser)


### PR DESCRIPTION
## Linked Issue
Closes #124.

## Root Cause
`McpHttpParser::reset()` unconditionally called `m_buffer.clear()`. `McpServer::onClientData()` calls `reset()` on the success path immediately after `handleHttpRequest()` returns, so any bytes already buffered past the just-parsed request body — most commonly a pipelined second HTTP request that arrived in the same TCP read — were silently wiped. `readyRead` does not re-fire unless additional bytes arrive on the wire, so the pipelined request was effectively dropped on the floor. The header's own doc on `reset()` ("Reset for the next request.") promised the parser was ready to continue on the same connection; the implementation contradicted it.

## Fix Description
Two coordinated changes:
1. `McpHttpParser::reset()` now removes only the bytes consumed by the just-parsed request (`m_bodyStart + m_contentLength`) and preserves any leftover for the next parsing cycle. The behaviour now matches the header doc. A defensive fallback to full-clear remains for the inconsistent / pre-headers-parsed cases.
2. `McpServer::onClientData()` drains any additional requests already in the parser buffer by looping `while (httpParser->feed(QByteArray())) { handleHttpRequest; reset; }` after the first dispatch. Without this loop, a pipelined request would sit in the buffer until fresh bytes arrived; with this loop, all pipelined requests are dispatched in order without further network activity. The `QPointer<QTcpSocket>` is re-checked each iteration so a nested event loop that destroys the socket (existing pattern, see `handleHttpRequest`'s comment) cleanly stops the drain.

## How Verified
- **Tests:** New `TestMcpHttpParser::resetPreservesLeftoverForPipelinedRequest` feeds two complete requests in one buffer, asserts the first body parses, calls `reset()`, then asserts `feed(empty)` immediately returns true and yields the second body. It also covers the no-leftover case (reset followed by `feed(empty)` returns false without erroring). `cmake --build build && ctest --test-dir build` reports 16/16 PASS.
- **Static:** Re-traced the two-request-in-one-feed path through the patched parser: after the first body is captured, `m_buffer` is sliced down to just the second request's bytes, the parser state is fully cleared, and the second `feed()` cycles through header parsing and body capture exactly like a fresh `McpHttpParser` would.

## Test Coverage
**Added:** `tests/unit/test_mcp_http_parser.cpp::resetPreservesLeftoverForPipelinedRequest`.

## Scope of Change
- **Files changed:**
  - `src/mcp/McpHttpParser.cpp` (preserve-leftover logic in `reset()`)
  - `src/mcp/McpServer.cpp` (drain loop after first dispatch)
  - `tests/unit/test_mcp_http_parser.cpp` (new regression test)
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

## Risk and Rollout
Local to the MCP transport's request boundary handling. The well-behaved single-request-per-connection case is byte-identical before and after the change (after a request body is parsed, `m_buffer` is sliced to size zero, equivalent to the old `clear()`). The new behaviour only deviates when there are leftover bytes in the buffer — exactly the case the bug was dropping. Each iteration of the drain loop runs `handleHttpRequest` synchronously, so dispatch order is preserved and the existing `QPointer` guards continue to protect against nested-event-loop disconnects.

## Notes
The server's own responses still set `Connection: close`, so most well-behaved clients do not pipeline today; this fix removes the silent-drop failure mode for clients that do.
