### PR TITLE
[bugfix] Fix OAuth token exchange omitting redirect_uri (#145)

### DIFF
--- a/src/agent/auth/oauth_flow.cpp
+++ b/src/agent/auth/oauth_flow.cpp
@@ -49,13 +49,13 @@ void OAuthFlow::start() {
     }
 
     quint16 port = m_server.serverPort();
-    QString redirectUri = QStringLiteral("http://127.0.0.1:%1/callback").arg(port);
+    m_redirectUri = QStringLiteral("http://127.0.0.1:%1/callback").arg(port);
 
     QUrl authUrl(m_config.authorizationEndpoint);
     QUrlQuery query;
     query.addQueryItem("response_type", "code");
     query.addQueryItem("client_id", m_config.clientId);
-    query.addQueryItem("redirect_uri", redirectUri);
+    query.addQueryItem("redirect_uri", m_redirectUri);
     query.addQueryItem("code_challenge", QString::fromLatin1(computeCodeChallenge(m_codeVerifier)));
     query.addQueryItem("code_challenge_method", "S256");
     query.addQueryItem("state", QString::fromLatin1(m_state));
@@ -143,12 +143,6 @@ void OAuthFlow::onNewConnection() {
 }
 
 void OAuthFlow::exchangeCode(const QString &code) {
-    // Server may already be closed, but we stored the port from the redirect_uri
-    // Reconstruct the redirect_uri used during authorization
-    // Note: we need the same redirect_uri that was used in the authorization request
-    // The server was on an ephemeral port, so we reconstruct it from the URL the browser hit.
-    // Since the server is closed now, we just build the same URI string.
-
     QUrl tokenUrl(m_config.tokenEndpoint);
     QNetworkRequest request(tokenUrl);
     request.setHeader(QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded");
@@ -157,6 +151,10 @@ void OAuthFlow::exchangeCode(const QString &code) {
     params.addQueryItem("grant_type", "authorization_code");
     params.addQueryItem("code", code);
     params.addQueryItem("client_id", m_config.clientId);
+    // RFC 6749 §4.1.3: redirect_uri is REQUIRED here (and must be identical)
+    // because the authorization request included it. The callback server may
+    // already be closed, so the value was saved in start().
+    params.addQueryItem("redirect_uri", m_redirectUri);
     params.addQueryItem("code_verifier", QString::fromLatin1(m_codeVerifier));
 
     QNetworkReply *reply = m_nam.post(request, params.query(QUrl::FullyEncoded).toUtf8());

--- a/src/agent/auth/oauth_flow.h
+++ b/src/agent/auth/oauth_flow.h
@@ -61,6 +61,10 @@ class OAuthFlow : public QObject {
     QNetworkAccessManager m_nam;
     QByteArray m_codeVerifier;
     QByteArray m_state;
+    // Redirect URI sent in the authorization request. RFC 6749 §4.1.3
+    // requires the token request to repeat the identical value, and the
+    // callback server may already be closed by then, so it is kept here.
+    QString m_redirectUri;
     bool m_completed = false;
 };
 


### PR DESCRIPTION
### Linked Issue
Closes #145

### Root Cause
The redirect URI was built as a local variable inside `OAuthFlow::start()` for the authorization request and never retained. When `exchangeCode()` later built the token request, the value was unavailable — the function's comment block even described reconstructing it but no code did — so the POST carried only `grant_type`, `code`, `client_id`, and `code_verifier`. RFC 6749 §4.1.3 requires the token request to repeat the identical `redirect_uri` whenever the authorization request included one; conforming servers reject the exchange with `invalid_grant`, ending every OAuth sign-in in `flowFailed`.

### Fix Description
Store the redirect URI in a new `m_redirectUri` member when `start()` builds it (the callback server may already be closed at exchange time, so it cannot be re-derived from the listener), and add it to the token-request parameters in `exchangeCode()`. The stale narrative comment is replaced by one stating the RFC requirement.

### How Verified
- **Static:** the token request now contains the exact string sent in the authorization request — both reference the same `m_redirectUri` member, satisfying the "values MUST be identical" clause of §4.1.3. `exchangeCode()` is only reachable from the callback handler, which runs strictly after `start()` populated the member.
- **Runtime:** full build clean; existing test suite passes.

### Test Coverage
**None:** exercising the exchange requires a live (or mocked) OAuth authorization server plus a browser round-trip; the project has no HTTP-mocking harness for `QNetworkAccessManager`. The change is a single required parameter whose presence is verifiable by inspection of the request construction.

### Scope of Change
- **Files changed:** `src/agent/auth/oauth_flow.cpp`, `src/agent/auth/oauth_flow.h`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Adds one parameter to the token POST. Servers that tolerated its absence ignore nothing new (the value matches the authorization request); servers that enforced the RFC start working. Safe to merge directly.