### PR TITLE
[bugfix] Fix agent providers permitting parallel tool calls they cannot continue (#155)

### DIFF
--- a/src/agent/providers/anthropic_provider.cpp
+++ b/src/agent/providers/anthropic_provider.cpp
@@ -93,6 +93,15 @@ void AnthropicProvider::sendRequest() {
     body["max_tokens"] = 4096;
     body["messages"] = m_conversationHistory;
     body["tools"] = anthropicToolsArray();
+    // This client executes exactly one tool call per turn (handleResponse
+    // forwards a single ToolCall and sendToolResult appends a single
+    // tool_result block). A turn with multiple tool_use blocks would leave
+    // unanswered tool_use ids in the continuation, which the Messages API
+    // rejects — so disable parallel tool use.
+    QJsonObject toolChoice;
+    toolChoice["type"] = "auto";
+    toolChoice["disable_parallel_tool_use"] = true;
+    body["tool_choice"] = toolChoice;
 
     if (!m_systemContext.isEmpty()) {
         body["system"] = m_systemContext;

--- a/src/agent/providers/openai_provider.cpp
+++ b/src/agent/providers/openai_provider.cpp
@@ -102,6 +102,12 @@ void OpenAiProvider::sendRequest() {
     body["model"] = m_model;
     body["messages"] = messages;
     body["tools"] = openaiToolsArray();
+    // This client executes exactly one tool call per turn (handleResponse
+    // dispatches a single ToolCall and sendToolResult appends a single
+    // role:"tool" message). A turn with N>1 tool_calls would require N tool
+    // messages in the continuation or the API rejects it with a 400 — so
+    // tell the API not to emit parallel tool calls.
+    body["parallel_tool_calls"] = false;
 
     QNetworkRequest request(QUrl("https://api.openai.com/v1/chat/completions"));
     request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");


### PR DESCRIPTION
### Linked Issue
Closes #155

### Root Cause
Both providers implement a strictly single-tool-call protocol — `handleResponse` forwards one `ToolCall` to the agent panel and `sendToolResult` appends exactly one tool-result message before re-sending — but neither request builder told the API so. Both APIs default to allowing parallel tool calls, and both enforce that every tool call in an assistant turn receives a result in the continuation. A multi-call turn therefore produced a continuation with N−1 missing results, which the API rejected (OpenAI 400 "messages with role 'tool' must be a response to…", Anthropic unanswered-`tool_use`-id rejection), stalling the conversation. As a secondary symptom, the OpenAI path dispatched the first call while the Anthropic path dispatched the last.

### Fix Description
Declare the client's protocol to each API in `sendRequest()`:
- OpenAI: `"parallel_tool_calls": false` — the Chat Completions switch guaranteeing at most one entry in `tool_calls` per assistant turn.
- Anthropic: `"tool_choice": {"type": "auto", "disable_parallel_tool_use": true}` — `auto` preserves the existing model-decides behavior; the flag caps tool use at one block per turn.

With at most one tool call per turn, the saved pending assistant message and the single-result continuation are always consistent, and the first/last dispatch discrepancy becomes moot. The alternative — queueing N calls and collecting N results across the panel round-trip — would touch the provider interface, the panel, and the script runner for no user-visible benefit over the protocol declaration.

### How Verified
- **Static:** both parameters are the documented switches for exactly this contract; with one call per turn, every `tool_call_id`/`tool_use` id in the pending assistant message is matched by the single result message `sendToolResult` constructs. Single-call turns (the previously working path) are unaffected: response parsing is unchanged and `auto` retains model-initiated tool use.
- **Runtime:** full build clean; existing suite passes. Exercising the failure requires a live API turn that emits parallel calls, which is model-dependent and not reproducible in CI.

### Test Coverage
**None:** the providers have no HTTP-mocking harness, and the defect manifests only in the interaction with the live APIs' continuation validation. The fix is two request fields whose presence is verifiable by inspection.

### Scope of Change
- **Files changed:** `src/agent/providers/openai_provider.cpp`, `src/agent/providers/anthropic_provider.cpp`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — single-tool-call turns behave identically; models simply chain calls across turns instead of batching them.

### Risk and Rollout
Both fields are long-standing, documented API parameters. Worst case a model takes an extra round trip where it previously batched two calls — which is the only mode this client can execute anyway.