### PR TITLE
[bugfix] Fix match-replace overlay leaking original text past shortening replacements (#147)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -416,6 +416,7 @@ if(BUILD_TESTS)
     add_tn5250_test(test_codepage tests/unit/test_codepage.cpp)
 
     add_tn5250_test(test_terminal_theme tests/unit/test_terminal_theme.cpp)
+    add_tn5250_test(test_match_replace tests/unit/test_match_replace.cpp)
 
     # Host server tests
     add_tn5250_test(test_host_data_stream tests/unit/test_host_data_stream.cpp)

--- a/src/core/match_replace_engine.cpp
+++ b/src/core/match_replace_engine.cpp
@@ -49,15 +49,19 @@ void MatchReplaceEngine::rebuildOverlay(const QVector<QString> &decodedLines, in
         if (replaced == original) continue;
 
         int base = r * cols;
-        int len = qMin(replaced.size(), cols);
+        // Cover the full extent of both lines: when the replacement shrinks
+        // the row, the cells past the end of `replaced` must be overlaid
+        // with blanks, otherwise the original (now shifted-out) characters
+        // keep showing there — leaking exactly the text the rule rewrote.
+        int len = qMin(qMax(replaced.size(), original.size()), qsizetype(cols));
         for (int c = 0; c < len; ++c) {
             QChar origCh = (c < original.size()) ? original[c] : QChar(' ');
-            if (replaced[c] != origCh) {
-                m_overlay[base + c] = replaced[c];
+            QChar replCh = (c < replaced.size()) ? replaced[c] : QChar(' ');
+            if (replCh != origCh) {
+                m_overlay[base + c] = replCh;
                 m_overlayActive[base + c] = true;
             }
         }
-        // If replacement is shorter than original, remaining cells stay original
         // If replacement is longer than cols, truncated (grid is fixed-width)
     }
 }

--- a/tests/unit/test_match_replace.cpp
+++ b/tests/unit/test_match_replace.cpp
@@ -1,0 +1,115 @@
+// 5250ng - A modern IBM TN5250 terminal emulator
+// Copyright (C) 2025-2026 Remi GASCOU (Podalirius)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include "core/match_replace_engine.h"
+
+#include <QtTest/QtTest>
+
+using core::MatchReplaceEngine;
+using core::MatchReplaceRule;
+
+class TestMatchReplace : public QObject {
+    Q_OBJECT
+
+  private slots:
+    void init();
+    void cleanup();
+
+    void testSameLengthReplacementOverlaysDiffs();
+    void testShorterReplacementBlanksDisplacedTail();
+    void testShorterReplacementMasksFullSecret();
+    void testLongerReplacementTruncatedAtCols();
+    void testDisabledEngineProducesNoOverlay();
+
+  private:
+    // Renders row 0 of the overlay applied over `original`, the way the
+    // screen widget does at paint time.
+    QString renderedRow(const QString &original, int cols) const {
+        QString out;
+        for (int c = 0; c < cols; ++c) {
+            if (m_engine->hasOverlay(0, c)) {
+                out += m_engine->overlayChar(0, c);
+            } else {
+                out += (c < original.size()) ? original[c] : QChar(' ');
+            }
+        }
+        return out;
+    }
+
+    MatchReplaceEngine *m_engine = nullptr;
+};
+
+void TestMatchReplace::init() {
+    m_engine = new MatchReplaceEngine(this);
+    m_engine->setEnabled(true);
+}
+
+void TestMatchReplace::cleanup() {
+    delete m_engine;
+    m_engine = nullptr;
+}
+
+void TestMatchReplace::testSameLengthReplacementOverlaysDiffs() {
+    m_engine->setRules({MatchReplaceRule{"PROD", "TEST", false, true, true}});
+    const int cols = 20;
+    QString row = QStringLiteral("SYS: PROD READY     ");
+    m_engine->rebuildOverlay({row}, 1, cols);
+    QCOMPARE(renderedRow(row, cols), QStringLiteral("SYS: TEST READY     "));
+}
+
+// Regression test for issue #147: a replacement shorter than its match must
+// not leave the displaced original characters visible after the replaced
+// text.
+void TestMatchReplace::testShorterReplacementBlanksDisplacedTail() {
+    m_engine->setRules({MatchReplaceRule{"LONGVALUE", "X", false, true, true}});
+    const int cols = 20;
+    QString row = QStringLiteral("A LONGVALUE B       ");
+    m_engine->rebuildOverlay({row}, 1, cols);
+    QCOMPARE(renderedRow(row, cols), QStringLiteral("A X B               "));
+}
+
+void TestMatchReplace::testShorterReplacementMasksFullSecret() {
+    // The motivating case: masking a value at the end of the row. Before the
+    // fix the rendered row ended in "***WORD" because cells past the end of
+    // the shrunk line kept their original characters.
+    m_engine->setRules({MatchReplaceRule{"PASSWORD", "***", false, true, true}});
+    const int cols = 12;
+    QString row = QStringLiteral("    PASSWORD");
+    m_engine->rebuildOverlay({row}, 1, cols);
+    QString rendered = renderedRow(row, cols);
+    QCOMPARE(rendered, QStringLiteral("    ***     "));
+    QVERIFY(!rendered.contains(QStringLiteral("WORD")));
+}
+
+void TestMatchReplace::testLongerReplacementTruncatedAtCols() {
+    m_engine->setRules({MatchReplaceRule{"AB", "0123456789", false, true, true}});
+    const int cols = 8;
+    QString row = QStringLiteral("      AB");
+    m_engine->rebuildOverlay({row}, 1, cols);
+    QCOMPARE(renderedRow(row, cols), QStringLiteral("      01"));
+}
+
+void TestMatchReplace::testDisabledEngineProducesNoOverlay() {
+    m_engine->setRules({MatchReplaceRule{"A", "B", false, true, true}});
+    m_engine->setEnabled(false);
+    const int cols = 4;
+    QString row = QStringLiteral("AAAA");
+    m_engine->rebuildOverlay({row}, 1, cols);
+    QCOMPARE(renderedRow(row, cols), row);
+}
+
+QTEST_MAIN(TestMatchReplace)
+#include "test_match_replace.moc"


### PR DESCRIPTION
### Linked Issue
Closes #147

### Root Cause
`rebuildOverlay()` bounded its per-row loop at `qMin(replaced.size(), cols)`, i.e. the length of the line *after* applying the rules. A replacement shorter than its match shifts the rest of the line left, so the cells between the shrunk line's end and the row width hold original characters that the replacement displaced — but the loop never visited them, so they were neither overlaid nor blanked, and the renderer kept painting them from the unmodified screen buffer. The result spliced replaced and original text (`PASSWORD → ***` rendered as `***SWORD` when the match sat at the row's end), partially defeating masking rules.

