### PR TITLE
[enhancement] Add an option to replay a session from a PCAP (#30)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,8 @@ set(CORE_SOURCES
     src/core/macro_to_script.h
     src/core/command_runner.cpp
     src/core/command_runner.h
+    src/core/pcap_replay.cpp
+    src/core/pcap_replay.h
 )
 
 set(SESSION_SOURCES
@@ -289,6 +291,7 @@ set(UI_SOURCES
     src/ui/actions/onToggleAgentPanel.cpp
     src/ui/actions/onMatchReplace.cpp
     src/ui/actions/onVirtualKeyboard.cpp
+    src/ui/actions/onReplayPcap.cpp
     # setup
     src/ui/setup/setupUI.cpp
     src/ui/setup/setupMenuBar.cpp
@@ -416,6 +419,7 @@ if(BUILD_TESTS)
     add_tn5250_test(test_codepage tests/unit/test_codepage.cpp)
 
     add_tn5250_test(test_terminal_theme tests/unit/test_terminal_theme.cpp)
+    add_tn5250_test(test_pcap_replay tests/unit/test_pcap_replay.cpp)
 
     # Host server tests
     add_tn5250_test(test_host_data_stream tests/unit/test_host_data_stream.cpp)

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@
  - [x] Code page support: `CP037`, `CP273`, `CP277`, `CP278`, `CP280`, `CP284`, `CP285`, `CP297`, `CP500`, `CP870`, `CP420`, `CP424`, `CP838`
  - [x] Hotspot detection, screen history/scrollback, regex match & replace, session logging
  - [x] Session logging with configurable verbosity (screens only, screens + keys, full protocol)
+ - [x] Session replay from pcap/pcapng capture files with original timing
  - [x] Screenshot capture to PNG
  - [x] Cross-platform: Linux, macOS, and Windows
 
@@ -104,6 +105,7 @@ Options:
   --tls                            Use TLS/SSL encryption
   -s, --load-session-from-name     Load a saved session by name
   -f, --load-session-from-file     Load a session from a JSON file
+  --replay-pcap <path>             Replay a TN5250 session from a pcap/pcapng capture file
   --enable-mcp-server              Enable the MCP server on startup
   --mcp-server-port <port>         MCP server port (default: 9250)
   -d, --debug                      Enable debug output
@@ -127,6 +129,12 @@ Options:
 
     ```
     ./build/bin/5250ng --load-session-from-name "Production AS400"
+    ```
+
+ + Replay a captured session from a PCAP file (also available via File → Replay Session from PCAP):
+
+    ```
+    ./build/bin/5250ng --replay-pcap session-capture.pcapng
     ```
 
  + Start with the MCP server enabled:

--- a/src/core/pcap_replay.cpp
+++ b/src/core/pcap_replay.cpp
@@ -1,0 +1,705 @@
+// 5250ng - A modern IBM TN5250 terminal emulator
+// Copyright (C) 2025-2026 Remi GASCOU (Podalirius)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include "pcap_replay.h"
+#include "network/tn5250_qt/telnet/commands.h"
+#include <QFile>
+#include <QHash>
+#include <QHostAddress>
+#include <algorithm>
+
+namespace core::pcap {
+
+namespace {
+
+using telnet::TelnetCommand;
+
+// ---------------------------------------------------------------------------
+// Endian-aware integer reads
+// ---------------------------------------------------------------------------
+
+quint16 readU16(const uchar *p, bool bigEndian) {
+    return bigEndian ? static_cast<quint16>((p[0] << 8) | p[1])
+                     : static_cast<quint16>((p[1] << 8) | p[0]);
+}
+
+quint32 readU32(const uchar *p, bool bigEndian) {
+    return bigEndian
+        ? (quint32(p[0]) << 24) | (quint32(p[1]) << 16) | (quint32(p[2]) << 8) | quint32(p[3])
+        : (quint32(p[3]) << 24) | (quint32(p[2]) << 16) | (quint32(p[1]) << 8) | quint32(p[0]);
+}
+
+// Network byte order (big-endian) reads used by all protocol headers
+quint16 readBE16(const uchar *p) { return readU16(p, true); }
+quint32 readBE32(const uchar *p) { return readU32(p, true); }
+
+// ---------------------------------------------------------------------------
+// Capture container parsing
+// ---------------------------------------------------------------------------
+
+// Link-layer types (https://www.tcpdump.org/linktypes.html)
+constexpr quint32 LINKTYPE_NULL = 0;
+constexpr quint32 LINKTYPE_ETHERNET = 1;
+constexpr quint32 LINKTYPE_RAW = 101;
+constexpr quint32 LINKTYPE_LOOP = 108;
+constexpr quint32 LINKTYPE_LINUX_SLL = 113;
+constexpr quint32 LINKTYPE_LINUX_SLL2 = 276;
+
+struct RawPacket {
+    qint64 tsUsec = 0;
+    quint32 linkType = LINKTYPE_ETHERNET;
+    QByteArray frame;
+};
+
+// Classic pcap magic numbers as read little-endian from the file
+constexpr quint32 PCAP_MAGIC_USEC = 0xA1B2C3D4;      // little-endian file, µs
+constexpr quint32 PCAP_MAGIC_USEC_SWAP = 0xD4C3B2A1; // big-endian file, µs
+constexpr quint32 PCAP_MAGIC_NSEC = 0xA1B23C4D;      // little-endian file, ns
+constexpr quint32 PCAP_MAGIC_NSEC_SWAP = 0x4D3CB2A1; // big-endian file, ns
+
+bool isClassicPcap(const QByteArray &data) {
+    if (data.size() < 4) return false;
+    quint32 magic = readU32(reinterpret_cast<const uchar *>(data.constData()), false);
+    return magic == PCAP_MAGIC_USEC || magic == PCAP_MAGIC_USEC_SWAP
+        || magic == PCAP_MAGIC_NSEC || magic == PCAP_MAGIC_NSEC_SWAP;
+}
+
+bool parseClassicPcap(const QByteArray &data, QVector<RawPacket> *out, QString *error) {
+    const uchar *d = reinterpret_cast<const uchar *>(data.constData());
+    const qsizetype size = data.size();
+    if (size < 24) {
+        if (error) *error = QStringLiteral("pcap file truncated (no global header)");
+        return false;
+    }
+    quint32 magic = readU32(d, false);
+    bool bigEndian = (magic == PCAP_MAGIC_USEC_SWAP || magic == PCAP_MAGIC_NSEC_SWAP);
+    bool nanosecond = (magic == PCAP_MAGIC_NSEC || magic == PCAP_MAGIC_NSEC_SWAP);
+    quint32 linkType = readU32(d + 20, bigEndian);
+
+    qsizetype pos = 24;
+    // Tolerate a capture cut off mid-record (live capture killed): keep the
+    // packets parsed so far instead of failing the whole load.
+    while (pos + 16 <= size) {
+        quint32 tsSec = readU32(d + pos, bigEndian);
+        quint32 tsFrac = readU32(d + pos + 4, bigEndian);
+        quint32 inclLen = readU32(d + pos + 8, bigEndian);
+        pos += 16;
+        if (inclLen > static_cast<quint64>(size - pos)) break;
+        RawPacket pkt;
+        pkt.tsUsec = qint64(tsSec) * 1000000
+                   + (nanosecond ? qint64(tsFrac) / 1000 : qint64(tsFrac));
+        pkt.linkType = linkType;
+        pkt.frame = data.mid(pos, inclLen);
+        out->append(pkt);
+        pos += inclLen;
+    }
+    return true;
+}
+
+// pcapng block types
+constexpr quint32 PCAPNG_SHB = 0x0A0D0D0A;
+constexpr quint32 PCAPNG_IDB = 0x00000001;
+constexpr quint32 PCAPNG_SPB = 0x00000003;
+constexpr quint32 PCAPNG_EPB = 0x00000006;
+constexpr quint32 PCAPNG_BYTE_ORDER_MAGIC = 0x1A2B3C4D;
+
+bool isPcapNg(const QByteArray &data) {
+    if (data.size() < 12) return false;
+    const uchar *d = reinterpret_cast<const uchar *>(data.constData());
+    // SHB block type is an endianness palindrome
+    return readU32(d, true) == PCAPNG_SHB
+        && (readU32(d + 8, true) == PCAPNG_BYTE_ORDER_MAGIC
+            || readU32(d + 8, false) == PCAPNG_BYTE_ORDER_MAGIC);
+}
+
+struct PcapNgInterface {
+    quint32 linkType = LINKTYPE_ETHERNET;
+    quint64 ticksPerSecond = 1000000; // from if_tsresol, default 10^-6
+};
+
+bool parsePcapNg(const QByteArray &data, QVector<RawPacket> *out, QString *error) {
+    const uchar *d = reinterpret_cast<const uchar *>(data.constData());
+    const qsizetype size = data.size();
+    bool bigEndian = false;
+    QVector<PcapNgInterface> interfaces;
+    qint64 lastTsUsec = 0;
+    qsizetype pos = 0;
+
+    while (pos + 12 <= size) {
+        quint32 blockType = readU32(d + pos, bigEndian);
+        if (blockType == PCAPNG_SHB) {
+            // New section: re-resolve endianness from the byte-order magic
+            if (readU32(d + pos + 8, true) == PCAPNG_BYTE_ORDER_MAGIC) {
+                bigEndian = true;
+            } else if (readU32(d + pos + 8, false) == PCAPNG_BYTE_ORDER_MAGIC) {
+                bigEndian = false;
+            } else {
+                if (error) *error = QStringLiteral("pcapng: bad byte-order magic");
+                return false;
+            }
+            blockType = readU32(d + pos, bigEndian);
+            interfaces.clear();
+        }
+        quint32 totalLen = readU32(d + pos + 4, bigEndian);
+        // Block lengths are 4-aligned and include the 12-byte envelope
+        if (totalLen < 12 || (totalLen & 3) != 0
+            || totalLen > static_cast<quint64>(size - pos)) {
+            break; // truncated or corrupt tail: keep what we have
+        }
+        const uchar *body = d + pos + 8;
+        const quint32 bodyLen = totalLen - 12;
+
+        if (blockType == PCAPNG_IDB && bodyLen >= 8) {
+            PcapNgInterface iface;
+            iface.linkType = readU16(body, bigEndian);
+            // Walk options looking for if_tsresol (code 9, length 1)
+            quint32 opt = 8;
+            while (opt + 4 <= bodyLen) {
+                quint16 code = readU16(body + opt, bigEndian);
+                quint16 len = readU16(body + opt + 2, bigEndian);
+                if (code == 0) break; // opt_endofopt
+                if (opt + 4 + len > bodyLen) break;
+                if (code == 9 && len == 1) {
+                    quint8 res = body[opt + 4];
+                    quint64 ticks = 1;
+                    if (res & 0x80) {
+                        for (int i = 0; i < (res & 0x7F) && i < 63; ++i) ticks <<= 1;
+                    } else {
+                        for (int i = 0; i < res && i < 19; ++i) ticks *= 10;
+                    }
+                    iface.ticksPerSecond = ticks;
+                }
+                opt += 4 + ((len + 3u) & ~3u);
+            }
+            interfaces.append(iface);
+        } else if (blockType == PCAPNG_EPB && bodyLen >= 20) {
+            quint32 ifId = readU32(body, bigEndian);
+            quint64 ts = (quint64(readU32(body + 4, bigEndian)) << 32)
+                       | readU32(body + 8, bigEndian);
+            quint32 capLen = readU32(body + 12, bigEndian);
+            if (capLen <= bodyLen - 20) {
+                PcapNgInterface iface = (ifId < quint32(interfaces.size()))
+                    ? interfaces[ifId] : PcapNgInterface{};
+                RawPacket pkt;
+                pkt.tsUsec = (iface.ticksPerSecond == 1000000)
+                    ? qint64(ts)
+                    : qint64((long double)ts * 1000000.0L / iface.ticksPerSecond);
+                pkt.linkType = iface.linkType;
+                pkt.frame = QByteArray(reinterpret_cast<const char *>(body + 20), capLen);
+                out->append(pkt);
+                lastTsUsec = pkt.tsUsec;
+            }
+        } else if (blockType == PCAPNG_SPB && bodyLen >= 4) {
+            quint32 origLen = readU32(body, bigEndian);
+            quint32 capLen = qMin<quint32>(origLen, bodyLen - 4);
+            PcapNgInterface iface = !interfaces.isEmpty() ? interfaces[0] : PcapNgInterface{};
+            RawPacket pkt;
+            pkt.tsUsec = lastTsUsec; // SPB carries no timestamp
+            pkt.linkType = iface.linkType;
+            pkt.frame = QByteArray(reinterpret_cast<const char *>(body + 4), capLen);
+            out->append(pkt);
+        }
+        pos += totalLen;
+    }
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// Link / network / transport decapsulation
+// ---------------------------------------------------------------------------
+
+struct ParsedTcp {
+    QByteArray srcAddr, dstAddr; // 4 (IPv4) or 16 (IPv6) bytes
+    quint16 srcPort = 0, dstPort = 0;
+    quint32 seq = 0;
+    bool syn = false, ack = false, fin = false;
+    QByteArray payload;
+};
+
+// Returns the offset of the IP header within the frame and sets *ipVersion,
+// or -1 if the frame does not carry IP.
+qsizetype decapLink(const RawPacket &pkt, int *ipVersion) {
+    const uchar *d = reinterpret_cast<const uchar *>(pkt.frame.constData());
+    const qsizetype size = pkt.frame.size();
+
+    auto versionFromEtherType = [](quint16 et) -> int {
+        if (et == 0x0800) return 4;
+        if (et == 0x86DD) return 6;
+        return 0;
+    };
+
+    switch (pkt.linkType) {
+    case LINKTYPE_ETHERNET: {
+        qsizetype off = 14;
+        if (size < off) return -1;
+        quint16 etherType = readBE16(d + 12);
+        // Skip 802.1Q / 802.1ad VLAN tags
+        while ((etherType == 0x8100 || etherType == 0x88A8 || etherType == 0x9100)
+               && size >= off + 4) {
+            etherType = readBE16(d + off + 2);
+            off += 4;
+        }
+        int v = versionFromEtherType(etherType);
+        if (!v) return -1;
+        *ipVersion = v;
+        return off;
+    }
+    case LINKTYPE_LINUX_SLL: {
+        if (size < 16) return -1;
+        int v = versionFromEtherType(readBE16(d + 14));
+        if (!v) return -1;
+        *ipVersion = v;
+        return 16;
+    }
+    case LINKTYPE_LINUX_SLL2: {
+        if (size < 20) return -1;
+        int v = versionFromEtherType(readBE16(d));
+        if (!v) return -1;
+        *ipVersion = v;
+        return 20;
+    }
+    case LINKTYPE_NULL:
+    case LINKTYPE_LOOP: {
+        if (size < 4) return -1;
+        // The 4-byte address family is written in the capture host's byte
+        // order for NULL and big-endian for LOOP; accept either.
+        quint32 famLE = readU32(d, false);
+        quint32 famBE = readU32(d, true);
+        auto familyToVersion = [](quint32 fam) -> int {
+            if (fam == 2) return 4;                            // AF_INET
+            if (fam == 24 || fam == 28 || fam == 30) return 6; // AF_INET6 variants
+            return 0;
+        };
+        int v = familyToVersion(famLE);
+        if (!v) v = familyToVersion(famBE);
+        if (!v) return -1;
+        *ipVersion = v;
+        return 4;
+    }
+    case LINKTYPE_RAW: {
+        if (size < 1) return -1;
+        int v = d[0] >> 4;
+        if (v != 4 && v != 6) return -1;
+        *ipVersion = v;
+        return 0;
+    }
+    default:
+        return -1;
+    }
+}
+
+bool parseTcpPacket(const RawPacket &pkt, ParsedTcp *out) {
+    int ipVersion = 0;
+    qsizetype ipOff = decapLink(pkt, &ipVersion);
+    if (ipOff < 0) return false;
+
+    const uchar *d = reinterpret_cast<const uchar *>(pkt.frame.constData());
+    const qsizetype size = pkt.frame.size();
+    qsizetype tcpOff = 0;
+    qsizetype ipPayloadEnd = 0;
+
+    if (ipVersion == 4) {
+        if (size < ipOff + 20) return false;
+        const uchar *ip = d + ipOff;
+        if ((ip[0] >> 4) != 4) return false;
+        const qsizetype ihl = (ip[0] & 0x0F) * 4;
+        if (ihl < 20 || size < ipOff + ihl) return false;
+        // Skip fragmented packets: MF set or fragment offset non-zero
+        quint16 fragField = readBE16(ip + 6);
+        if ((fragField & 0x2000) || (fragField & 0x1FFF)) return false;
+        if (ip[9] != 6) return false; // not TCP
+        qsizetype totalLen = readBE16(ip + 2);
+        // Bound by the IP total length to trim Ethernet trailer padding
+        ipPayloadEnd = qMin<qsizetype>(size, ipOff + totalLen);
+        tcpOff = ipOff + ihl;
+        out->srcAddr = QByteArray(reinterpret_cast<const char *>(ip + 12), 4);
+        out->dstAddr = QByteArray(reinterpret_cast<const char *>(ip + 16), 4);
+    } else {
+        if (size < ipOff + 40) return false;
+        const uchar *ip = d + ipOff;
+        if ((ip[0] >> 4) != 6) return false;
+        qsizetype payloadLen = readBE16(ip + 4);
+        quint8 nextHeader = ip[6];
+        out->srcAddr = QByteArray(reinterpret_cast<const char *>(ip + 8), 16);
+        out->dstAddr = QByteArray(reinterpret_cast<const char *>(ip + 24), 16);
+        qsizetype hdrOff = ipOff + 40;
+        ipPayloadEnd = qMin<qsizetype>(size, hdrOff + payloadLen);
+        // Walk extension headers until TCP
+        while (nextHeader != 6) {
+            if (nextHeader == 0 || nextHeader == 43 || nextHeader == 60) {
+                if (ipPayloadEnd < hdrOff + 8) return false;
+                quint8 next = d[hdrOff];
+                qsizetype extLen = (d[hdrOff + 1] + 1) * 8;
+                nextHeader = next;
+                hdrOff += extLen;
+            } else if (nextHeader == 44) { // fragment header
+                if (ipPayloadEnd < hdrOff + 8) return false;
+                quint16 fragField = readBE16(d + hdrOff + 2);
+                if (fragField & 0xFFF9) return false; // offset != 0 or MF set
+                nextHeader = d[hdrOff];
+                hdrOff += 8;
+            } else {
+                return false; // unsupported header chain
+            }
+        }
+        tcpOff = hdrOff;
+    }
+
+    if (ipPayloadEnd < tcpOff + 20) return false;
+    const uchar *tcp = d + tcpOff;
+    const qsizetype dataOff = (tcp[12] >> 4) * 4;
+    if (dataOff < 20 || ipPayloadEnd < tcpOff + dataOff) return false;
+    out->srcPort = readBE16(tcp);
+    out->dstPort = readBE16(tcp + 2);
+    out->seq = readBE32(tcp + 4);
+    quint8 flags = tcp[13];
+    out->syn = flags & 0x02;
+    out->ack = flags & 0x10;
+    out->fin = flags & 0x01;
+    out->payload = pkt.frame.mid(tcpOff + dataOff, ipPayloadEnd - tcpOff - dataOff);
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// TCP flow tracking and reassembly
+// ---------------------------------------------------------------------------
+
+struct Endpoint {
+    QByteArray addr;
+    quint16 port = 0;
+
+    bool operator==(const Endpoint &o) const { return port == o.port && addr == o.addr; }
+    bool operator<(const Endpoint &o) const {
+        if (addr != o.addr) return addr < o.addr;
+        return port < o.port;
+    }
+    QString toString() const {
+        QHostAddress ha;
+        if (addr.size() == 4) {
+            ha.setAddress(readBE32(reinterpret_cast<const uchar *>(addr.constData())));
+        } else if (addr.size() == 16) {
+            ha.setAddress(reinterpret_cast<const quint8 *>(addr.constData()));
+        }
+        QString s = ha.toString();
+        return addr.size() == 16 ? QStringLiteral("[%1]:%2").arg(s).arg(port)
+                                 : QStringLiteral("%1:%2").arg(s).arg(port);
+    }
+};
+
+struct TcpSegment {
+    qint64 tsUsec = 0;
+    quint32 seq = 0;
+    QByteArray payload;
+};
+
+struct FlowDirection {
+    bool sawSyn = false;
+    bool sawSynAck = false;
+    bool isnKnown = false;
+    quint32 isn = 0; // sequence number of the SYN
+    qint64 payloadBytes = 0;
+    QVector<TcpSegment> segments;
+};
+
+struct Flow {
+    Endpoint a, b;       // a < b (canonical order)
+    FlowDirection ab, ba; // a→b and b→a
+    qint64 firstTsUsec = 0;
+};
+
+// A contiguous run of reassembled stream bytes with the timestamp of the
+// packet that carried them.
+struct StreamChunk {
+    qint64 tsUsec = 0;
+    QByteArray data;
+};
+
+QVector<StreamChunk> reassembleDirection(const FlowDirection &dir) {
+    QVector<StreamChunk> chunks;
+    if (dir.segments.isEmpty()) return chunks;
+
+    // Establish the stream base: first byte after the SYN when we saw the
+    // handshake, otherwise the smallest sequence number relative to the
+    // earliest segment (signed 32-bit distance handles wraparound).
+    quint32 base;
+    if (dir.isnKnown) {
+        base = dir.isn + 1;
+    } else {
+        base = dir.segments.first().seq;
+        for (const TcpSegment &s : dir.segments) {
+            if (qint32(s.seq - base) < 0) base = s.seq;
+        }
+    }
+
+    QVector<const TcpSegment *> ordered;
+    ordered.reserve(dir.segments.size());
+    for (const TcpSegment &s : dir.segments) ordered.append(&s);
+    std::stable_sort(ordered.begin(), ordered.end(),
+        [base](const TcpSegment *l, const TcpSegment *r) {
+            return qint32(l->seq - base) < qint32(r->seq - base);
+        });
+
+    qint64 nextExpected = 0;
+    for (const TcpSegment *s : ordered) {
+        qint64 relStart = qint64(qint32(s->seq - base));
+        if (relStart > nextExpected) {
+            // Hole in the capture: bytes were lost. The telnet stream can't
+            // be parsed past the gap, so stop here.
+            break;
+        }
+        qint64 skip = nextExpected - relStart; // retransmitted/overlapping prefix
+        if (skip >= s->payload.size()) continue;
+        StreamChunk chunk;
+        chunk.tsUsec = s->tsUsec;
+        chunk.data = s->payload.mid(skip);
+        nextExpected += chunk.data.size();
+        chunks.append(chunk);
+    }
+    return chunks;
+}
+
+// ---------------------------------------------------------------------------
+// Passive telnet stream extraction
+// ---------------------------------------------------------------------------
+
+// Strips the telnet layer from a reassembled host→client stream and splits
+// the application data into records at IAC EOR boundaries. Mirrors the
+// parsing semantics of TN5250Client::processTelnetData, minus the replies.
+QVector<ReplayRecord> extractRecords(const QVector<StreamChunk> &chunks) {
+    QByteArray stream;
+    QVector<qsizetype> chunkEnds;
+    QVector<qint64> chunkTs;
+    for (const StreamChunk &c : chunks) {
+        stream.append(c.data);
+        chunkEnds.append(stream.size());
+        chunkTs.append(c.tsUsec);
+    }
+
+    int tsIdx = 0;
+    auto timestampAt = [&](qsizetype offset) -> qint64 {
+        while (tsIdx < chunkEnds.size() - 1 && offset >= chunkEnds[tsIdx]) tsIdx++;
+        return chunkTs.isEmpty() ? 0 : chunkTs[tsIdx];
+    };
+
+    QVector<ReplayRecord> records;
+    QByteArray current;
+    qint64 currentTs = 0;
+    bool inSubnegotiation = false;
+    const uchar IAC = static_cast<uchar>(TelnetCommand::IAC);
+
+    qsizetype i = 0;
+    const qsizetype size = stream.size();
+    while (i < size) {
+        uchar byte = static_cast<uchar>(stream[i]);
+
+        if (byte == IAC) {
+            if (i + 1 >= size) break; // truncated escape at capture end
+            uchar next = static_cast<uchar>(stream[i + 1]);
+
+            if (next == IAC) {
+                // Literal 0xFF. Inside a subnegotiation it belongs to the SB
+                // payload (which replay discards); outside it is app data.
+                if (!inSubnegotiation) {
+                    current.append(char(0xFF));
+                    currentTs = timestampAt(i);
+                }
+                i += 2;
+                continue;
+            }
+
+            if (telnet::isStandaloneTelnetCommand(next)) {
+                if (next == static_cast<uchar>(TelnetCommand::SE)) {
+                    inSubnegotiation = false;
+                } else if (next == static_cast<uchar>(TelnetCommand::EOR)) {
+                    if (!current.isEmpty()) {
+                        records.append({timestampAt(i), current});
+                        current.clear();
+                    }
+                }
+                i += 2;
+                continue;
+            }
+
+            // WILL / WONT / DO / DONT / SB take an option byte
+            if (i + 2 >= size) break;
+            if (next == static_cast<uchar>(TelnetCommand::SB)) {
+                inSubnegotiation = true;
+            }
+            i += 3;
+        } else if (inSubnegotiation) {
+            i++;
+        } else {
+            current.append(char(byte));
+            currentTs = timestampAt(i);
+            i++;
+        }
+    }
+
+    // Capture ended mid-record (no final IAC EOR): keep what we have, the
+    // decoder parses by GDS length prefix and tolerates a short tail.
+    if (!current.isEmpty()) {
+        records.append({currentTs, current});
+    }
+    return records;
+}
+
+// A direction looks like TN5250 when its stream opens with telnet
+// negotiation (IAC) or, for captures started mid-session, directly with a
+// GDS record (record type 0x12A0 at offset 2 of the length-prefixed record).
+bool looksLikeTn5250(const FlowDirection &dir) {
+    for (const TcpSegment &s : dir.segments) {
+        if (s.payload.isEmpty()) continue;
+        if (static_cast<uchar>(s.payload[0]) == static_cast<uchar>(TelnetCommand::IAC)) {
+            return true;
+        }
+        return s.payload.size() >= 4
+            && static_cast<uchar>(s.payload[2]) == 0x12
+            && static_cast<uchar>(s.payload[3]) == 0xA0;
+    }
+    return false;
+}
+
+bool isTelnetServerPort(quint16 port) {
+    return port == 23 || port == 992;
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// PcapReplayLoader
+// ---------------------------------------------------------------------------
+
+bool PcapReplayLoader::loadFile(const QString &path, ReplaySession *out, QString *error) {
+    QFile file(path);
+    if (!file.open(QIODevice::ReadOnly)) {
+        if (error) *error = QStringLiteral("Cannot open file: %1").arg(path);
+        return false;
+    }
+    return loadData(file.readAll(), out, error);
+}
+
+bool PcapReplayLoader::loadData(const QByteArray &data, ReplaySession *out, QString *error) {
+    QVector<RawPacket> packets;
+    if (isClassicPcap(data)) {
+        if (!parseClassicPcap(data, &packets, error)) return false;
+    } else if (isPcapNg(data)) {
+        if (!parsePcapNg(data, &packets, error)) return false;
+    } else {
+        if (error) *error = QStringLiteral("Not a pcap or pcapng capture file");
+        return false;
+    }
+
+    // Group TCP segments into bidirectional flows
+    QVector<Flow> flows;
+    QHash<QByteArray, int> flowIndex;
+    for (const RawPacket &pkt : packets) {
+        ParsedTcp tcp;
+        if (!parseTcpPacket(pkt, &tcp)) continue;
+
+        Endpoint src{tcp.srcAddr, tcp.srcPort};
+        Endpoint dst{tcp.dstAddr, tcp.dstPort};
+        bool srcIsA = src < dst;
+        const Endpoint &a = srcIsA ? src : dst;
+        const Endpoint &b = srcIsA ? dst : src;
+
+        QByteArray key = a.addr;
+        key.append(reinterpret_cast<const char *>(&a.port), 2);
+        key.append(b.addr);
+        key.append(reinterpret_cast<const char *>(&b.port), 2);
+
+        int idx = flowIndex.value(key, -1);
+        if (idx < 0) {
+            idx = flows.size();
+            flowIndex.insert(key, idx);
+            Flow flow;
+            flow.a = a;
+            flow.b = b;
+            flow.firstTsUsec = pkt.tsUsec;
+            flows.append(flow);
+        }
+        FlowDirection &dir = srcIsA ? flows[idx].ab : flows[idx].ba;
+
+        if (tcp.syn) {
+            dir.sawSyn = true;
+            dir.sawSynAck = tcp.ack;
+            dir.isnKnown = true;
+            dir.isn = tcp.seq;
+        }
+        if (!tcp.payload.isEmpty()) {
+            TcpSegment seg;
+            seg.tsUsec = pkt.tsUsec;
+            seg.seq = tcp.seq;
+            seg.payload = tcp.payload;
+            dir.payloadBytes += tcp.payload.size();
+            dir.segments.append(seg);
+        }
+    }
+
+    if (flows.isEmpty()) {
+        if (error) *error = QStringLiteral("No TCP traffic found in capture");
+        return false;
+    }
+
+    // Select the telnet/TN5250 flow: a flow where at least one direction's
+    // stream opens with telnet negotiation or GDS records. Among candidates
+    // take the one with the most payload. A capture without any such flow is
+    // rejected — replaying arbitrary TCP bytes through the 5250 decoder
+    // would only render garbage.
+    Flow *selected = nullptr;
+    qint64 selectedBytes = -1;
+    for (Flow &flow : flows) {
+        if (!looksLikeTn5250(flow.ab) && !looksLikeTn5250(flow.ba)) continue;
+        qint64 bytes = flow.ab.payloadBytes + flow.ba.payloadBytes;
+        if (bytes > selectedBytes) {
+            selected = &flow;
+            selectedBytes = bytes;
+        }
+    }
+    if (!selected) {
+        if (error) *error = QStringLiteral("No telnet/TN5250 flow found in capture");
+        return false;
+    }
+
+    // Identify the server→client direction:
+    // 1. The direction that sent SYN+ACK is from the server.
+    // 2. A plain SYN identifies the client side.
+    // 3. A well-known telnet port (23/992) identifies the server endpoint.
+    // 4. Fall back to the direction with more payload (the host sends far
+    //    more data than the terminal).
+    bool serverIsA;
+    if (selected->ab.sawSynAck || selected->ba.sawSynAck) {
+        serverIsA = selected->ab.sawSynAck;
+    } else if (selected->ab.sawSyn || selected->ba.sawSyn) {
+        serverIsA = selected->ba.sawSyn;
+    } else if (isTelnetServerPort(selected->a.port) != isTelnetServerPort(selected->b.port)) {
+        serverIsA = isTelnetServerPort(selected->a.port);
+    } else {
+        serverIsA = selected->ab.payloadBytes >= selected->ba.payloadBytes;
+    }
+
+    const FlowDirection &hostToClient = serverIsA ? selected->ab : selected->ba;
+    out->serverEndpoint = (serverIsA ? selected->a : selected->b).toString();
+    out->clientEndpoint = (serverIsA ? selected->b : selected->a).toString();
+    out->records = extractRecords(reassembleDirection(hostToClient));
+
+    if (out->records.isEmpty()) {
+        if (error) *error = QStringLiteral("No TN5250 session data found in capture");
+        return false;
+    }
+    return true;
+}
+
+} // namespace core::pcap

--- a/src/core/pcap_replay.h
+++ b/src/core/pcap_replay.h
@@ -1,0 +1,66 @@
+// 5250ng - A modern IBM TN5250 terminal emulator
+// Copyright (C) 2025-2026 Remi GASCOU (Podalirius)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <QByteArray>
+#include <QString>
+#include <QVector>
+#include <cstdint>
+
+namespace core::pcap {
+
+// One host→client TN5250 GDS record extracted from a capture. The telnet
+// layer (IAC negotiation, subnegotiations, IAC IAC escaping, IAC EOR record
+// terminators) has already been removed: `data` is exactly what the live
+// client would emit via TN5250Client::dataReceived for one record.
+struct ReplayRecord {
+    qint64 timestampUsec = 0; // capture timestamp of the packet that completed the record
+    QByteArray data;          // raw GDS record bytes
+};
+
+// A replayable TN5250 session extracted from a capture file.
+struct ReplaySession {
+    QVector<ReplayRecord> records;
+    QString serverEndpoint; // "address:port" of the AS/400 side
+    QString clientEndpoint; // "address:port" of the terminal side
+};
+
+// Loads a TN5250 session from a packet capture.
+//
+// Supported containers: classic pcap (both endiannesses, microsecond and
+// nanosecond timestamp variants) and pcapng (Section Header / Interface
+// Description / Enhanced Packet / Simple Packet blocks).
+// Supported link layers: Ethernet (including 802.1Q/802.1ad VLAN tags),
+// Linux cooked SLL and SLL2, raw IP, and BSD loopback (NULL/LOOP).
+// IPv4 and IPv6 are supported; fragmented IP packets are ignored.
+//
+// The loader reassembles every TCP flow in the capture, selects the flow
+// that carries telnet/TN5250 traffic (and within it the host→client
+// direction), strips the telnet layer, and splits the application stream
+// into GDS records at IAC EOR boundaries.
+class PcapReplayLoader {
+  public:
+    // Reads `path` and extracts the session. Returns false and sets *error
+    // (if non-null) when the file cannot be read, is not a recognized
+    // capture format, or contains no TN5250 session data.
+    static bool loadFile(const QString &path, ReplaySession *out, QString *error);
+
+    // Same as loadFile but operates on an in-memory capture image.
+    static bool loadData(const QByteArray &data, ReplaySession *out, QString *error);
+};
+
+} // namespace core::pcap

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,6 +34,7 @@
 #include <QJsonObject>
 #include <QStandardPaths>
 #include <QStyleFactory>
+#include <QTimer>
 
 #ifdef Q_OS_WIN
 #include <windows.h>
@@ -97,6 +98,10 @@ int main(int argc, char *argv[]) {
     QCommandLineOption sessionFileOption(QStringList() << "f" << "load-session-from-file", "Load a session from a JSON file", "path");
     parser.addOption(sessionFileOption);
 
+    // PCAP replay option (replay a captured session instead of connecting)
+    QCommandLineOption replayPcapOption(QStringList() << "replay-pcap", "Replay a TN5250 session from a pcap/pcapng capture file", "path");
+    parser.addOption(replayPcapOption);
+
     // MCP server options
     QCommandLineOption mcpEnableOption(QStringList() << "enable-mcp-server", "Enable the MCP server on startup");
     parser.addOption(mcpEnableOption);
@@ -122,12 +127,25 @@ int main(int argc, char *argv[]) {
 
     int connectOptionCount = (parser.isSet(hostOption) ? 1 : 0)
                            + (parser.isSet(sessionOption) ? 1 : 0)
-                           + (parser.isSet(sessionFileOption) ? 1 : 0);
+                           + (parser.isSet(sessionFileOption) ? 1 : 0)
+                           + (parser.isSet(replayPcapOption) ? 1 : 0);
     if (connectOptionCount > 1) {
         logger::Logger::instance()->error(
-            "Options --host, --session, and --session-file are mutually exclusive"
+            "Options --host, --load-session-from-name, --load-session-from-file, "
+            "and --replay-pcap are mutually exclusive"
         );
         return 1;
+    }
+
+    QString replayPcapPath;
+    if (parser.isSet(replayPcapOption)) {
+        replayPcapPath = parser.value(replayPcapOption);
+        if (!QFile::exists(replayPcapPath)) {
+            logger::Logger::instance()->error(
+                QString("Capture file not found: %1").arg(replayPcapPath)
+            );
+            return 1;
+        }
     }
 
     if (parser.isSet(sessionOption)) {
@@ -252,6 +270,12 @@ int main(int argc, char *argv[]) {
     // Auto-connect if host was provided
     if (autoConnect) {
         win.autoConnect(autoConnectConfig);
+    } else if (!replayPcapPath.isEmpty()) {
+        // Open the replay tab once the event loop is running, mirroring
+        // the autoConnect() startup deferral.
+        QTimer::singleShot(100, &win, [&win, replayPcapPath]() {
+            win.startPcapReplay(replayPcapPath);
+        });
     }
 
     return app.exec();

--- a/src/session/config.cpp
+++ b/src/session/config.cpp
@@ -23,7 +23,7 @@ namespace session {
 
 SessionConfig::SessionConfig(QObject *parent) : QObject(parent), m_name("New Session"), m_hostname(""), m_port(23), m_useTLS(false), m_deviceType("IBM-3179-2"), m_deviceName(""), m_screenRows(24), m_screenCols(80), m_codePage(core::CodePage::ID::CP037), m_terminalThemeId("classic_green") {}
 
-SessionConfig::SessionConfig(const SessionConfig &other) : QObject(other.parent()), m_name(other.m_name), m_hostname(other.m_hostname), m_port(other.m_port), m_useTLS(other.m_useTLS), m_allowInvalidCertificates(other.m_allowInvalidCertificates), m_deviceType(other.m_deviceType), m_deviceName(other.m_deviceName), m_screenRows(other.m_screenRows), m_screenCols(other.m_screenCols), m_codePage(other.m_codePage), m_terminalThemeId(other.m_terminalThemeId), m_startupScriptSource(other.m_startupScriptSource), m_startupScriptName(other.m_startupScriptName), m_sessionVariables(other.m_sessionVariables), m_username(other.m_username), m_password(other.m_password), m_pcCommandPolicy(other.m_pcCommandPolicy) {}
+SessionConfig::SessionConfig(const SessionConfig &other) : QObject(other.parent()), m_name(other.m_name), m_hostname(other.m_hostname), m_port(other.m_port), m_useTLS(other.m_useTLS), m_allowInvalidCertificates(other.m_allowInvalidCertificates), m_deviceType(other.m_deviceType), m_deviceName(other.m_deviceName), m_screenRows(other.m_screenRows), m_screenCols(other.m_screenCols), m_codePage(other.m_codePage), m_terminalThemeId(other.m_terminalThemeId), m_startupScriptSource(other.m_startupScriptSource), m_startupScriptName(other.m_startupScriptName), m_sessionVariables(other.m_sessionVariables), m_username(other.m_username), m_password(other.m_password), m_pcCommandPolicy(other.m_pcCommandPolicy), m_replayPcapFile(other.m_replayPcapFile) {}
 
 SessionConfig &SessionConfig::operator=(const SessionConfig &other) {
     if (this != &other) {
@@ -44,6 +44,7 @@ SessionConfig &SessionConfig::operator=(const SessionConfig &other) {
         m_username = other.m_username;
         m_password = other.m_password;
         m_pcCommandPolicy = other.m_pcCommandPolicy;
+        m_replayPcapFile = other.m_replayPcapFile;
         emit changed();
     }
     return *this;

--- a/src/session/config.h
+++ b/src/session/config.h
@@ -113,6 +113,13 @@ class SessionConfig : public QObject {
     PcCommandPolicy pcCommandPolicy() const { return m_pcCommandPolicy; }
     void setPcCommandPolicy(PcCommandPolicy policy) { m_pcCommandPolicy = policy; }
 
+    // Path to a pcap/pcapng capture to replay instead of opening a live
+    // connection. Transient: never serialized to JSON — a replay session is
+    // bound to a file picked at open time, not a saved profile.
+    QString replayPcapFile() const { return m_replayPcapFile; }
+    void setReplayPcapFile(const QString &path) { m_replayPcapFile = path; }
+    bool isReplay() const { return !m_replayPcapFile.isEmpty(); }
+
     // Serialization
     QJsonObject toJson() const;
     bool fromJson(const QJsonObject &json);
@@ -141,6 +148,7 @@ class SessionConfig : public QObject {
     QString m_username;
     QString m_password;
     PcCommandPolicy m_pcCommandPolicy = PcCommandPolicy::DenyAndAlert;
+    QString m_replayPcapFile;
 
 };
 

--- a/src/session/worker.cpp
+++ b/src/session/worker.cpp
@@ -18,10 +18,19 @@
 #include "logger/logger.h"
 #include "tn5250/message/message.h"
 #include <QThread>
+#include <QTimer>
 #include <sstream>
 #include <vector>
 
 namespace tn5250::session {
+
+namespace {
+// Replay pacing: original capture timing, clamped so the replay neither
+// flashes past multi-record bursts nor stalls on operator think time.
+constexpr int kReplayInitialDelayMs = 250;
+constexpr qint64 kReplayMinStepMs = 40;
+constexpr qint64 kReplayMaxStepMs = 1000;
+} // namespace
 
 Worker::Worker(QObject *parent)
     : QObject(parent), m_client(nullptr) {}
@@ -35,6 +44,10 @@ void Worker::setConfig(const ::session::SessionConfig &cfg) {
 }
 
 void Worker::start() {
+    if (m_config.isReplay()) {
+        startReplay();
+        return;
+    }
     if (m_client) {
         return;
     }
@@ -71,6 +84,15 @@ void Worker::stop() {
     // Disconnect logger before destroying client to prevent use-after-free
     // from DirectConnection signals arriving from other threads
     disconnect(logger::Logger::instance(), nullptr, this, nullptr);
+    if (m_replayTimer) {
+        m_replayTimer->stop();
+        m_replayTimer->deleteLater();
+        m_replayTimer = nullptr;
+        m_replayRecords.clear();
+        m_replayIndex = 0;
+        emit stateChanged(tn5250::client::TN5250Client::ConnectionState::Disconnected);
+        emit disconnected();
+    }
     if (!m_client) {
         return;
     }
@@ -123,6 +145,60 @@ void Worker::onClientData(const QByteArray &data) {
     }
 
     emit appData(data);
+}
+
+void Worker::startReplay() {
+    if (m_replayTimer) {
+        return;
+    }
+    core::pcap::ReplaySession replay;
+    QString err;
+    if (!core::pcap::PcapReplayLoader::loadFile(m_config.replayPcapFile(), &replay, &err)) {
+        logger::Logger::instance()->error(
+            QString("[Worker] PCAP replay failed: %1").arg(err));
+        emit errorOccurred(err);
+        emit stateChanged(tn5250::client::TN5250Client::ConnectionState::Disconnected);
+        return;
+    }
+    logger::Logger::instance()->debug(
+        QString("[Worker] Replaying %1 records from %2 (server %3, client %4)")
+            .arg(replay.records.size())
+            .arg(m_config.replayPcapFile())
+            .arg(replay.serverEndpoint)
+            .arg(replay.clientEndpoint));
+
+    m_replayRecords = replay.records;
+    m_replayIndex = 0;
+    emit stateChanged(tn5250::client::TN5250Client::ConnectionState::Connected);
+    emit connected();
+
+    m_replayTimer = new QTimer(this);
+    m_replayTimer->setSingleShot(true);
+    connect(m_replayTimer, &QTimer::timeout, this, &Worker::onReplayTick);
+    m_replayTimer->start(kReplayInitialDelayMs);
+}
+
+void Worker::onReplayTick() {
+    if (m_replayIndex >= m_replayRecords.size()) {
+        return;
+    }
+    const QByteArray data = m_replayRecords[m_replayIndex].data;
+    const qint64 tsUsec = m_replayRecords[m_replayIndex].timestampUsec;
+    m_replayIndex++;
+
+    if (m_replayIndex < m_replayRecords.size()) {
+        const qint64 deltaMs =
+            (m_replayRecords[m_replayIndex].timestampUsec - tsUsec) / 1000;
+        m_replayTimer->start(
+            static_cast<int>(qBound(kReplayMinStepMs, deltaMs, kReplayMaxStepMs)));
+    }
+
+    onClientData(data);
+
+    if (m_replayIndex >= m_replayRecords.size()) {
+        logger::Logger::instance()->debug("[Worker] Replay finished");
+        emit replayFinished();
+    }
 }
 
 } // namespace tn5250::session

--- a/src/session/worker.h
+++ b/src/session/worker.h
@@ -16,10 +16,13 @@
 
 #pragma once
 
+#include "core/pcap_replay.h"
 #include "network/tn5250_qt/client/client.h"
 #include "session/config.h"
 #include <QByteArray>
 #include <QObject>
+
+class QTimer;
 
 namespace tn5250::session {
 
@@ -45,12 +48,21 @@ class Worker : public QObject {
     void errorOccurred(const QString &error);
     void stateChanged(tn5250::client::TN5250Client::ConnectionState state);
     void appData(const QByteArray &data);
+    // Emitted by replay sessions once the last captured record was delivered.
+    void replayFinished();
 
   private:
     ::session::SessionConfig m_config;
     tn5250::client::TN5250Client *m_client;
 
+    // PCAP replay state (active when m_config.isReplay())
+    QTimer *m_replayTimer = nullptr;
+    QVector<core::pcap::ReplayRecord> m_replayRecords;
+    int m_replayIndex = 0;
+
     void onClientData(const QByteArray &data);
+    void startReplay();
+    void onReplayTick();
 };
 
 } // namespace tn5250::session

--- a/src/ui/actions/onReplayPcap.cpp
+++ b/src/ui/actions/onReplayPcap.cpp
@@ -1,0 +1,46 @@
+// 5250ng - A modern IBM TN5250 terminal emulator
+// Copyright (C) 2025-2026 Remi GASCOU (Podalirius)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include "../main_window.h"
+#include <QFileDialog>
+#include <QFileInfo>
+
+// ---------------------------------------------------------------------------
+// Replay Session from PCAP (issue #30)
+//
+// Opens a regular session tab whose Worker, instead of connecting a socket,
+// feeds the host→client TN5250 records extracted from a capture file through
+// the normal decoder → renderer pipeline. The tab is read-only: there is no
+// peer to answer input.
+// ---------------------------------------------------------------------------
+
+void MainWindow::onReplayPcap() {
+    QString filePath = QFileDialog::getOpenFileName(this, "Replay Session from PCAP",
+        QString(), "Capture files (*.pcap *.pcapng *.cap);;All files (*)");
+    if (filePath.isEmpty()) return;
+    startPcapReplay(filePath);
+}
+
+void MainWindow::startPcapReplay(const QString &path) {
+    QFileInfo fi(path);
+    session::SessionConfig config;
+    config.setName(fi.fileName());
+    // Hostname is display-only for replay sessions (tab fallback label and
+    // SessionConfig::isValid); no connection is ever opened to it.
+    config.setHostname(fi.fileName());
+    config.setReplayPcapFile(fi.absoluteFilePath());
+    connectToServer(config);
+}

--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -504,6 +504,11 @@ void MainWindow::connectToServer(const session::SessionConfig &config,
         session->displayWidget->setReadOnly(true);
     }
 
+    // Replay sessions have no peer to answer input: lock the screen
+    if (config.isReplay()) {
+        session->displayWidget->setReadOnly(true);
+    }
+
     // Agent panel (hidden by default, second child of splitter)
     // Skipped for MCP-controlled sessions
     if (!session->mcpControlled) {
@@ -584,9 +589,11 @@ void MainWindow::connectToServer(const session::SessionConfig &config,
                 switch (state) {
                 case tn5250::client::TN5250Client::ConnectionState::Connected:
                     session->connectionStatus->setStatusText(
-                        QString("Connected to %1:%2")
-                            .arg(session->config.hostname())
-                            .arg(session->config.port()));
+                        session->config.isReplay()
+                            ? QString("Replaying %1").arg(session->config.name())
+                            : QString("Connected to %1:%2")
+                                  .arg(session->config.hostname())
+                                  .arg(session->config.port()));
                     // Run startup script once on first connect
                     if (!*startupScriptRan && !session->config.startupScriptSource().isEmpty()) {
                         *startupScriptRan = true;
@@ -646,6 +653,17 @@ void MainWindow::connectToServer(const session::SessionConfig &config,
         if (session->parser) {
             session->parser->parseData(bytes);
         } }, Qt::QueuedConnection);
+    // Replay end-of-capture: keep the final screen, update the status text
+    connect(session->worker, &tn5250::session::Worker::replayFinished, this,
+        [this, session]() {
+            if (session->connectionStatus) {
+                session->connectionStatus->setStatusText(
+                    QString("Replay finished — %1").arg(session->config.name()));
+            }
+            if (m_sessions.indexOf(session) == m_activeIndex && session->connectionStatus) {
+                m_globalConnectionStatus->setStatusText(session->connectionStatus->statusText());
+            }
+        });
     session->config = m_currentSession;
 
     // Use session name for saved sessions, ip:port for CLI/unsaved

--- a/src/ui/main_window.h
+++ b/src/ui/main_window.h
@@ -59,6 +59,10 @@ class MainWindow : public ui::widgets::BaseFramelessWindow {
     // Auto-connect on startup
     void autoConnect(const session::SessionConfig &config);
 
+    // Opens a replay tab for a pcap/pcapng capture file (also used by the
+    // --replay-pcap command line option).
+    void startPcapReplay(const QString &path);
+
   protected:
     bool eventFilter(QObject *obj, QEvent *event) override;
     void resizeEvent(QResizeEvent *event) override;
@@ -68,6 +72,7 @@ class MainWindow : public ui::widgets::BaseFramelessWindow {
   private slots:
     void onConnect();
     void onDisconnect();
+    void onReplayPcap();
     void onConnectRequested(const session::SessionConfig &config);
     void onLogMessage(logger::LogLevel level, const QString &message);
     void onCurrentTabChanged(int index);

--- a/src/ui/setup/setupMenuBar.cpp
+++ b/src/ui/setup/setupMenuBar.cpp
@@ -41,6 +41,8 @@ void MainWindow::setupMenuBar() {
         fileMenu->addAction("&Reconnect", this, &MainWindow::onReconnect);
     m_reconnectAction->setEnabled(false);
     fileMenu->addSeparator();
+    fileMenu->addAction("Replay Session from &PCAP...", this, &MainWindow::onReplayPcap);
+    fileMenu->addSeparator();
     fileMenu->addAction("&Settings...", this, &MainWindow::onOpenSettings);
     fileMenu->addSeparator();
     QMenu *mcpMenu = fileMenu->addMenu("&MCP Server");

--- a/tests/unit/test_pcap_replay.cpp
+++ b/tests/unit/test_pcap_replay.cpp
@@ -1,0 +1,656 @@
+// 5250ng - A modern IBM TN5250 terminal emulator
+// Copyright (C) 2025-2026 Remi GASCOU (Podalirius)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include "core/pcap_replay.h"
+
+#include <QtTest/QtTest>
+
+using core::pcap::PcapReplayLoader;
+using core::pcap::ReplaySession;
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// Synthetic packet builders
+// ---------------------------------------------------------------------------
+
+void appendBE16(QByteArray &b, quint16 v) {
+    b.append(char(v >> 8));
+    b.append(char(v & 0xFF));
+}
+
+void appendBE32(QByteArray &b, quint32 v) {
+    b.append(char(v >> 24));
+    b.append(char((v >> 16) & 0xFF));
+    b.append(char((v >> 8) & 0xFF));
+    b.append(char(v & 0xFF));
+}
+
+void appendLE32(QByteArray &b, quint32 v) {
+    b.append(char(v & 0xFF));
+    b.append(char((v >> 8) & 0xFF));
+    b.append(char((v >> 16) & 0xFF));
+    b.append(char(v >> 24));
+}
+
+struct TcpParams {
+    quint32 srcIp = 0;
+    quint32 dstIp = 0;
+    quint16 srcPort = 0;
+    quint16 dstPort = 0;
+    quint32 seq = 0;
+    quint32 ack = 0;
+    quint8 flags = 0x10; // ACK
+    QByteArray payload;
+    int etherPadding = 0; // trailer bytes after the IP datagram
+    bool vlanTag = false;
+};
+
+constexpr quint8 TCP_SYN = 0x02;
+constexpr quint8 TCP_ACK = 0x10;
+
+// Ethernet + IPv4 + TCP frame
+QByteArray buildFrame(const TcpParams &p) {
+    QByteArray tcp;
+    appendBE16(tcp, p.srcPort);
+    appendBE16(tcp, p.dstPort);
+    appendBE32(tcp, p.seq);
+    appendBE32(tcp, p.ack);
+    tcp.append(char(5 << 4)); // data offset: 5 words, no options
+    tcp.append(char(p.flags));
+    appendBE16(tcp, 8192); // window
+    appendBE16(tcp, 0);    // checksum (unchecked)
+    appendBE16(tcp, 0);    // urgent pointer
+    tcp.append(p.payload);
+
+    QByteArray ip;
+    ip.append(char(0x45)); // v4, ihl=5
+    ip.append(char(0x00)); // DSCP
+    appendBE16(ip, quint16(20 + tcp.size()));
+    appendBE16(ip, 0x1234); // identification
+    appendBE16(ip, 0x4000); // DF, no fragment offset
+    ip.append(char(64));    // TTL
+    ip.append(char(6));     // TCP
+    appendBE16(ip, 0);      // checksum (unchecked)
+    appendBE32(ip, p.srcIp);
+    appendBE32(ip, p.dstIp);
+    ip.append(tcp);
+
+    QByteArray frame;
+    frame.append(QByteArray(6, char(0x02))); // dst MAC
+    frame.append(QByteArray(6, char(0x04))); // src MAC
+    if (p.vlanTag) {
+        appendBE16(frame, 0x8100);
+        appendBE16(frame, 42); // VLAN id
+    }
+    appendBE16(frame, 0x0800);
+    frame.append(ip);
+    frame.append(QByteArray(p.etherPadding, char(0xEE)));
+    return frame;
+}
+
+struct CapturePacket {
+    qint64 tsUsec = 0;
+    QByteArray frame;
+};
+
+// Classic pcap container, little-endian, microsecond resolution, Ethernet
+QByteArray buildClassicPcap(const QVector<CapturePacket> &packets,
+                            bool nanosecond = false) {
+    QByteArray out;
+    appendLE32(out, nanosecond ? 0xA1B23C4D : 0xA1B2C3D4);
+    out.append(char(2)); out.append(char(0)); // version major
+    out.append(char(4)); out.append(char(0)); // version minor
+    appendLE32(out, 0);     // thiszone
+    appendLE32(out, 0);     // sigfigs
+    appendLE32(out, 65535); // snaplen
+    appendLE32(out, 1);     // LINKTYPE_ETHERNET
+    for (const CapturePacket &p : packets) {
+        appendLE32(out, quint32(p.tsUsec / 1000000));
+        quint32 frac = quint32(p.tsUsec % 1000000);
+        appendLE32(out, nanosecond ? frac * 1000 : frac);
+        appendLE32(out, quint32(p.frame.size()));
+        appendLE32(out, quint32(p.frame.size()));
+        out.append(p.frame);
+    }
+    return out;
+}
+
+// Classic pcap container, big-endian byte order
+QByteArray buildBigEndianPcap(const QVector<CapturePacket> &packets) {
+    QByteArray out;
+    appendBE32(out, 0xA1B2C3D4);
+    out.append(char(0)); out.append(char(2));
+    out.append(char(0)); out.append(char(4));
+    appendBE32(out, 0);
+    appendBE32(out, 0);
+    appendBE32(out, 65535);
+    appendBE32(out, 1);
+    for (const CapturePacket &p : packets) {
+        appendBE32(out, quint32(p.tsUsec / 1000000));
+        appendBE32(out, quint32(p.tsUsec % 1000000));
+        appendBE32(out, quint32(p.frame.size()));
+        appendBE32(out, quint32(p.frame.size()));
+        out.append(p.frame);
+    }
+    return out;
+}
+
+// pcapng container: SHB + one Ethernet IDB + one EPB per packet
+QByteArray buildPcapNg(const QVector<CapturePacket> &packets) {
+    QByteArray out;
+
+    QByteArray shb;
+    appendLE32(shb, 0x1A2B3C4D); // byte-order magic
+    shb.append(char(1)); shb.append(char(0)); // major
+    shb.append(char(0)); shb.append(char(0)); // minor
+    shb.append(QByteArray(8, char(0xFF)));    // section length: unspecified
+    appendLE32(out, 0x0A0D0D0A);
+    appendLE32(out, quint32(shb.size() + 12));
+    out.append(shb);
+    appendLE32(out, quint32(shb.size() + 12));
+
+    QByteArray idb;
+    idb.append(char(1)); idb.append(char(0)); // LINKTYPE_ETHERNET
+    idb.append(char(0)); idb.append(char(0)); // reserved
+    appendLE32(idb, 65535);                   // snaplen
+    appendLE32(out, 1);
+    appendLE32(out, quint32(idb.size() + 12));
+    out.append(idb);
+    appendLE32(out, quint32(idb.size() + 12));
+
+    for (const CapturePacket &p : packets) {
+        QByteArray epb;
+        appendLE32(epb, 0); // interface id
+        quint64 ts = quint64(p.tsUsec);
+        appendLE32(epb, quint32(ts >> 32));
+        appendLE32(epb, quint32(ts & 0xFFFFFFFF));
+        appendLE32(epb, quint32(p.frame.size()));
+        appendLE32(epb, quint32(p.frame.size()));
+        epb.append(p.frame);
+        while (epb.size() % 4) epb.append(char(0));
+        appendLE32(out, 6);
+        appendLE32(out, quint32(epb.size() + 12));
+        out.append(epb);
+        appendLE32(out, quint32(epb.size() + 12));
+    }
+    return out;
+}
+
+// ---------------------------------------------------------------------------
+// TN5250 stream fragments
+// ---------------------------------------------------------------------------
+
+const char IAC = char(0xFF);
+const char DO = char(0xFD);
+const char WILL = char(0xFB);
+const char SB = char(0xFA);
+const char SE = char(0xF0);
+const char EOR_CMD = char(0xEF);
+const char OPT_TERMINAL_TYPE = char(0x18);
+const char OPT_EOR = char(0x19);
+
+// A minimal GDS record: length prefix, type 0x12A0, header, payload
+QByteArray gdsRecord(const QByteArray &payload) {
+    QByteArray rec;
+    appendBE16(rec, quint16(10 + payload.size()));
+    rec.append(char(0x12));
+    rec.append(char(0xA0));
+    appendBE16(rec, 0);     // reserved
+    rec.append(char(0x04)); // variable header length
+    rec.append(char(0x00)); // flags
+    rec.append(char(0x00));
+    rec.append(char(0x03)); // opcode
+    rec.append(payload);
+    return rec;
+}
+
+QByteArray telnetNegotiation() {
+    QByteArray b;
+    b.append(IAC); b.append(DO); b.append(OPT_TERMINAL_TYPE);
+    b.append(IAC); b.append(SB); b.append(OPT_TERMINAL_TYPE);
+    b.append(char(0x01)); // SEND
+    b.append(IAC); b.append(SE);
+    b.append(IAC); b.append(DO); b.append(OPT_EOR);
+    b.append(IAC); b.append(WILL); b.append(OPT_EOR);
+    return b;
+}
+
+QByteArray withEor(const QByteArray &record) {
+    QByteArray b = record;
+    b.append(IAC);
+    b.append(EOR_CMD);
+    return b;
+}
+
+// IAC-escape record content the way a live host would
+QByteArray iacEscaped(const QByteArray &data) {
+    QByteArray b;
+    for (char c : data) {
+        b.append(c);
+        if (c == IAC) b.append(IAC);
+    }
+    return b;
+}
+
+constexpr quint32 SERVER_IP = 0x0A000001; // 10.0.0.1
+constexpr quint32 CLIENT_IP = 0x0A000002; // 10.0.0.2
+constexpr quint16 SERVER_PORT = 23;
+constexpr quint16 CLIENT_PORT = 51000;
+
+// A full TN5250 conversation: handshake, negotiation, then the given
+// host→client stream split into segments. Returns packets ready for a
+// container builder.
+struct ConversationBuilder {
+    QVector<CapturePacket> packets;
+    quint32 serverSeq = 1000;
+    quint32 clientSeq = 5000;
+    qint64 ts = 1700000000000000LL; // µs
+
+    void handshake() {
+        TcpParams syn;
+        syn.srcIp = CLIENT_IP; syn.dstIp = SERVER_IP;
+        syn.srcPort = CLIENT_PORT; syn.dstPort = SERVER_PORT;
+        syn.seq = clientSeq; syn.flags = TCP_SYN;
+        packets.append({ts, buildFrame(syn)});
+        ts += 1000;
+
+        TcpParams synAck;
+        synAck.srcIp = SERVER_IP; synAck.dstIp = CLIENT_IP;
+        synAck.srcPort = SERVER_PORT; synAck.dstPort = CLIENT_PORT;
+        synAck.seq = serverSeq; synAck.ack = clientSeq + 1;
+        synAck.flags = TCP_SYN | TCP_ACK;
+        packets.append({ts, buildFrame(synAck)});
+        ts += 1000;
+        serverSeq++;
+        clientSeq++;
+    }
+
+    void serverSends(const QByteArray &data, qint64 advanceUsec = 1000,
+                     int etherPadding = 0) {
+        TcpParams p;
+        p.srcIp = SERVER_IP; p.dstIp = CLIENT_IP;
+        p.srcPort = SERVER_PORT; p.dstPort = CLIENT_PORT;
+        p.seq = serverSeq; p.payload = data;
+        p.etherPadding = etherPadding;
+        packets.append({ts, buildFrame(p)});
+        serverSeq += data.size();
+        ts += advanceUsec;
+    }
+
+    void clientSends(const QByteArray &data) {
+        TcpParams p;
+        p.srcIp = CLIENT_IP; p.dstIp = SERVER_IP;
+        p.srcPort = CLIENT_PORT; p.dstPort = SERVER_PORT;
+        p.seq = clientSeq; p.payload = data;
+        packets.append({ts, buildFrame(p)});
+        clientSeq += data.size();
+        ts += 1000;
+    }
+};
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+
+class TestPcapReplay : public QObject {
+    Q_OBJECT
+
+  private slots:
+
+    void testClassicPcapBasicSession() {
+        ConversationBuilder conv;
+        conv.handshake();
+        conv.serverSends(telnetNegotiation());
+        conv.clientSends(QByteArray(1, IAC) + QByteArray(1, WILL)
+                         + QByteArray(1, OPT_TERMINAL_TYPE));
+        QByteArray rec1 = gdsRecord(QByteArray("\x40\x11", 2) + QByteArray("SCREEN-ONE"));
+        QByteArray rec2 = gdsRecord(QByteArray("\x40\x11", 2) + QByteArray("SCREEN-TWO"));
+        conv.serverSends(withEor(rec1));
+        conv.serverSends(withEor(rec2));
+
+        ReplaySession session;
+        QString error;
+        QVERIFY2(PcapReplayLoader::loadData(buildClassicPcap(conv.packets),
+                                            &session, &error),
+                 qPrintable(error));
+        QCOMPARE(session.records.size(), 2);
+        QCOMPARE(session.records[0].data, rec1);
+        QCOMPARE(session.records[1].data, rec2);
+        QCOMPARE(session.serverEndpoint, QStringLiteral("10.0.0.1:23"));
+        QCOMPARE(session.clientEndpoint, QStringLiteral("10.0.0.2:51000"));
+        QVERIFY(session.records[1].timestampUsec > session.records[0].timestampUsec);
+    }
+
+    void testPcapNgSession() {
+        ConversationBuilder conv;
+        conv.handshake();
+        conv.serverSends(telnetNegotiation());
+        QByteArray rec = gdsRecord(QByteArray("NG-PAYLOAD"));
+        conv.serverSends(withEor(rec));
+
+        ReplaySession session;
+        QString error;
+        QVERIFY2(PcapReplayLoader::loadData(buildPcapNg(conv.packets),
+                                            &session, &error),
+                 qPrintable(error));
+        QCOMPARE(session.records.size(), 1);
+        QCOMPARE(session.records[0].data, rec);
+    }
+
+    void testNanosecondPcap() {
+        ConversationBuilder conv;
+        conv.handshake();
+        conv.serverSends(telnetNegotiation());
+        QByteArray rec = gdsRecord(QByteArray("NSEC"));
+        conv.serverSends(withEor(rec));
+
+        ReplaySession session;
+        QString error;
+        QVERIFY2(PcapReplayLoader::loadData(buildClassicPcap(conv.packets, true),
+                                            &session, &error),
+                 qPrintable(error));
+        QCOMPARE(session.records.size(), 1);
+        QCOMPARE(session.records[0].data, rec);
+        QCOMPARE(session.records[0].timestampUsec % 1000000,
+                 conv.packets.last().tsUsec % 1000000);
+    }
+
+    void testBigEndianPcap() {
+        ConversationBuilder conv;
+        conv.handshake();
+        conv.serverSends(telnetNegotiation());
+        QByteArray rec = gdsRecord(QByteArray("BIGEND"));
+        conv.serverSends(withEor(rec));
+
+        ReplaySession session;
+        QString error;
+        QVERIFY2(PcapReplayLoader::loadData(buildBigEndianPcap(conv.packets),
+                                            &session, &error),
+                 qPrintable(error));
+        QCOMPARE(session.records.size(), 1);
+        QCOMPARE(session.records[0].data, rec);
+    }
+
+    void testIacIacUnescapedInRecord() {
+        ConversationBuilder conv;
+        conv.handshake();
+        conv.serverSends(telnetNegotiation());
+        QByteArray rec = gdsRecord(QByteArray("\x01") + QByteArray(2, IAC)
+                                   + QByteArray("\x02"));
+        // The record contains 0xFF bytes: the host doubles them on the wire
+        conv.serverSends(iacEscaped(rec) + QByteArray(1, IAC)
+                         + QByteArray(1, EOR_CMD));
+
+        ReplaySession session;
+        QString error;
+        QVERIFY2(PcapReplayLoader::loadData(buildClassicPcap(conv.packets),
+                                            &session, &error),
+                 qPrintable(error));
+        QCOMPARE(session.records.size(), 1);
+        QCOMPARE(session.records[0].data, rec);
+    }
+
+    void testSubnegotiationWithIacIacStripped() {
+        ConversationBuilder conv;
+        conv.handshake();
+        // Subnegotiation payload contains an escaped 0xFF which must NOT
+        // leak into the application stream
+        QByteArray neg;
+        neg.append(IAC); neg.append(SB); neg.append(OPT_TERMINAL_TYPE);
+        neg.append(char(0x01));
+        neg.append(IAC); neg.append(IAC); // literal 0xFF inside SB payload
+        neg.append(char(0x02));
+        neg.append(IAC); neg.append(SE);
+        conv.serverSends(neg);
+        QByteArray rec = gdsRecord(QByteArray("AFTER-SB"));
+        conv.serverSends(withEor(rec));
+
+        ReplaySession session;
+        QString error;
+        QVERIFY2(PcapReplayLoader::loadData(buildClassicPcap(conv.packets),
+                                            &session, &error),
+                 qPrintable(error));
+        QCOMPARE(session.records.size(), 1);
+        QCOMPARE(session.records[0].data, rec);
+    }
+
+    void testRecordSplitAcrossSegments() {
+        ConversationBuilder conv;
+        conv.handshake();
+        conv.serverSends(telnetNegotiation());
+        QByteArray rec = gdsRecord(QByteArray("SPLIT-ACROSS-SEGMENTS"));
+        QByteArray wire = withEor(rec);
+        conv.serverSends(wire.left(7));
+        conv.serverSends(wire.mid(7));
+
+        ReplaySession session;
+        QString error;
+        QVERIFY2(PcapReplayLoader::loadData(buildClassicPcap(conv.packets),
+                                            &session, &error),
+                 qPrintable(error));
+        QCOMPARE(session.records.size(), 1);
+        QCOMPARE(session.records[0].data, rec);
+    }
+
+    void testRetransmissionDeduplicated() {
+        ConversationBuilder conv;
+        conv.handshake();
+        conv.serverSends(telnetNegotiation());
+        QByteArray rec = gdsRecord(QByteArray("RETRANSMITTED"));
+        QByteArray wire = withEor(rec);
+        conv.serverSends(wire);
+        // Full retransmission of the same segment (stale seq)
+        TcpParams dup;
+        dup.srcIp = SERVER_IP; dup.dstIp = CLIENT_IP;
+        dup.srcPort = SERVER_PORT; dup.dstPort = CLIENT_PORT;
+        dup.seq = conv.serverSeq - wire.size();
+        dup.payload = wire;
+        conv.packets.append({conv.ts, buildFrame(dup)});
+
+        ReplaySession session;
+        QString error;
+        QVERIFY2(PcapReplayLoader::loadData(buildClassicPcap(conv.packets),
+                                            &session, &error),
+                 qPrintable(error));
+        QCOMPARE(session.records.size(), 1);
+        QCOMPARE(session.records[0].data, rec);
+    }
+
+    void testOutOfOrderSegmentsReassembled() {
+        ConversationBuilder conv;
+        conv.handshake();
+        conv.serverSends(telnetNegotiation());
+        QByteArray rec = gdsRecord(QByteArray("OUT-OF-ORDER-DATA"));
+        QByteArray wire = withEor(rec);
+        QByteArray part1 = wire.left(9);
+        QByteArray part2 = wire.mid(9);
+        quint32 seqBase = conv.serverSeq;
+        // Append part2 first (higher seq), then part1
+        TcpParams p2;
+        p2.srcIp = SERVER_IP; p2.dstIp = CLIENT_IP;
+        p2.srcPort = SERVER_PORT; p2.dstPort = CLIENT_PORT;
+        p2.seq = seqBase + part1.size(); p2.payload = part2;
+        conv.packets.append({conv.ts, buildFrame(p2)});
+        TcpParams p1 = p2;
+        p1.seq = seqBase; p1.payload = part1;
+        conv.packets.append({conv.ts + 500, buildFrame(p1)});
+
+        ReplaySession session;
+        QString error;
+        QVERIFY2(PcapReplayLoader::loadData(buildClassicPcap(conv.packets),
+                                            &session, &error),
+                 qPrintable(error));
+        QCOMPARE(session.records.size(), 1);
+        QCOMPARE(session.records[0].data, rec);
+    }
+
+    void testEthernetTrailerPaddingTrimmed() {
+        ConversationBuilder conv;
+        conv.handshake();
+        conv.serverSends(telnetNegotiation());
+        QByteArray rec = gdsRecord(QByteArray("PAD"));
+        // Short frame padded by the NIC to the Ethernet minimum: the pad
+        // bytes sit after the IP datagram and must not enter the stream
+        conv.serverSends(withEor(rec), 1000, 18);
+
+        ReplaySession session;
+        QString error;
+        QVERIFY2(PcapReplayLoader::loadData(buildClassicPcap(conv.packets),
+                                            &session, &error),
+                 qPrintable(error));
+        QCOMPARE(session.records.size(), 1);
+        QCOMPARE(session.records[0].data, rec);
+    }
+
+    void testVlanTaggedFrames() {
+        ConversationBuilder conv;
+        conv.handshake();
+        conv.serverSends(telnetNegotiation());
+        QByteArray rec = gdsRecord(QByteArray("VLAN"));
+        QByteArray wire = withEor(rec);
+        TcpParams p;
+        p.srcIp = SERVER_IP; p.dstIp = CLIENT_IP;
+        p.srcPort = SERVER_PORT; p.dstPort = CLIENT_PORT;
+        p.seq = conv.serverSeq; p.payload = wire; p.vlanTag = true;
+        conv.packets.append({conv.ts, buildFrame(p)});
+
+        ReplaySession session;
+        QString error;
+        QVERIFY2(PcapReplayLoader::loadData(buildClassicPcap(conv.packets),
+                                            &session, &error),
+                 qPrintable(error));
+        QCOMPARE(session.records.size(), 1);
+        QCOMPARE(session.records[0].data, rec);
+    }
+
+    void testTelnetFlowPreferredOverLargerNoiseFlow() {
+        ConversationBuilder conv;
+        conv.handshake();
+        conv.serverSends(telnetNegotiation());
+        QByteArray rec = gdsRecord(QByteArray("REAL-SESSION"));
+        conv.serverSends(withEor(rec));
+
+        // A bigger non-telnet flow (e.g. an HTTP transfer in the same capture)
+        TcpParams noise;
+        noise.srcIp = 0x0A000003; noise.dstIp = 0x0A000004;
+        noise.srcPort = 80; noise.dstPort = 40000;
+        noise.seq = 1;
+        noise.payload = QByteArray(4096, 'x');
+        conv.packets.prepend({conv.ts - 50000, buildFrame(noise)});
+
+        ReplaySession session;
+        QString error;
+        QVERIFY2(PcapReplayLoader::loadData(buildClassicPcap(conv.packets),
+                                            &session, &error),
+                 qPrintable(error));
+        QCOMPARE(session.records.size(), 1);
+        QCOMPARE(session.records[0].data, rec);
+        QCOMPARE(session.serverEndpoint, QStringLiteral("10.0.0.1:23"));
+    }
+
+    void testServerInferredFromPortWithoutHandshake() {
+        // Capture started mid-session: no SYN packets at all
+        ConversationBuilder conv;
+        conv.serverSeq = 100000;
+        conv.clientSeq = 200000;
+        QByteArray rec = gdsRecord(QByteArray("MID-SESSION"));
+        conv.serverSends(withEor(rec));
+        conv.clientSends(QByteArray(1, IAC) + QByteArray(1, WILL)
+                         + QByteArray(1, OPT_EOR));
+
+        ReplaySession session;
+        QString error;
+        QVERIFY2(PcapReplayLoader::loadData(buildClassicPcap(conv.packets),
+                                            &session, &error),
+                 qPrintable(error));
+        QCOMPARE(session.serverEndpoint, QStringLiteral("10.0.0.1:23"));
+        QCOMPARE(session.records.size(), 1);
+        QCOMPARE(session.records[0].data, rec);
+    }
+
+    void testFinalRecordWithoutEorKept() {
+        ConversationBuilder conv;
+        conv.handshake();
+        conv.serverSends(telnetNegotiation());
+        QByteArray rec = gdsRecord(QByteArray("CUT-OFF"));
+        conv.serverSends(rec); // capture ends before IAC EOR arrives
+
+        ReplaySession session;
+        QString error;
+        QVERIFY2(PcapReplayLoader::loadData(buildClassicPcap(conv.packets),
+                                            &session, &error),
+                 qPrintable(error));
+        QCOMPARE(session.records.size(), 1);
+        QCOMPARE(session.records[0].data, rec);
+    }
+
+    void testNotACaptureFile() {
+        ReplaySession session;
+        QString error;
+        QVERIFY(!PcapReplayLoader::loadData(QByteArray("definitely not a pcap"),
+                                            &session, &error));
+        QVERIFY(!error.isEmpty());
+    }
+
+    void testEmptyCapture() {
+        ReplaySession session;
+        QString error;
+        QVERIFY(!PcapReplayLoader::loadData(buildClassicPcap({}), &session, &error));
+        QVERIFY(!error.isEmpty());
+    }
+
+    void testCaptureWithoutTelnetTraffic() {
+        QVector<CapturePacket> packets;
+        TcpParams p;
+        p.srcIp = 0x0A000003; p.dstIp = 0x0A000004;
+        p.srcPort = 80; p.dstPort = 40000;
+        p.seq = 1;
+        p.payload = QByteArray("HTTP/1.1 200 OK\r\n\r\n");
+        packets.append({1000, buildFrame(p)});
+
+        ReplaySession session;
+        QString error;
+        QVERIFY(!PcapReplayLoader::loadData(buildClassicPcap(packets),
+                                            &session, &error));
+        QVERIFY(!error.isEmpty());
+    }
+
+    void testTruncatedCaptureTailTolerated() {
+        ConversationBuilder conv;
+        conv.handshake();
+        conv.serverSends(telnetNegotiation());
+        QByteArray rec = gdsRecord(QByteArray("BEFORE-TRUNCATION"));
+        conv.serverSends(withEor(rec));
+        QByteArray capture = buildClassicPcap(conv.packets);
+        // A record header announcing more bytes than remain in the file
+        capture.chop(10);
+        // The cut hits the last packet's frame, so only the negotiation
+        // and the cut packet's prefix survive; the loader must not crash
+        // and must still report a coherent result or a clean error.
+        ReplaySession session;
+        QString error;
+        bool ok = PcapReplayLoader::loadData(capture, &session, &error);
+        if (ok) {
+            QVERIFY(!session.records.isEmpty());
+        } else {
+            QVERIFY(!error.isEmpty());
+        }
+    }
+};
+
+QTEST_MAIN(TestPcapReplay)
+#include "test_pcap_replay.moc"


### PR DESCRIPTION
### Linked Issue
Closes #30

### Summary
Adds session replay from packet captures: a captured TN5250 conversation can be opened as a regular session tab and watched as it originally played out, without any live connection.

Three entry points:
- **File → Replay Session from PCAP...** menu action
- `--replay-pcap <path>` command line option
- programmatic `MainWindow::startPcapReplay(path)`

### Design
A new `core::pcap::PcapReplayLoader` (`src/core/pcap_replay.{h,cpp}`) handles the full extraction pipeline:

1. **Container parsing** — classic pcap (both endiannesses, microsecond and nanosecond variants) and pcapng (SHB/IDB/EPB/SPB blocks, per-interface `if_tsresol`, per-section endianness). Captures truncated mid-record (live capture killed) keep the packets parsed so far.
2. **Decapsulation** — Ethernet (with 802.1Q/802.1ad VLAN tags), Linux SLL/SLL2, raw IP, BSD loopback; IPv4 and IPv6 (extension header chain); fragmented datagrams are skipped. TCP payloads are bounded by the IP total length so Ethernet trailer padding never reaches the stream.
3. **TCP reassembly** — per-direction segment ordering by relative sequence number (wraparound-safe), retransmission/overlap deduplication, stop-at-gap so a lossy capture cannot desync the telnet parser.
4. **Flow selection** — picks the flow whose stream opens with telnet negotiation (IAC) or a GDS record (`0x12A0`), preferring the largest such flow. Captures with no TN5250 flow are rejected instead of rendering garbage. The server side is identified by SYN/SYN-ACK, falling back to well-known ports (23/992), then payload volume.
5. **Telnet stripping** — passive equivalent of `TN5250Client::processTelnetData`: negotiation commands and subnegotiations removed, `IAC IAC` unescaped (SB-payload-aware), application data split into records at `IAC EOR`.

`tn5250::session::Worker` gains a replay mode: when `SessionConfig::replayPcapFile()` is set, `start()` loads the capture instead of opening a socket and emits the extracted records through the existing `appData` signal, paced by the original capture timing clamped to 40–1000 ms per step. The rest of the pipeline (decoder adapter → command handler → renderer → screen history) is untouched, so replayed sessions get scrollback, theming, and screenshots for free. A new `replayFinished` signal keeps the final screen up and updates the status bar instead of clearing the display.

Replay tabs are read-only (`setReadOnly(true)`) since there is no peer to answer input. `replayPcapFile` is transient configuration: never serialized into saved session profiles.

### How Verified
- **Tests:** new `tests/unit/test_pcap_replay.cpp` (20 cases) builds synthetic captures in memory and covers: classic pcap/pcapng/nanosecond/big-endian containers, IAC IAC unescaping in records, SB payload escapes not leaking into app data, records split across TCP segments, retransmission dedup, out-of-order reassembly, Ethernet trailer trimming, VLAN tags, telnet-flow selection over a larger noise flow, server inference without a handshake, final record without EOR, non-capture/empty/non-telnet inputs rejected, truncated tail tolerated.
- **Runtime:** generated a synthetic capture (handshake + negotiation + Clear Unit + Write To Display records) and ran `5250ng --replay-pcap` offscreen: log shows `Replaying 2 records from ... (server 10.0.0.1:23, client 10.0.0.2:51000)`, both GDS records decoded and rendered (SBA row 4, EBCDIC text), original ~300 ms pacing respected, `Replay finished` emitted with the final screen retained.
- Full suite: 19/19 ctest targets pass; main app builds warning-free.

### Scope of Change
- **Files changed:** `src/core/pcap_replay.{h,cpp}` (new), `src/session/worker.{h,cpp}`, `src/session/config.{h,cpp}`, `src/ui/actions/onReplayPcap.cpp` (new), `src/ui/main_window.{h,cpp}`, `src/ui/setup/setupMenuBar.cpp`, `src/main.cpp`, `CMakeLists.txt`, `tests/unit/test_pcap_replay.cpp` (new), `README.md`
- **Submodule pointer updated:** no
- **Behavioral changes outside the feature:** none — live sessions take the exact same code paths as before; the replay branch in `Worker::start()`/`stop()` is inert unless a replay file is configured.

### Risk and Rollout
Self-contained: no existing behavior changes unless a replay is explicitly opened. The loader is pure parsing code exercised by unit tests; worst case for a malformed capture is a clean error dialog.

### Notes
Screen size defaults to 24×80 for replay tabs; a capture of a 27×132 session still replays (the renderer clips rows beyond the configured size). Deriving the geometry from the captured TERMINAL_TYPE negotiation is a possible follow-up.