### PR TITLE
[bugfix] Fix ScreenBuffer::scrollRegion out-of-bounds write on oversized Roll line count (#131)

### DIFF
--- a/src/ui/widgets/Q5250ScreenWidget/screen_buffer.cpp
+++ b/src/ui/widgets/Q5250ScreenWidget/screen_buffer.cpp
@@ -453,6 +453,13 @@ void ScreenBuffer::scrollRegion(int topRow, int botRow, int lines, bool up) {
     if (topRow < 0) topRow = 0;
     if (botRow >= m_rows) botRow = m_rows - 1;
     if (topRow > botRow || lines <= 0) return;
+    // A line count >= the region height shifts everything out of the window:
+    // clamp so the clear loops below stay inside [topRow, botRow]. Without
+    // this, a host-controlled Roll order with lineCount up to 31 makes the
+    // up-branch clear loop start at a negative row (write before m_buffer)
+    // and the down-branch clear loop run past botRow (write after m_buffer).
+    const int regionHeight = botRow - topRow + 1;
+    if (lines > regionHeight) lines = regionHeight;
     LOG_DEBUG(QString("[ScreenBuffer] scrollRegion: top=%1 bot=%2 lines=%3 dir=%4")
         .arg(topRow).arg(botRow).arg(lines).arg(up ? "up" : "down"));
 

--- a/tests/unit/test_screen_buffer.cpp
+++ b/tests/unit/test_screen_buffer.cpp
@@ -33,6 +33,7 @@ class TestScreenBuffer : public QObject {
     void testFieldManagement();
     void testClear();
     void testScroll();
+    void testScrollRegionOversizedLineCount();
     void testWriteOperations();
     void testAttributes();
     void testProtectedFields();
@@ -136,6 +137,40 @@ void TestScreenBuffer::testScroll() {
 
     // Last row should now be empty
     QCOMPARE(m_buffer->character(23, 0), static_cast<uint8_t>(0x40));
+}
+
+void TestScreenBuffer::testScrollRegionOversizedLineCount() {
+    // A Roll order carries a 5-bit line count (up to 31), which a host can
+    // set larger than the rolled window. scrollRegion must clamp it instead
+    // of indexing outside the buffer (issue #131).
+
+    // Region of 3 rows (1..3), line count far beyond the region height: the
+    // up-branch clear loop would otherwise start at row 3 - 31 + 1 = -27.
+    m_buffer->writeChar(1, 0, 0xC1);
+    m_buffer->writeChar(3, 0, 0xC2);
+    m_buffer->writeChar(0, 0, 0xC9); // outside the region, must survive
+    m_buffer->writeChar(4, 0, 0xC9);
+    m_buffer->scrollRegion(1, 3, 31, true);
+    // Whole region cleared, neighbours untouched
+    QCOMPARE(m_buffer->character(1, 0), static_cast<uint8_t>(0x40));
+    QCOMPARE(m_buffer->character(3, 0), static_cast<uint8_t>(0x40));
+    QCOMPARE(m_buffer->character(0, 0), static_cast<uint8_t>(0xC9));
+    QCOMPARE(m_buffer->character(4, 0), static_cast<uint8_t>(0xC9));
+
+    // Same for the down branch near the bottom of the screen: the clear loop
+    // would otherwise run from row 21 up to row 21 + 31 - 1 = 51 (rows = 24).
+    m_buffer->writeChar(21, 0, 0xC3);
+    m_buffer->writeChar(23, 0, 0xC4);
+    m_buffer->writeChar(20, 0, 0xC9);
+    m_buffer->scrollRegion(21, 23, 31, false);
+    QCOMPARE(m_buffer->character(21, 0), static_cast<uint8_t>(0x40));
+    QCOMPARE(m_buffer->character(23, 0), static_cast<uint8_t>(0x40));
+    QCOMPARE(m_buffer->character(20, 0), static_cast<uint8_t>(0xC9));
+
+    // Line count exactly the region height behaves the same as oversized
+    m_buffer->writeChar(5, 2, 0xC5);
+    m_buffer->scrollRegion(5, 7, 3, true);
+    QCOMPARE(m_buffer->character(5, 2), static_cast<uint8_t>(0x40));
 }
 
 void TestScreenBuffer::testWriteOperations() {


### PR DESCRIPTION
### Linked Issue
Closes #131

### Root Cause
`scrollRegion()` was added alongside the full-screen `scrollUp()`/`scrollDown()` but did not replicate their line-count guard (`lines >= m_rows`). The function clamps `topRow`/`botRow` to the screen and rejects non-positive counts, yet trusts that `lines` fits inside the region. The Roll order's line count is a 5-bit host-controlled field (up to 31) that the decoder and `TN5250CommandHandler::onRollRequested` forward unchecked, so a region smaller than the line count drove the clear loops outside `m_buffer`: the up branch's clear loop starts at `botRow - lines + 1` (negative), the down branch's runs to `topRow + lines - 1` (past the last row).

### Fix Description
Clamp `lines` to the region height (`botRow - topRow + 1`) after the existing row clamps in `screen_buffer.cpp`. With `lines == regionHeight` the shift loops degenerate to zero iterations and the clear loops cover exactly `[topRow, botRow]`, which is the correct semantic for a roll larger than the window: everything shifts out and the region is cleared. No change to in-range rolls.

### How Verified
- **Tests:** `tests/unit/test_screen_buffer.cpp`, new `testScrollRegionOversizedLineCount` — rolls a 3-row region with line count 31 in both directions and asserts the region is cleared while the rows bordering the region are untouched, plus the `lines == regionHeight` boundary case. Without the fix the up-branch case writes to `m_buffer[-2160..]` (caught by ASan; in release it corrupts the heap).
- **Static:** with the clamp, `botRow - lines + 1 >= topRow >= 0` and `topRow + lines - 1 <= botRow <= m_rows - 1`, so every `index(row, col)` in both branches is within `[0, m_rows*m_cols)`.
- Full suite: all 19 ctest targets pass.

### Test Coverage
**Added:** `tests/unit/test_screen_buffer.cpp` — `TestScreenBuffer::testScrollRegionOversizedLineCount`.

### Scope of Change
- **Files changed:** `src/ui/widgets/Q5250ScreenWidget/screen_buffer.cpp`, `tests/unit/test_screen_buffer.cpp`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Two-line clamp in one function; rolls that fit the region are byte-for-byte unchanged. Safe to merge directly.