### PR TITLE
[bugfix] Fix unclamped SOH error row driving out-of-bounds screen buffer access (#133)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -421,6 +421,21 @@ if(BUILD_TESTS)
     add_tn5250_test(test_host_data_stream tests/unit/test_host_data_stream.cpp)
     add_tn5250_test(test_password_encrypt tests/unit/test_password_encrypt.cpp)
 
+    # Command handler tests
+    # TN5250CommandHandler / TN5250StreamRenderer live in the main
+    # application target (not tn5250_core), so compile them into the test
+    # binary directly.
+    add_executable(test_command_handler_soh
+        tests/unit/test_command_handler_soh.cpp
+        src/ui/rendering/tn5250_command_handler.cpp
+        src/ui/rendering/tn5250_stream_renderer.cpp
+        src/ui/dialogs/pc_command_confirm_dialog.cpp
+        src/ui/widgets/Frameless/BaseFramelessDialog.cpp
+        src/ui/widgets/Frameless/TitleBar.cpp
+        src/ui/themes/manager.cpp)
+    target_link_libraries(test_command_handler_soh PRIVATE tn5250_core Qt6::Test)
+    add_test(NAME test_command_handler_soh COMMAND test_command_handler_soh)
+
     # MCP transport tests
     # McpHttpParser lives in the main application target (not tn5250_core),
     # so compile it into the test binary directly.

--- a/src/ui/rendering/tn5250_command_handler.cpp
+++ b/src/ui/rendering/tn5250_command_handler.cpp
@@ -373,7 +373,16 @@ void TN5250CommandHandler::onSohReceived(uint8_t errorRow, uint8_t ckm1,
         return;
     }
     if (errorRow > 0) {
-        m_displayWidget->setErrorLineRow(errorRow - 1);
+        // The SOH error row is a raw host byte; everything that later indexes
+        // the screen with errorLineRow() (Write Error Code save/clear, error
+        // reset restore) goes through ScreenBuffer::cell(), which has no
+        // release-mode bounds check. Clamp to the last screen row.
+        int row = errorRow - 1;
+        if (m_displayWidget->screenBuffer()
+            && row >= m_displayWidget->screenBuffer()->rows()) {
+            row = m_displayWidget->screenBuffer()->rows() - 1;
+        }
+        m_displayWidget->setErrorLineRow(row);
     }
     m_displayWidget->setCmdKeyMask(ckm1, ckm2, ckm3);
     logger::Logger::instance()->debug(
@@ -399,7 +408,7 @@ void TN5250CommandHandler::onWriteErrorCode(const QByteArray &errorData) {
     }
     auto *screen = m_displayWidget->screenBuffer();
     int errRow = m_displayWidget->errorLineRow();
-    if (errRow < 0) errRow = screen->rows() - 1;
+    if (errRow < 0 || errRow >= screen->rows()) errRow = screen->rows() - 1;
 
     QVector<ui::widgets::ScreenCell> savedLine;
     for (int c = 0; c < screen->cols(); ++c) {

--- a/src/ui/widgets/Q5250ScreenWidget/events.cpp
+++ b/src/ui/widgets/Q5250ScreenWidget/events.cpp
@@ -112,6 +112,9 @@ void Q5250ScreenWidget::keyPressEvent(QKeyEvent *event) {
             // Error Reset: restore error line and unlock keyboard
             if (!m_savedErrorLine.isEmpty() && m_screenBuffer) {
                 int errRow = (m_errorLineRow >= 0) ? m_errorLineRow : (m_screenBuffer->rows() - 1);
+                // The screen may have been resized since the row was stored
+                // (24x80 <-> 27x132); cell() has no release-mode bounds check
+                if (errRow >= m_screenBuffer->rows()) errRow = m_screenBuffer->rows() - 1;
                 for (int c = 0; c < m_screenBuffer->cols() && c < m_savedErrorLine.size(); ++c) {
                     m_screenBuffer->cell(errRow, c) = m_savedErrorLine[c];
                 }
@@ -244,6 +247,8 @@ void Q5250ScreenWidget::dispatchMappedAction(core::MappedAction action) {
             if (!m_savedErrorLine.isEmpty() && m_screenBuffer) {
                 int errRow = (m_errorLineRow >= 0) ? m_errorLineRow
                                                     : (m_screenBuffer->rows() - 1);
+                // Clamp: screen may have been resized since the row was stored
+                if (errRow >= m_screenBuffer->rows()) errRow = m_screenBuffer->rows() - 1;
                 for (int c = 0; c < m_screenBuffer->cols() && c < m_savedErrorLine.size(); ++c) {
                     m_screenBuffer->cell(errRow, c) = m_savedErrorLine[c];
                 }

--- a/tests/unit/test_command_handler_soh.cpp
+++ b/tests/unit/test_command_handler_soh.cpp
@@ -1,0 +1,92 @@
+// 5250ng - A modern IBM TN5250 terminal emulator
+// Copyright (C) 2025-2026 Remi GASCOU (Podalirius)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include "ui/rendering/tn5250_command_handler.h"
+#include "ui/widgets/Q5250ScreenWidget/Q5250ScreenWidget.h"
+
+#include <QtTest/QtTest>
+
+using ui::rendering::TN5250CommandHandler;
+using ui::widgets::Q5250ScreenWidget;
+
+// Regression tests for issue #133: the SOH error-row byte is host-controlled
+// and was stored unclamped, driving ScreenBuffer::cell() (no release-mode
+// bounds check) out of bounds in Write Error Code and error reset handling.
+class TestCommandHandlerSoh : public QObject {
+    Q_OBJECT
+
+  private slots:
+    void init();
+    void cleanup();
+
+    void testSohErrorRowClampedToScreen();
+    void testWriteErrorCodeWithHostileErrorRow();
+    void testSohValidErrorRowKept();
+
+  private:
+    Q5250ScreenWidget *m_widget = nullptr;
+    TN5250CommandHandler *m_handler = nullptr;
+};
+
+void TestCommandHandlerSoh::init() {
+    m_widget = new Q5250ScreenWidget();
+    m_widget->setScreenSize(24, 80);
+    m_handler = new TN5250CommandHandler(this);
+    m_handler->setDisplayWidget(m_widget);
+}
+
+void TestCommandHandlerSoh::cleanup() {
+    delete m_handler;
+    m_handler = nullptr;
+    delete m_widget;
+    m_widget = nullptr;
+}
+
+void TestCommandHandlerSoh::testSohErrorRowClampedToScreen() {
+    // Host byte far beyond the 24-row screen
+    m_handler->onSohReceived(0xFE, 0, 0, 0);
+    QVERIFY(m_widget->errorLineRow() >= 0);
+    QVERIFY(m_widget->errorLineRow() < m_widget->screenBuffer()->rows());
+    QCOMPARE(m_widget->errorLineRow(), m_widget->screenBuffer()->rows() - 1);
+}
+
+void TestCommandHandlerSoh::testWriteErrorCodeWithHostileErrorRow() {
+    // SOH with hostile row followed by Write Error Code: before the fix this
+    // read screen cells at row 253 of a 24-row buffer (and the later error
+    // reset wrote there). Must stay inside the buffer and not crash.
+    m_handler->onSohReceived(0xFE, 0, 0, 0);
+    QByteArray errorCode;
+    errorCode.append(static_cast<char>(0xC5)); // EBCDIC 'E'
+    errorCode.append(static_cast<char>(0xD9)); // EBCDIC 'R'
+    m_handler->onWriteErrorCode(errorCode);
+
+    int lastRow = m_widget->screenBuffer()->rows() - 1;
+    QCOMPARE(m_widget->screenBuffer()->character(lastRow, 0),
+             static_cast<uint8_t>(0xC5));
+    QCOMPARE(m_widget->screenBuffer()->character(lastRow, 1),
+             static_cast<uint8_t>(0xD9));
+}
+
+void TestCommandHandlerSoh::testSohValidErrorRowKept() {
+    // A legal SOH error row (1-based on the wire) must still land unchanged
+    m_handler->onSohReceived(24, 0, 0, 0);
+    QCOMPARE(m_widget->errorLineRow(), 23);
+    m_handler->onSohReceived(1, 0, 0, 0);
+    QCOMPARE(m_widget->errorLineRow(), 0);
+}
+
+QTEST_MAIN(TestCommandHandlerSoh)
+#include "test_command_handler_soh.moc"


### PR DESCRIPTION
### Linked Issue
Closes #133

### Root Cause
`onSohReceived` stored the SOH error-row byte (host-controlled, up to 255) after only handling the `errorRow == 0` case, on the assumption that hosts send rows within the screen. Every consumer of `errorLineRow()` then indexed the screen through `ScreenBuffer::cell()`, whose bounds check is a `Q_ASSERT` that compiles out in release builds. Nothing between the wire and the buffer index validated the row, so a row beyond the screen height read out of bounds in Write Error Code handling and wrote out of bounds when the user cleared the error state with Escape/Reset.

### Fix Description
Three clamps along the path, all to the last screen row:
- `tn5250_command_handler.cpp` `onSohReceived`: clamp the stored row at the producer, so `errorLineRow()` can never exceed `rows - 1`.
- `tn5250_command_handler.cpp` `onWriteErrorCode`: extend the existing `errRow < 0` fallback to also catch `errRow >= rows`, covering a screen resize between SOH and Write Error Code.
- `events.cpp` error-reset paths (Escape and the Reset mapped action): clamp before restoring the saved line, since the screen can be resized (24×80 ↔ 27×132 via Clear Screen Alternate) between saving and restoring.

Clamping to the last row matches the existing default (`errRow < 0` → last row), which is where the 5250 error line conventionally lives.

### How Verified
- **Tests:** new `tests/unit/test_command_handler_soh.cpp` drives the real `TN5250CommandHandler` against a `Q5250ScreenWidget`: SOH with row byte `0xFE` is clamped into range (fails before the fix with `errorLineRow() == 253` on a 24-row screen), a following Write Error Code lands on the last row inside the buffer, and legal SOH rows (1 and 24) still map to rows 0 and 23 unchanged.
- **Static:** all `cell(errRow, ...)` call sites now execute with `0 <= errRow < rows`: the producer clamps, and both consumers re-clamp against the current screen size.
- Full suite passes (19 targets including the new one).

### Test Coverage
**Added:** `tests/unit/test_command_handler_soh.cpp` — `testSohErrorRowClampedToScreen`, `testWriteErrorCodeWithHostileErrorRow`, `testSohValidErrorRowKept` (new CMake target `test_command_handler_soh`).

### Scope of Change
- **Files changed:** `src/ui/rendering/tn5250_command_handler.cpp`, `src/ui/widgets/Q5250ScreenWidget/events.cpp`, `tests/unit/test_command_handler_soh.cpp`, `CMakeLists.txt`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — in-range error rows take the same path as before.

### Risk and Rollout
Pure clamping on an error-display path; hosts sending valid SOH rows see identical behavior. Safe to merge directly.