### PR TITLE
[bugfix] Fix IBMRSEED seed truncation on escaped NEW_ENVIRON control bytes (#139)

### DIFF
--- a/src/network/tn5250_qt/client/client_telnet.cpp
+++ b/src/network/tn5250_qt/client/client_telnet.cpp
@@ -331,15 +331,28 @@ void TN5250Client::handleSubnegotiation(TelnetOption opt, const QByteArray &data
                     uint8_t sb = static_cast<uint8_t>(data[si]);
                     if (sb == 0x00 || sb == 0x03) { // VAR or USERVAR
                         if (!reqVars.isEmpty()) reqVars += ", ";
-                        // Read variable name + any trailing data until next marker
+                        // Read variable name + any trailing data until next
+                        // marker, un-escaping RFC 1572 ESC (0x02) sequences.
+                        // The IBMRSEED seed is 8 raw binary bytes embedded in
+                        // the USERVAR name: bytes equal to VAR/VALUE/ESC/
+                        // USERVAR arrive escaped, and treating them as
+                        // markers truncates the seed — which silently
+                        // downgrades the RFC 4777 password encryption to
+                        // cleartext (the seed fails the 8-byte check).
                         int nameStart = si + 1;
                         int nameEnd = nameStart;
+                        QByteArray rawName;
                         while (nameEnd < data.size()) {
                             uint8_t nb = static_cast<uint8_t>(data[nameEnd]);
+                            if (nb == 0x02 && nameEnd + 1 < data.size()) {
+                                rawName.append(data[nameEnd + 1]);
+                                nameEnd += 2;
+                                continue;
+                            }
                             if (nb == 0x00 || nb == 0x01 || nb == 0x03) break;
+                            rawName.append(static_cast<char>(nb));
                             nameEnd++;
                         }
-                        QByteArray rawName = data.mid(nameStart, nameEnd - nameStart);
                         // Check if this is IBMRSEED with embedded seed bytes
                         QByteArray ibmrseedTag("IBMRSEED");
                         if (rawName.startsWith(ibmrseedTag) &&

--- a/tests/unit/test_telnet_subnegotiation.cpp
+++ b/tests/unit/test_telnet_subnegotiation.cpp
@@ -32,6 +32,8 @@ class TestTelnetSubnegotiation : public QObject {
   private slots:
     void testEscapedIacInsideSubnegotiationStaysInSbBuffer();
     void testEscapedIacOutsideSubnegotiationFlowsAsAppData();
+    void testIbmrseedSeedWithEscapedControlBytes();
+    void testIbmrseedPlainSeedStillParsed();
 
   private:
     static QByteArray makeFrame(std::initializer_list<uint8_t> bytes) {
@@ -104,6 +106,56 @@ void TestTelnetSubnegotiation::testEscapedIacOutsideSubnegotiationFlowsAsAppData
         received.append(args.at(0).toByteArray());
     }
     QCOMPARE(received, QByteArray::fromHex("58FF59")); // X 0xFF Y
+}
+
+// Regression tests for issue #139: the NEW_ENVIRON SEND parser must
+// un-escape RFC 1572 ESC (0x02) sequences when reading the IBMRSEED
+// USERVAR name, otherwise seed bytes equal to VAR/VALUE/USERVAR markers
+// truncate the seed and silently disable RFC 4777 password encryption.
+void TestTelnetSubnegotiation::testIbmrseedSeedWithEscapedControlBytes() {
+    TN5250Client client;
+
+    // NEW_ENVIRON SEND payload: SEND USERVAR "IBMRSEED" <8-byte seed>
+    // USERVAR "IBMSUBSPW". The seed contains 0x00, 0x01, 0x02 and 0x03,
+    // each ESC-escaped per RFC 1572.
+    QByteArray sb;
+    sb.append(char(0x01)); // SEND
+    sb.append(char(0x03)); // USERVAR
+    sb.append("IBMRSEED");
+    const uint8_t seed[8] = {0xAA, 0x00, 0x01, 0x02, 0x03, 0xBB, 0xCC, 0xDD};
+    for (uint8_t b : seed) {
+        if (b == 0x00 || b == 0x01 || b == 0x02 || b == 0x03) {
+            sb.append(char(0x02)); // RFC 1572 ESC
+        }
+        sb.append(char(b));
+    }
+    sb.append(char(0x03)); // USERVAR
+    sb.append("IBMSUBSPW");
+
+    client.handleSubnegotiation(TelnetOption::NEW_ENVIRON, sb);
+
+    QCOMPARE(client.m_serverSeed.size(), 8);
+    QCOMPARE(client.m_serverSeed,
+             QByteArray(reinterpret_cast<const char *>(seed), 8));
+}
+
+// A seed without escapable bytes must parse exactly as before.
+void TestTelnetSubnegotiation::testIbmrseedPlainSeedStillParsed() {
+    TN5250Client client;
+
+    QByteArray sb;
+    sb.append(char(0x01)); // SEND
+    sb.append(char(0x03)); // USERVAR
+    sb.append("IBMRSEED");
+    const uint8_t seed[8] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88};
+    sb.append(reinterpret_cast<const char *>(seed), 8);
+    sb.append(char(0x03)); // USERVAR
+    sb.append("IBMSUBSPW");
+
+    client.handleSubnegotiation(TelnetOption::NEW_ENVIRON, sb);
+
+    QCOMPARE(client.m_serverSeed,
+             QByteArray(reinterpret_cast<const char *>(seed), 8));
 }
 
 QTEST_MAIN(TestTelnetSubnegotiation)


### PR DESCRIPTION
### Linked Issue
Closes #139

### Root Cause
The NEW_ENVIRON SEND parser scanned the USERVAR name byte-by-byte and stopped at the first VAR (0x00), VALUE (0x01), or USERVAR (0x03) marker, with no awareness of RFC 1572 ESC (0x02) escaping. The IBMRSEED server seed is 8 raw binary bytes embedded in that name, and RFC 1572 requires marker octets within names to be ESC-escaped — which the project's own send side already does for the client seed and DEVNAME (#120). Because the receive side treated escaped markers as terminators (and left stray 0x02 bytes in the name otherwise), any seed containing 0x00/0x01/0x02/0x03 was truncated or corrupted, failed the `m_serverSeed.size() == 8` gate in `sendNewEnviron()`, and silently downgraded RFC 4777 password substitution to a cleartext password — for roughly 9 % of random seeds.

### Fix Description
Rewrite the name scan in `handleSubnegotiation()` to accumulate the name with RFC 1572 un-escaping: an ESC byte causes the following byte to be taken literally; unescaped marker bytes still terminate the name. Plain names (and seeds without escapable bytes) parse byte-for-byte as before. This mirrors the escaping already applied on the send side, making the round trip symmetric.

### How Verified
- **Tests:** two new cases in `tests/unit/test_telnet_subnegotiation.cpp` (the friend-class harness with access to `m_serverSeed`):
  - `testIbmrseedSeedWithEscapedControlBytes` — a SEND payload whose seed contains 0x00/0x01/0x02/0x03, each ESC-escaped, followed by `USERVAR IBMSUBSPW`; asserts the full 8-byte seed is recovered. A/B verified: fails before the fix (seed truncated at the first escaped marker), passes after.
  - `testIbmrseedPlainSeedStillParsed` — an unescaped 8-byte seed parses identically to the old behavior.
- Full `test_telnet_subnegotiation` suite passes (6/6), as do all other test targets.

### Test Coverage
**Added:** `tests/unit/test_telnet_subnegotiation.cpp` — `testIbmrseedSeedWithEscapedControlBytes`, `testIbmrseedPlainSeedStillParsed`.

### Scope of Change
- **Files changed:** `src/network/tn5250_qt/client/client_telnet.cpp`, `tests/unit/test_telnet_subnegotiation.cpp`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — names without ESC bytes parse identically (covered by the plain-seed test); the change also benefits the debug log of requested variable names, which previously split on escaped bytes.

### Risk and Rollout
Localized to NEW_ENVIRON SEND parsing. Servers that send unescaped seeds (already handled today only when the seed happens to contain no marker bytes) behave exactly as before. Safe to merge directly.