### PR TITLE
[bugfix] Fix --mcp-server-port CLI override discarded by config reload (Fixes #173)

### DIFF
--- a/src/agent/config.cpp
+++ b/src/agent/config.cpp
@@ -99,7 +99,10 @@ void AgentConfig::load() {
     // mcpServerEnabled is runtime-only — never persisted.
     settings.remove("mcpServerEnabled"); // clean up stale key from older versions
     m_mcpAutoStart = settings.value("mcpAutoStart", false).toBool();
-    m_mcpServerPort = static_cast<quint16>(settings.value("mcpServerPort", 9250).toUInt());
+    // A CLI-pinned port must survive this reload (MainWindow calls load() again
+    // after main() has applied the --mcp-server-port override).
+    if (!m_mcpServerPortPinned)
+        m_mcpServerPort = static_cast<quint16>(settings.value("mcpServerPort", 9250).toUInt());
 
     // Per-tool config
     const QStringList toolNames = {

--- a/src/agent/config.h
+++ b/src/agent/config.h
@@ -81,7 +81,17 @@ class AgentConfig {
     bool mcpServerEnabled() const { return m_mcpServerEnabled; }
     void setMcpServerEnabled(bool enabled) { m_mcpServerEnabled = enabled; }
     quint16 mcpServerPort() const { return m_mcpServerPort; }
-    void setMcpServerPort(quint16 port) { m_mcpServerPort = port; }
+    // Explicit user-driven change (e.g. the settings dialog): releases any CLI
+    // pin so the value tracks the persisted setting again.
+    void setMcpServerPort(quint16 port) {
+        m_mcpServerPort = port;
+        m_mcpServerPortPinned = false;
+    }
+    // CLI override: pinned so a later load() cannot discard it.
+    void pinMcpServerPort(quint16 port) {
+        m_mcpServerPort = port;
+        m_mcpServerPortPinned = true;
+    }
 
     // MCP auto-start on launch (persisted)
     bool mcpAutoStart() const { return m_mcpAutoStart; }
@@ -109,6 +119,7 @@ class AgentConfig {
     bool m_mcpServerEnabled = false;
     bool m_mcpAutoStart = false;
     quint16 m_mcpServerPort = 9250;
+    bool m_mcpServerPortPinned = false;
 };
 
 } // namespace agent

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -238,7 +238,7 @@ int main(int argc, char *argv[]) {
             bool portOk = false;
             int mcpPort = parser.value(mcpPortOption).toInt(&portOk);
             if (portOk && mcpPort >= 1024 && mcpPort <= 65535) {
-                agentCfg.setMcpServerPort(static_cast<quint16>(mcpPort));
+                agentCfg.pinMcpServerPort(static_cast<quint16>(mcpPort));
             } else {
                 logger::Logger::instance()->error(
                     QString("Invalid MCP port number: %1").arg(parser.value(mcpPortOption)));


### PR DESCRIPTION
### Linked Issue
`Closes #173`

### Root Cause
`main()` applies the `--mcp-server-port` override into the `AgentConfig` singleton before constructing `MainWindow`. But `MainWindow`'s constructor calls `agentCfg.load()` again (`src/ui/main_window.cpp:291`) before starting the server, and `AgentConfig::load()` reassigned `m_mcpServerPort` from `QSettings` unconditionally. The CLI value was therefore overwritten with the persisted value (default `9250`) a few lines before `m_mcpServer->start(agentCfg.mcpServerPort())` ran.

The sibling flag `--enable-mcp-server` worked only by accident: `m_mcpServerEnabled` is runtime-only and `load()` never assigns it, so nothing clobbered it. The port field had no such protection, which made the defect asymmetric and easy to miss — the startup log printed the requested port because it read the value before `MainWindow` was built.

### Fix Description
A CLI-supplied port is now *pinned*: `AgentConfig::pinMcpServerPort()` sets the value and marks it pinned, and `load()` skips the `mcpServerPort` assignment while the pin is held. `main()` uses the new pinning setter.

`setMcpServerPort()` — the path used by the settings dialog — clears the pin, so an explicit user change hands authority back to the persisted setting rather than being shadowed for the rest of the process lifetime.

Rejected alternative: removing the `load()` call from `MainWindow`'s constructor. `main()` only loads the config when the MCP flag is set, so that would leave every other launch with an unloaded config — a far larger behavioral change than the bug warrants.

### How Verified
**Runtime**, with an unrelated process already holding `127.0.0.1:9250` so a wrong-port bind is unmistakable.

Before, `--enable-mcp-server --mcp-server-port 9999 -d`:
```
[DEBUG] MCP server enabled via CLI (port 9999)
[ERROR] [MCP]: Failed to start: The bound address is already in use
```
`ss -ltnp` showed nothing on `9999` — it had collided on `9250`.

After, same command:
```
[DEBUG] MCP server enabled via CLI (port 9999)
[INFO] [MCP]: Listening on localhost:9999
```
```
LISTEN 127.0.0.1:9999  users:(("5250ng",pid=254096,fd=5))
```

Default path regression check — `--enable-mcp-server` with no port flag still resolves the persisted value:
```
[DEBUG] MCP server enabled via CLI (port 9250)
[INFO] [MCP]: Listening on localhost:9250
```

### Test Coverage
**None.** `AgentConfig` is a singleton reading process-wide `QSettings`, and the defect is an ordering interaction between `main()` and `MainWindow`'s constructor — reproducing it requires a real `QApplication` plus a full `MainWindow`, which the suite has no harness for. Verified by the runtime socket evidence above instead. The existing 25-test suite passes unchanged.

### Scope of Change
- **Files changed:** `src/agent/config.h`, `src/agent/config.cpp`, `src/main.cpp`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Blast radius is limited to the MCP server's port selection. When no CLI override is given the pin is never set and `load()` behaves exactly as before, so the default and settings-dialog paths are untouched. Safe to merge directly.
