### PR TITLE
[bugfix] Fix TLS sessions never starting telnet negotiation (#135)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -436,6 +436,7 @@ if(BUILD_TESTS)
 
     # Integration tests
     add_tn5250_test(test_tn5250_connection tests/integration/test_tn5250_connection.cpp)
+    add_tn5250_test(test_tn5250_tls_connection tests/integration/test_tn5250_tls_connection.cpp)
 
     message(STATUS "Testing enabled - unit and integration tests configured")
 endif()

--- a/src/network/tn5250_qt/client/client_connection.cpp
+++ b/src/network/tn5250_qt/client/client_connection.cpp
@@ -61,6 +61,13 @@ void TN5250Client::connectToHost(const QString &hostname, quint16 port, bool use
         m_socket = m_sslSocket;
 
         connect(m_sslSocket, &QSslSocket::connected, this, &TN5250Client::onSocketConnected);
+        // QSslSocket emits connected() at TCP establishment, before the TLS
+        // handshake; onSocketConnected early-returns there because
+        // isEncrypted() is still false. encrypted() is the actual
+        // "link ready" event for implicit TLS — route it to the same
+        // handler, which then enters Negotiating and performs the telnet
+        // handshake.
+        connect(m_sslSocket, &QSslSocket::encrypted, this, &TN5250Client::onSocketConnected);
         connect(m_sslSocket, &QSslSocket::disconnected, this, &TN5250Client::onSocketDisconnected);
         connect(m_sslSocket, &QSslSocket::readyRead, this, &TN5250Client::onSocketReadyRead);
         connect(

--- a/tests/integration/test_tn5250_tls_connection.cpp
+++ b/tests/integration/test_tn5250_tls_connection.cpp
@@ -1,0 +1,140 @@
+// 5250ng - A modern IBM TN5250 terminal emulator
+// Copyright (C) 2025-2026 Remi GASCOU (Podalirius)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include "network/tn5250_qt/client/client.h"
+
+#include <QtTest/QtTest>
+
+#ifdef HAVE_QT6_SSL
+#include <QSslCertificate>
+#include <QSslConfiguration>
+#include <QSslKey>
+#include <QSslServer>
+#include <QSslSocket>
+#endif
+
+using namespace tn5250::client;
+
+namespace {
+
+// Self-signed CN=localhost certificate generated for this test only
+// (valid until 2126). Never use outside the test suite.
+const char kTestCertPem[] =
+    "-----BEGIN CERTIFICATE-----\n"
+    "MIIDCzCCAfOgAwIBAgIUWJcvbMjMhEV+CDg0upy/AtLIHicwDQYJKoZIhvcNAQEL\n"
+    "BQAwFDESMBAGA1UEAwwJbG9jYWxob3N0MCAXDTI2MDYxMDA3MDQyOFoYDzIxMjYw\n"
+    "NTE3MDcwNDI4WjAUMRIwEAYDVQQDDAlsb2NhbGhvc3QwggEiMA0GCSqGSIb3DQEB\n"
+    "AQUAA4IBDwAwggEKAoIBAQDSZKcCKrhMXhjM64KYoF9leK2IRpNnbFWU5Q7DFeRM\n"
+    "p9I4oRxqrvzM3zPm0V0WqGL2m/7xoHIvxGKNXMhCqntr8Qr7q0YC5moxNhtgVMB4\n"
+    "NPgcpWwSd1GsuD8OAUooSKwq/qxLeo4VAXscrgXXXgqDPTz177LXw2umE7Se+ejH\n"
+    "8u3+JrKG+bgqTDiuUGEBCbYtLvv47h2Cw2XBNCSPth1pwniBfs/+ocgHPC9Xco//\n"
+    "woFuDzw0hGIpzzbVi36uHqBYz0VGz22Us+bCue9ZvZ+plsxIIbvf8W8uF8gyxPOQ\n"
+    "2mPCeH01JZ3uXA/ArdcAMTj26uPkRBS/+UNciR8jXW8JAgMBAAGjUzBRMB0GA1Ud\n"
+    "DgQWBBSo26+Aq/IqhqzK5KDYsJyIdbcgizAfBgNVHSMEGDAWgBSo26+Aq/IqhqzK\n"
+    "5KDYsJyIdbcgizAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQA5\n"
+    "8TlyvyplsZYunuAh/cBni/EuiWCVzphR9/JrM3usvZdMPwT6iZ/uHLViD65AqNxT\n"
+    "D9/pBr/0MiAYSFKxcxpFmMD+rV5rgIwlqGfmBG43ArztPQx5eM/EsUnfbv7A8EwO\n"
+    "BPVTn7UICnfrQnxcu79Gzz+btbRcvIDjVTZFmIFz/YJ0r4U+mKmObmC2Y7gy0ZOH\n"
+    "ZD/kAqJSdC3u6NpRf8FZJIzTPCidfRNkW+eJYdJwligh8NGua4qit7v1hIVsj4ax\n"
+    "4TrTUf+J0KhgyQR0g4vpcX2CLLDKiGip6EW6hvp4nNIAf6VyUTY7o+c1l8wsgqOp\n"
+    "g84HV/VzZnCOFxqybc4k\n"
+    "-----END CERTIFICATE-----\n";
+
+const char kTestKeyPem[] =
+    "-----BEGIN PRIVATE KEY-----\n"
+    "MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDSZKcCKrhMXhjM\n"
+    "64KYoF9leK2IRpNnbFWU5Q7DFeRMp9I4oRxqrvzM3zPm0V0WqGL2m/7xoHIvxGKN\n"
+    "XMhCqntr8Qr7q0YC5moxNhtgVMB4NPgcpWwSd1GsuD8OAUooSKwq/qxLeo4VAXsc\n"
+    "rgXXXgqDPTz177LXw2umE7Se+ejH8u3+JrKG+bgqTDiuUGEBCbYtLvv47h2Cw2XB\n"
+    "NCSPth1pwniBfs/+ocgHPC9Xco//woFuDzw0hGIpzzbVi36uHqBYz0VGz22Us+bC\n"
+    "ue9ZvZ+plsxIIbvf8W8uF8gyxPOQ2mPCeH01JZ3uXA/ArdcAMTj26uPkRBS/+UNc\n"
+    "iR8jXW8JAgMBAAECggEAA0uZymLyrJmJbxKAHpnmcfGswTRaczFLx2TcdWngN0lZ\n"
+    "jzloP9GWIPeLzyWvPP06sMi0re0STD/M+qF5roJLo9JbVpC++Slr90b9ffJ7v7qC\n"
+    "7b4zWa+xcoO5QgpIB/NlLXripjLdU6zd4SAq/K/r5+5bdyj/tZ+8q55uj6d8X7aI\n"
+    "dCEAzmYRpZfW6zgrayv3/fOUg7XBmxQxhAiH4UG5e6lz+8PuLuNfko2K0SyosoP1\n"
+    "y1KhiXqGQ5pvPJ64MG40VHseMby/jadr7BT5R24UCUyZ8vgB/B8BPwPV3yqNXVnq\n"
+    "LJyLNH0fWPWYghlV938RO0jHogQyMOkquypK3zz8/QKBgQD6w/bU9p1H+BZxqyRW\n"
+    "FW+XLw5DBsqu+fK4kl0Bs2kiu94U9xI8SymmSl5sU0wfvftvWqeiCDU7V+KyzlYu\n"
+    "XHz2ZkDUqKvrfOXsdrvih47vKxF3X/7ZH1afd8/lnRu9sylnk/NB/EFwip0UrTP1\n"
+    "7qyBu+DI89NlA0uPaNJQOULHlQKBgQDWyPKI2ztHM2xL3fxnIMa3wkJXUYOwstJh\n"
+    "zP7FJBV2VTCdC/Gt9j5C2dRwDx32QlqAl1p4GWGiNr4DquBeEaFGUVkOA42OuFrX\n"
+    "kVRUa+Qg8I0xM2ocs1CFQzsoIuiFHmbt3CHkovb230ouMwJrSrZ+AanMCBJL/m34\n"
+    "1dOWZeScpQKBgBqaudBETdF535+1oYhEg+9NPb0ctlo0CG1OkfGBQFFAD0K4J8Yf\n"
+    "z05mK3hgqf3gIRHiU1CcgFFIdLO1smz+wP8/P/eP4ZV9TcN1oV9aNG7padP5akdM\n"
+    "zNrkUjkxHuVUYbssdi10/thazGmKKq4X4VNuRF3tiGr6G4UegNmkCZK1AoGAXDJ+\n"
+    "CckxtOqZ/icYBZzIMHEu0RSoltzr+hdo9W7714PSDlfmMmqVZ1TiIAgdMGxjNPfD\n"
+    "WfJrOpqNDj33eenPdMPOmnlj9nOkawxzSpnVn14i/Y+4aQF/+vRVHHF/pkTaohfw\n"
+    "ZJifsnE/An3a9/tmQsir/m0ojX517m67GMA8VhECgYAKB6xYXcP706yFeu0l2/MR\n"
+    "NsUvNEWbSSxRGDzAauWravdese3TqN+fBP2NpDrSNU8Did1CxEKQtBKpIuozMYdU\n"
+    "2SAMHArX1mcmgaO6r1dNowEBPNKKKj44vBpzT0vlYr/uAtkdRv7U7Kg5jHUXeYdz\n"
+    "yHDjiGok8w3AkYkBK9mzHg==\n"
+    "-----END PRIVATE KEY-----\n";
+
+} // namespace
+
+// Regression test for issue #135: implicit-TLS sessions never started the
+// telnet negotiation because QSslSocket::encrypted was not connected, so the
+// post-encryption branch of onSocketConnected() was unreachable.
+class TestTN5250TlsConnection : public QObject {
+    Q_OBJECT
+
+  private slots:
+    void testTlsHandshakeStartsTelnetNegotiation();
+};
+
+void TestTN5250TlsConnection::testTlsHandshakeStartsTelnetNegotiation() {
+#ifndef HAVE_QT6_SSL
+    QSKIP("Built without Qt6 SSL support");
+#else
+    if (!QSslSocket::supportsSsl()) {
+        QSKIP("No SSL backend available at runtime");
+    }
+
+    QSslServer server;
+    QSslConfiguration serverConfig = QSslConfiguration::defaultConfiguration();
+    serverConfig.setLocalCertificate(QSslCertificate(QByteArray(kTestCertPem)));
+    serverConfig.setPrivateKey(
+        QSslKey(QByteArray(kTestKeyPem), QSsl::Rsa, QSsl::Pem, QSsl::PrivateKey));
+    QVERIFY(!serverConfig.localCertificate().isNull());
+    QVERIFY(!serverConfig.privateKey().isNull());
+    server.setSslConfiguration(serverConfig);
+    QVERIFY(server.listen(QHostAddress::LocalHost, 0));
+
+    QByteArray serverReceived;
+    connect(&server, &QTcpServer::pendingConnectionAvailable, this, [&]() {
+        QTcpSocket *socket = server.nextPendingConnection();
+        connect(socket, &QTcpSocket::readyRead, this, [&serverReceived, socket]() {
+            serverReceived.append(socket->readAll());
+        });
+    });
+
+    TN5250Client client;
+    client.setAllowInvalidCertificates(true); // self-signed test certificate
+    client.connectToHost(QStringLiteral("127.0.0.1"), server.serverPort(), true);
+
+    // After the TLS handshake completes the client must proactively send its
+    // RFC 1205 option negotiation (DO/WILL BINARY, DO/WILL EOR = four 3-byte
+    // telnet commands). Without the encrypted() connection nothing is ever
+    // sent and the state stays Connecting.
+    QTRY_VERIFY_WITH_TIMEOUT(serverReceived.size() >= 12, 5000);
+    QCOMPARE(static_cast<quint8>(serverReceived[0]), quint8(0xFF)); // IAC
+
+    client.disconnectFromHost();
+#endif
+}
+
+QTEST_MAIN(TestTN5250TlsConnection)
+#include "test_tn5250_tls_connection.moc"


### PR DESCRIPTION
### Linked Issue
Closes #135

### Root Cause
The TLS signal wiring treated `QSslSocket::connected` as the "link ready" event, but Qt emits `connected()` at TCP establishment, before the TLS handshake (verified empirically: `connected()` fires with `isEncrypted() == false`, then `encrypted()` fires). `onSocketConnected()` was written to run after encryption — it checks `isEncrypted()` and early-returns otherwise — yet `QSslSocket::encrypted`, the only signal delivered at that moment, was never connected. `performHandshake()` is reachable solely from `onSocketConnected()`, so for TLS sessions the telnet negotiation never started, the state never left `Connecting`, and the 30-second connect timeout tore the session down.

### Fix Description
Connect `QSslSocket::encrypted` to the existing `onSocketConnected` slot in `connectToHost()`. On the `connected()` emission the handler still early-returns (handshake in progress); on `encrypted()` it now takes its intended path: stop the connect timeout, enter `Negotiating`, and perform the RFC 1205 negotiation. The plaintext path is untouched.

### How Verified
- **Tests:** new `tests/integration/test_tn5250_tls_connection.cpp` starts a local `QSslServer` with an embedded self-signed test certificate, connects `TN5250Client` with `useTLS=true` and `allowInvalidCertificates`, and asserts the client proactively sends its telnet negotiation (≥12 bytes starting with IAC). A/B verified in an SSL-enabled build: fails before the fix (no bytes ever sent, 16 s timeout), passes after (negotiation arrives in ~60 ms).
- **Runtime:** standalone Qt probe confirming the signal order assumption: `connected()` fires with `isEncrypted()=0`, `encrypted()` fires after the handshake.

### Test Coverage
**Added:** `tests/integration/test_tn5250_tls_connection.cpp` — `testTlsHandshakeStartsTelnetNegotiation`. Note: the test `QSKIP`s on default builds because of #136 (`HAVE_QT6_SSL` is never defined, so TLS code is compiled out); it runs for real once #136 is fixed. It was A/B verified here with the define forced on.

### Scope of Change
- **Files changed:** `src/network/tn5250_qt/client/client_connection.cpp`, `tests/integration/test_tn5250_tls_connection.cpp`, `CMakeLists.txt` (test registration)
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — plaintext connections are unaffected; for TLS, `onSocketConnected` is now additionally invoked at the moment its post-encryption branch was designed for.

### Risk and Rollout
One signal connection; the slot is idempotent with respect to the pre-encryption invocation. Safe to merge directly.

### Notes
Discovered while fixing this: `HAVE_QT6_SSL` is never defined by any build configuration, so the whole TLS path is currently dead code in shipped binaries — filed as #136 with a separate fix.