### PR TITLE
[bugfix] Fix signon auth scheme byte disagreeing with password algorithm at level >= 4 (#149)

### DIFF
--- a/src/network/hostserver/password_encrypt.cpp
+++ b/src/network/hostserver/password_encrypt.cpp
@@ -43,9 +43,13 @@ QByteArray PasswordEncrypt::generateSeed() {
 }
 
 uint8_t PasswordEncrypt::authScheme(uint8_t passwordLevel) {
+    // Must always describe the algorithm encrypt() actually uses for the
+    // same level. SHA-512/PBKDF2 substitution (scheme 0x07, QPWDLVL 4) is
+    // not implemented, and encrypt() falls back to SHA-1 for levels >= 2 —
+    // declaring 0x07 while sending a SHA-1 digest makes the server reject
+    // the signon with a mismatched credential.
     if (passwordLevel <= 1) return 0x01; // DES
-    if (passwordLevel <= 3) return 0x03; // SHA-1
-    return 0x07; // SHA-512/PBKDF2
+    return 0x03;                         // SHA-1
 }
 
 QByteArray PasswordEncrypt::encrypt(const QString &userId,

--- a/src/network/hostserver/signon_client.cpp
+++ b/src/network/hostserver/signon_client.cpp
@@ -251,6 +251,13 @@ void SignonClient::sendSignonInfo() {
     }
 
     uint8_t authScheme = PasswordEncrypt::authScheme(m_passwordLevel);
+    if (m_passwordLevel >= 4) {
+        logger::Logger::instance()->warning(
+            QString("[SignonClient] Server reports password level %1 "
+                    "(SHA-512/PBKDF2 substitution), which is not implemented; "
+                    "attempting SHA-1 substitution instead")
+                .arg(m_passwordLevel));
+    }
 
     // Build template: 1 byte auth scheme
     QByteArray templateData;

--- a/tests/unit/test_password_encrypt.cpp
+++ b/tests/unit/test_password_encrypt.cpp
@@ -40,7 +40,10 @@ class TestPasswordEncrypt : public QObject {
         QCOMPARE(PasswordEncrypt::authScheme(1), static_cast<uint8_t>(0x01)); // DES
         QCOMPARE(PasswordEncrypt::authScheme(2), static_cast<uint8_t>(0x03)); // SHA-1
         QCOMPARE(PasswordEncrypt::authScheme(3), static_cast<uint8_t>(0x03)); // SHA-1
-        QCOMPARE(PasswordEncrypt::authScheme(4), static_cast<uint8_t>(0x07)); // SHA-512
+        // Levels >= 4 (QPWDLVL 4, SHA-512/PBKDF2) are not implemented:
+        // encrypt() falls back to SHA-1, so the declared scheme must match
+        // the algorithm actually used (issue #149).
+        QCOMPARE(PasswordEncrypt::authScheme(4), static_cast<uint8_t>(0x03)); // SHA-1 fallback
     }
 
     void testEncryptDES() {


### PR DESCRIPTION
### Linked Issue
Closes #149

### Root Cause
`PasswordEncrypt::authScheme()` enumerated the protocol's scheme identifiers — including 0x07 (SHA-512/PBKDF2) for password levels ≥ 4 — while `PasswordEncrypt::encrypt()` only implements DES (levels ≤ 1) and SHA-1 (everything else). `sendSignonInfo()` feeds the same `m_passwordLevel` to both, so against a QPWDLVL 4 host the signon template declared SHA-512/PBKDF2 but carried a 20-byte SHA-1 substitute. The two functions made contradictory claims about the same payload, and the server rejected the credential with a mismatch instead of a comprehensible unsupported-level failure.

### Fix Description
- `authScheme()` now returns 0x03 (SHA-1) for every level ≥ 2, matching what `encrypt()` actually produces, with a comment pinning the invariant.
- `sendSignonInfo()` logs a warning when the server reports level ≥ 4, stating that SHA-512/PBKDF2 substitution is not implemented and SHA-1 is being attempted — making the limitation observable instead of silent.

Implementing real PBKDF2-SHA-512 substitution (so level-4 hosts that no longer accept SHA-1 work) is a separate enhancement; this fix removes the self-contradiction and the misleading failure mode.

### How Verified
- **Tests:** `tests/unit/test_password_encrypt.cpp` — the `authScheme` case for level 4 updated from pinning the inconsistent 0x07 to asserting the SHA-1 fallback (0x03) with a comment explaining why; all 12 cases pass.
- **Static:** for every `passwordLevel`, `authScheme(level)` now names exactly the branch `encrypt(level)` takes: ≤1 → DES/0x01, ≥2 → SHA-1/0x03.

### Test Coverage
**Existing (updated):** `test_password_encrypt` `authScheme` assertions now encode the algorithm/scheme invariant.

### Scope of Change
- **Files changed:** `src/network/hostserver/password_encrypt.cpp`, `src/network/hostserver/signon_client.cpp`, `tests/unit/test_password_encrypt.cpp`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — levels 0–3 produce identical bytes; only the level ≥ 4 scheme byte changes (plus a new warning log).

### Risk and Rollout
Levels 0–3 (the deployed majority) are byte-identical. Level-4 hosts that still accept SHA-1 substitutes start working; hosts that require PBKDF2 now fail with a consistent, diagnosable credential error and a client-side warning.