### PR TITLE
[bugfix] Fix use-after-free from queued worker events on tab close (#143)

### DIFF
--- a/src/ui/actions/onCloseTabRequested.cpp
+++ b/src/ui/actions/onCloseTabRequested.cpp
@@ -16,6 +16,7 @@
 
 #include "../main_window.h"
 #include "mcp/McpServer.h"
+#include <QCoreApplication>
 
 void MainWindow::onCloseTabRequested(int index) {
     if (index < 0 || index >= m_sessions.size()) {
@@ -86,6 +87,16 @@ void MainWindow::onCloseTabRequested(int index) {
         s->container->deleteLater();
         s->container = nullptr;
     }
+    // The worker emitted its signals via queued connections from its own
+    // thread, so QMetaCallEvents holding the per-session lambdas (which
+    // capture the raw Session*) may already sit in this thread's event
+    // queue. disconnect() does not remove already-posted events, and they
+    // are only auto-discarded when the receiver (MainWindow) dies — not
+    // when the captured Session is freed. Deliver them now, while the
+    // struct is still alive: the nulled pointers above and the removed
+    // m_sessions entry make every stale lambda a no-op. The worker thread
+    // has been stopped, so no new events can arrive after this point.
+    QCoreApplication::sendPostedEvents(this, QEvent::MetaCall);
     delete s;
     if (!m_sessions.isEmpty()) {
         int newIndex = qMin(index, m_sessions.size() - 1);


### PR DESCRIPTION
### Linked Issue
Closes #143

### Root Cause
The per-session lambdas connected to `Worker` signals (`appData`, `stateChanged`, `errorOccurred`) capture the raw `Session*` and run as queued connections, because the worker lives in its own `QThread`. Each emission posts a `QMetaCallEvent` containing the lambda to the main thread's queue. The teardown in `onCloseTabRequested()` relied on `disconnect()` plus nulling the struct's pointers — which stops future emissions and disarms lambdas that run while the struct is alive — but `delete s` freed the struct while already-posted events could still be queued. Qt only auto-discards posted meta-calls when the receiver object dies, and the receiver here is `MainWindow`, not the `Session`; so a stale event delivering after `delete s` read `session->parser` (and siblings) from freed memory.

### Fix Description
After the worker thread has been stopped (`thread->quit(); wait()`) and the session removed from `m_sessions`/the tab bar, flush the pending meta-call events for `MainWindow` with `QCoreApplication::sendPostedEvents(this, QEvent::MetaCall)` immediately before `delete s`. At that point the existing guards make every stale lambda a no-op: the struct's QObject pointers are nulled and `m_sessions.indexOf(session)` returns -1. Because the worker thread is already stopped, no new events can be posted after the flush, so `delete s` is safe.

Alternatives considered: capturing `QPointer`s in every lambda (touches five connect sites and still leaves the raw struct capture for `config`/flag reads) and deferring `delete s` via a zero-timer (ordering between posted events and timer events is not contractual). The flush is one line at the exact point the invariant must hold.

### How Verified
- **Static:** with the flush placed after thread shutdown and session removal, the event queue is provably empty of session-referencing meta-calls when `delete s` executes: stale events are delivered against a live struct whose guards (`if (session->parser)`, `if (session->connectionStatus)`, `indexOf == -1`) short-circuit, and the stopped worker thread cannot post new ones. Reviewed each worker-signal lambda for unguarded member access during the flush window: `stateChanged`'s global-status branch is gated on `indexOf(session) == m_activeIndex`, which cannot match the removed session since `m_activeIndex` still refers to a pre-close index.
- **Runtime:** full build clean; app opens/closes sessions normally (offscreen smoke run).

### Test Coverage
**None:** the race requires a worker-thread emission to be posted but undelivered at the exact moment the user closes the tab — not deterministically reproducible from a unit test without instrumenting the event loop. The fix is a queue-flush whose correctness follows from the event-delivery order argued above.

### Scope of Change
- **Files changed:** `src/ui/actions/onCloseTabRequested.cpp`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** stale queued events (e.g. a final `stateChanged`) now run their no-op path during close instead of after; no observable UI difference.

### Risk and Rollout
`sendPostedEvents` is scoped to `MainWindow`'s meta-calls and runs on the GUI thread it belongs to; other sessions' queued events simply deliver a few microseconds earlier than they otherwise would. Safe to merge directly.