### PR TITLE
[bugfix] Fix HAVE_QT6_SSL never being defined, compiling out all TLS support (#136)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,23 @@ find_package(Qt6 REQUIRED COMPONENTS
 
 find_package(OpenSSL REQUIRED)
 
+# TLS support gate. QSslSocket ships inside Qt6::Network (there is no
+# separate Qt6::Ssl module), but some Qt builds are compiled without SSL.
+# Probe that the header is present and usable; the TLS client code paths
+# (#ifdef HAVE_QT6_SSL) are compiled in only when this succeeds. Whether an
+# SSL backend is actually loadable is still checked at runtime via
+# QSslSocket::supportsSsl().
+include(CheckCXXSourceCompiles)
+set(CMAKE_REQUIRED_LIBRARIES Qt6::Network)
+check_cxx_source_compiles("
+#include <QSslSocket>
+int main() { return QSslSocket::supportsSsl() ? 0 : 1; }
+" HAVE_QT6_SSL)
+unset(CMAKE_REQUIRED_LIBRARIES)
+if(NOT HAVE_QT6_SSL)
+    message(WARNING "Qt6 Network was built without SSL support - TLS connections will be disabled")
+endif()
+
 # Generate version header from project version
 configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/src/version.h.in
@@ -338,8 +355,8 @@ target_link_libraries(5250ng
         5250script
 )
 
+# QSslSocket lives in Qt6::Network (already linked); only the define is needed
 if(HAVE_QT6_SSL)
-    target_link_libraries(5250ng PRIVATE Qt6::Ssl)
     target_compile_definitions(5250ng PRIVATE HAVE_QT6_SSL)
 endif()
 
@@ -387,7 +404,6 @@ if(BUILD_TESTS)
             5250script
     )
     if(HAVE_QT6_SSL)
-        target_link_libraries(tn5250_core PUBLIC Qt6::Ssl)
         target_compile_definitions(tn5250_core PUBLIC HAVE_QT6_SSL)
     endif()
     target_include_directories(tn5250_core PUBLIC

--- a/src/network/tn5250_qt/client/client.h
+++ b/src/network/tn5250_qt/client/client.h
@@ -28,9 +28,18 @@
 #include <QtNetwork/QTcpSocket>
 #include <memory>
 
+#ifdef HAVE_QT6_SSL
+// moc registers the onSslErrors slot parameter (QList<QSslError>) in the
+// metatype system, which requires the complete type, not a forward
+// declaration.
+#include <QtNetwork/QSslError>
+#endif
+
 // Forward declarations for optional SSL support
 class QSslSocket;
+#ifndef HAVE_QT6_SSL
 class QSslError;
+#endif
 
 // Forward-declared in the global namespace so the friend declaration below
 // names the test class defined at file scope in tests/unit/test_telnet_subnegotiation.cpp,


### PR DESCRIPTION
### Linked Issue
Closes #136

### Root Cause
The build gates every TLS code path on `HAVE_QT6_SSL`, but no logic ever defined it: there was no `set()`, no feature probe, and no `-D` flag in any build script or workflow. The gate also linked a `Qt6::Ssl` target that does not exist in Qt 6 (QSslSocket lives in Qt6::Network), so even passing the flag manually aborted CMake generation. The result was that every binary ever produced compiled out the TLS implementation and rejected `--tls` with "TLS/SSL support is not available". Because the code had never compiled, it also hid a latent build error: `client.h` only forward-declares `QSslError`, while moc needs the complete type to register the `onSslErrors(const QList<QSslError>&)` slot parameter in the metatype system.

### Fix Description
- `CMakeLists.txt`: probe SSL support with `check_cxx_source_compiles` against `Qt6::Network` (`QSslSocket::supportsSsl()`), defining `HAVE_QT6_SSL` when the header is usable; warn when Qt was built without SSL. Runtime backend availability remains a `QSslSocket::supportsSsl()` check.
- `CMakeLists.txt`: drop the nonexistent `Qt6::Ssl` link references for both the app target and `tn5250_core`; only the compile definition is needed since Qt6::Network is already linked.
- `client.h`: include `<QtNetwork/QSslError>` under the same guard so moc can register the slot's parameter type; keep the forward declaration for SSL-less builds.

### How Verified
- **Runtime:** CMake configure now reports `Performing Test HAVE_QT6_SSL - Success` and the cache contains `HAVE_QT6_SSL:INTERNAL=1`. Full build is clean. `5250ng --host 127.0.0.1 -p 1 --tls -d` previously logged `TLS requested but SSL support not available`; it now logs `Session worker connecting to 127.0.0.1:1 (TLS=1)` followed by a genuine socket `Connection refused` — the QSslSocket path is reachable.
- **Tests:** all ctest targets pass on the SSL-enabled build. Once #137 (its TLS integration test currently `QSKIP`s on SSL-less builds) lands together with this, `test_tn5250_tls_connection` exercises a full local TLS handshake and passes.

### Test Coverage
**Existing:** `tests/integration/test_tn5250_tls_connection.cpp` (added in #137) stops skipping and runs the real TLS handshake once both PRs are merged. No additional test added here — the change is build-system feature detection, verified by the configure log and the runtime smoke test above.

### Scope of Change
- **Files changed:** `CMakeLists.txt`, `src/network/tn5250_qt/client/client.h`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none for non-TLS usage; TLS code paths go from compiled-out to compiled-in, which is the point of the fix.

### Risk and Rollout
Plaintext sessions are untouched. The newly-enabled TLS path is exercised by the #137 integration test. On Qt builds genuinely lacking SSL, the probe fails and the build behaves exactly as today (plus a configure-time warning).

### Notes
Companion to #137 — both are required for working TLS sessions: this one compiles the code in, #137 makes the handshake actually start.