### Fix Description
Extend the loop to cover the union of both line lengths, capped at the row width, and compare per-cell against a blank-padded replacement (`replCh = c < replaced.size() ? replaced[c] : ' '`). Cells the replacement vacated now get an explicit blank overlay; cells where original and padded replacement agree (the common case: trailing blanks) remain un-overlaid, preserving the engine's diff-only overlay design. Same-length and lengthening replacements behave exactly as before.

### How Verified
- **Tests:** new `tests/unit/test_match_replace.cpp` (the engine previously had no unit test) rendering rows the way the screen widget does: same-length replacement, shrinking replacement mid-row (`A LONGVALUE B` → `A X B` with the tail blanked), the masking case (`PASSWORD → ***` leaves no `WORD` residue on screen), lengthening replacement truncated at the grid width, and disabled-engine no-op. A/B verified: the two shrinking-replacement cases fail before the fix and pass after; the other three pass on both, demonstrating no behavior change outside the bug.
- Full suite passes.

### Test Coverage
**Added:** `tests/unit/test_match_replace.cpp` (new CMake target `test_match_replace`) — five cases listed above.

### Scope of Change
- **Files changed:** `src/core/match_replace_engine.cpp`, `tests/unit/test_match_replace.cpp`, `CMakeLists.txt`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Loop-bound widening in one function; rows without shrinking replacements produce identical overlays. Safe to merge directly.