### PR TITLE
[bugfix] Fix PageUp/PageDown sending inverted Roll AID bytes (#141)

### DIFF
--- a/docs/5250script.md
+++ b/docs/5250script.md
@@ -93,8 +93,8 @@ AID (Attention Identifier) keys send data to the host and lock the keyboard unti
 | `F22`       | Function key 22            |
 | `F23`       | Function key 23            |
 | `F24`       | Function key 24            |
-| `PAGEUP`    | Page Up (Roll Up)          |
-| `PAGEDOWN`  | Page Down (Roll Down)      |
+| `PAGEUP`    | Page Up (Roll Down)        |
+| `PAGEDOWN`  | Page Down (Roll Up)        |
 | `ATTN`      | Attention                  |
 | `SYSREQ`    | System Request             |
 | `HELP`      | Help                       |

--- a/src/core/keyboard_encoder.cpp
+++ b/src/core/keyboard_encoder.cpp
@@ -66,11 +66,15 @@ QByteArray KeyboardEncoder::encodeKeyEvent(QKeyEvent *event, bool shiftPressed, 
     case Qt::Key_End:
         return encodeAction(KeyboardAction::End);
 
+    // 5250 Roll AIDs use window-movement semantics (SA21-9247): Roll Down
+    // (0xF4) shows the previous page, Roll Up (0xF5) shows the next page.
+    // PC Page Up therefore maps to Roll Down and Page Down to Roll Up,
+    // matching the AID comments in keyboard_encoder.h.
     case Qt::Key_PageUp:
-        return encodeAction(KeyboardAction::RollUp);
+        return encodeAction(KeyboardAction::RollDown);
 
     case Qt::Key_PageDown:
-        return encodeAction(KeyboardAction::RollDown);
+        return encodeAction(KeyboardAction::RollUp);
 
     case Qt::Key_Up:
         return encodeAction(KeyboardAction::ArrowUp);

--- a/src/core/keyboard_mapping.cpp
+++ b/src/core/keyboard_mapping.cpp
@@ -125,8 +125,9 @@ void KeyboardMapping::resetToDefaults() {
     m_chordToAction.insert({Qt::Key_Enter, Qt::NoModifier}, MappedAction::Enter);
     m_chordToAction.insert({Qt::Key_Escape, Qt::ControlModifier}, MappedAction::Attn);
     m_chordToAction.insert({Qt::Key_SysReq, Qt::NoModifier}, MappedAction::SysReq);
-    m_chordToAction.insert({Qt::Key_PageUp, Qt::NoModifier}, MappedAction::RollUp);
-    m_chordToAction.insert({Qt::Key_PageDown, Qt::NoModifier}, MappedAction::RollDown);
+    // Page Up = Roll Down (previous page), Page Down = Roll Up (next page)
+    m_chordToAction.insert({Qt::Key_PageUp, Qt::NoModifier}, MappedAction::RollDown);
+    m_chordToAction.insert({Qt::Key_PageDown, Qt::NoModifier}, MappedAction::RollUp);
     m_chordToAction.insert({Qt::Key_Tab, Qt::NoModifier}, MappedAction::Tab);
     m_chordToAction.insert({Qt::Key_Backtab, Qt::NoModifier}, MappedAction::BackTab);
     m_chordToAction.insert({Qt::Key_Tab, Qt::ShiftModifier}, MappedAction::BackTab);

--- a/tests/unit/test_keyboard_encoder.cpp
+++ b/tests/unit/test_keyboard_encoder.cpp
@@ -34,6 +34,7 @@ class TestKeyboardEncoder : public QObject {
     void testGetPFKeyNumber();
     void testEnterKey();
     void testTabKeys();
+    void testPageKeysSendRollAids();
     void testArrowKeys();
 
   private:
@@ -126,6 +127,21 @@ void TestKeyboardEncoder::testTabKeys() {
     QKeyEvent backTabEvent(QEvent::KeyPress, Qt::Key_Tab, Qt::ShiftModifier);
     QByteArray backTab = m_encoder->encodeKeyEvent(&backTabEvent);
     QVERIFY(backTab.isEmpty());
+}
+
+// Regression test for issue #141: 5250 Roll AIDs use window-movement
+// semantics — Page Up must send Roll Down (0xF4, previous page) and
+// Page Down must send Roll Up (0xF5, next page), not the other way round.
+void TestKeyboardEncoder::testPageKeysSendRollAids() {
+    QKeyEvent pageUpEvent(QEvent::KeyPress, Qt::Key_PageUp, Qt::NoModifier);
+    QByteArray pageUp = m_encoder->encodeKeyEvent(&pageUpEvent);
+    QCOMPARE(pageUp.size(), 1);
+    QCOMPARE(static_cast<uint8_t>(pageUp[0]), static_cast<uint8_t>(0xF4));
+
+    QKeyEvent pageDownEvent(QEvent::KeyPress, Qt::Key_PageDown, Qt::NoModifier);
+    QByteArray pageDown = m_encoder->encodeKeyEvent(&pageDownEvent);
+    QCOMPARE(pageDown.size(), 1);
+    QCOMPARE(static_cast<uint8_t>(pageDown[0]), static_cast<uint8_t>(0xF5));
 }
 
 void TestKeyboardEncoder::testArrowKeys() {

--- a/tests/unit/test_keyboard_mapping.cpp
+++ b/tests/unit/test_keyboard_mapping.cpp
@@ -29,6 +29,7 @@ class TestKeyboardMapping : public QObject {
     void init();
 
     void testDefaultsContainExpectedActions();
+    void testDefaultPageKeysMapToRollActions();
     void testShiftF1IsPF13();
     void testCtrlEscapeIsAttn();
     void testSetAndLookup();
@@ -71,6 +72,15 @@ void TestKeyboardMapping::testDefaultsContainExpectedActions() {
         KeyChord c = m.chordFor(action);
         QVERIFY2(c.isValid(), qPrintable(QString("PF%1 should have a default chord").arg(i)));
     }
+}
+
+// Regression test for issue #141: Page Up pages backward (Roll Down),
+// Page Down pages forward (Roll Up).
+void TestKeyboardMapping::testDefaultPageKeysMapToRollActions() {
+    KeyboardMapping &m = KeyboardMapping::instance();
+    m.resetToDefaults();
+    QCOMPARE(m.lookup(Qt::Key_PageUp, Qt::NoModifier), MappedAction::RollDown);
+    QCOMPARE(m.lookup(Qt::Key_PageDown, Qt::NoModifier), MappedAction::RollUp);
 }
 
 void TestKeyboardMapping::testShiftF1IsPF13() {

--- a/tests/unit/test_script_parser.cpp
+++ b/tests/unit/test_script_parser.cpp
@@ -163,15 +163,17 @@ void TestScriptParser::testPressKey() {
 }
 
 void TestScriptParser::testAIDKeys() {
-    auto result = m_parser->parse("ENTER\nF1\nF12\nPAGEUP");
+    auto result = m_parser->parse("ENTER\nF1\nF12\nPAGEUP\nPAGEDOWN");
     QVERIFY(!result.hasErrors());
-    QCOMPARE(result.root->children.size(), 4);
+    QCOMPARE(result.root->children.size(), 5);
     for (const auto &child : result.root->children)
         QCOMPARE(child->type, NodeType::AIDKey);
     QCOMPARE(result.root->children[0]->aidByte, static_cast<uint8_t>(0xF1));
     QCOMPARE(result.root->children[1]->aidByte, static_cast<uint8_t>(0x31));
     QCOMPARE(result.root->children[2]->aidByte, static_cast<uint8_t>(0x3C));
-    QCOMPARE(result.root->children[3]->aidByte, static_cast<uint8_t>(0xF5));
+    // PAGEUP = Roll Down (0xF4, previous page), PAGEDOWN = Roll Up (0xF5)
+    QCOMPARE(result.root->children[3]->aidByte, static_cast<uint8_t>(0xF4));
+    QCOMPARE(result.root->children[4]->aidByte, static_cast<uint8_t>(0xF5));
 }
 
 void TestScriptParser::testLocalKeys() {


### PR DESCRIPTION
### Linked Issue
Closes #141

### Root Cause
5250 Roll AIDs use window-movement semantics (SA21-9247): Roll Down (0xF4) shows the previous page, Roll Up (0xF5) the next page — IBM ACS and tn5250 both map PC Page Down to Roll Up accordingly, and the project's own AID constants document exactly that (`keyboard_encoder.h:115-116`: "0xF4 Roll Down / Page Up", "0xF5 Roll Up / Page Down"). The key maps were written with the opposite, screen-content reading of the names: `Key_PageUp → RollUp` in the encoder, the same pair in the default chord map, and `PAGEUP → 0xF5` in the 5250script parser. Every paging input — keys, wheel scrolling (which synthesizes PageUp/PageDown), and scripts — therefore rolled the host the wrong way.

### Fix Description
Swap the key-to-action mappings at all three sites:
- `keyboard_encoder.cpp`: `Key_PageUp → RollDown`, `Key_PageDown → RollUp` (with a comment pinning the semantics).
- `keyboard_mapping.cpp` defaults: same swap. User-saved custom mappings are unaffected; only the defaults change.
- `5250script` submodule (`src/script_parser.cpp`): `PAGEUP → 0xF4`, `PAGEDOWN → 0xF5` — submodule PR 5250ng/5250script#8, pointer bumped here.
- `docs/5250script.md`: keyword table updated to the corrected Roll directions.

The virtual keyboard's explicit "Roll↑"/"Roll↓" buttons name the 5250 functions directly and were already correct; they are unchanged.

### How Verified
- **Tests:**
  - `test_keyboard_encoder` — new `testPageKeysSendRollAids` asserts `encodeKeyEvent(PageUp)` emits 0xF4 and `PageDown` emits 0xF5.
  - `test_keyboard_mapping` — new `testDefaultPageKeysMapToRollActions` asserts the default chords resolve to `RollDown`/`RollUp` respectively.
  - `test_script_parser` — `testAIDKeys` extended to both keywords with the corrected bytes (parent copy and submodule copy).
  All fail against the old mapping and pass with the fix; the full suite is green.
- **Static:** `events.cpp:199-200` dispatches `MappedAction::RollUp/RollDown` 1:1 to `KeyboardAction::RollUp/RollDown`, and `getAIDForAction` maps those to 0xF5/0xF4 — so with the swapped defaults the wire bytes match the AID documentation for every input path, including `wheelEvent`'s synthesized PageUp/PageDown.

### Test Coverage
**Added:** `testPageKeysSendRollAids` (test_keyboard_encoder), `testDefaultPageKeysMapToRollActions` (test_keyboard_mapping). **Existing (updated):** `testAIDKeys` (test_script_parser, both copies).

### Scope of Change
- **Files changed:** `src/core/keyboard_encoder.cpp`, `src/core/keyboard_mapping.cpp`, `docs/5250script.md`, `tests/unit/test_keyboard_encoder.cpp`, `tests/unit/test_keyboard_mapping.cpp`, `tests/unit/test_script_parser.cpp`, submodule pointer `libs/5250script`
- **Submodule pointer updated:** yes — `libs/5250script` to the commit of 5250ng/5250script#8
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Users who saved a custom keyboard mapping keep their bindings (only defaults changed). Users who had internalized the inverted behavior will see paging match the key labels from now on. Merge 5250ng/5250script#8 first, then this PR.

### Notes
`tools/mcp_client.py` and the MCP `send_keys` documentation expose PAGEUP/PAGEDOWN by name only; their behavior is corrected transitively through the script parser.