### PR TITLE
[enhancement] Fix IBM 5292 GDDM graphics emulation (Fixes #175)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,6 +194,8 @@ set(UTILS_SOURCES
 )
 
 set(DISPLAY_SOURCES
+    src/ui/rendering/gddm_5292_decoder.cpp
+    src/ui/rendering/gddm_5292_decoder.h
     src/ui/widgets/Q5250ScreenWidget/screen_buffer.cpp
     src/ui/widgets/Q5250ScreenWidget/screen_buffer.h
     src/ui/widgets/Q5250ScreenWidget/screen_buffer_adapter.cpp
@@ -439,6 +441,7 @@ if(BUILD_TESTS)
     add_tn5250_test(test_terminal_theme tests/unit/test_terminal_theme.cpp)
     add_tn5250_test(test_pcap_replay tests/unit/test_pcap_replay.cpp)
     add_tn5250_test(test_match_replace tests/unit/test_match_replace.cpp)
+    add_tn5250_test(test_gddm_5292 tests/unit/test_gddm_5292.cpp)
 
     # Host server tests
     add_tn5250_test(test_host_data_stream tests/unit/test_host_data_stream.cpp)

--- a/src/agent/tool_definitions.h
+++ b/src/agent/tool_definitions.h
@@ -366,10 +366,17 @@ inline QJsonObject toolCreateSessionSchema() {
     tlsProp["type"] = "boolean";
     tlsProp["description"] = "Use TLS/SSL encryption (default false)";
 
+    QJsonObject deviceTypeProp;
+    deviceTypeProp["type"] = "string";
+    deviceTypeProp["description"] =
+        "TN5250 terminal type (default IBM-3179-2; use IBM-5292-2 for GDDM graphics)";
+    deviceTypeProp["default"] = "IBM-3179-2";
+
     QJsonObject properties;
     properties["hostname"] = hostProp;
     properties["port"] = portProp;
     properties["useTLS"] = tlsProp;
+    properties["deviceType"] = deviceTypeProp;
 
     QJsonObject schema;
     schema["type"] = "object";

--- a/src/mcp/McpServer.h
+++ b/src/mcp/McpServer.h
@@ -53,7 +53,7 @@ class McpServer : public QObject {
     void error(const QString &msg);
     /// Emitted when create_session tool is called.
     void createSessionRequested(const QString &sessionId, const QString &hostname,
-                                quint16 port, bool useTLS);
+                                quint16 port, bool useTLS, const QString &deviceType);
     /// Emitted when close_session tool is called.
     void closeSessionRequested(const QString &sessionId);
     void requestLog(const QString &entry);

--- a/src/mcp/McpToolHandler.cpp
+++ b/src/mcp/McpToolHandler.cpp
@@ -262,8 +262,12 @@ QJsonObject McpToolHandler::handleCreateSession(const QJsonObject &args) {
         return makeResult("Port must be an integer between 1 and 65535.", true);
     }
     bool useTLS = args.value("useTLS").toBool(false);
+    QString deviceType = args.value("deviceType").toString("IBM-3179-2").trimmed();
+    if (deviceType.isEmpty())
+        return makeResult("Device type must not be empty.", true);
 
-    MCP_LOG(QString("Creating session to %1:%2 (TLS=%3)").arg(hostname).arg(port).arg(useTLS));
+    MCP_LOG(QString("Creating session to %1:%2 (TLS=%3, device=%4)")
+                .arg(hostname).arg(port).arg(useTLS).arg(deviceType));
 
     // Generate session ID
     QString sessionId = QUuid::createUuid().toString(QUuid::WithoutBraces);
@@ -287,7 +291,7 @@ QJsonObject McpToolHandler::handleCreateSession(const QJsonObject &args) {
 
     // Emit the request — MainWindow creates the tab synchronously on the
     // same thread, which calls onSessionCreated() before we reach loop.exec()
-    emit createSessionRequested(sessionId, hostname, port, useTLS);
+    emit createSessionRequested(sessionId, hostname, port, useTLS, deviceType);
 
     if (!m_sessionCreated)
         loop.exec();

--- a/src/mcp/McpToolHandler.h
+++ b/src/mcp/McpToolHandler.h
@@ -47,7 +47,7 @@ class McpToolHandler : public QObject {
 
   signals:
     void createSessionRequested(const QString &sessionId, const QString &hostname,
-                                quint16 port, bool useTLS);
+                                quint16 port, bool useTLS, const QString &deviceType);
     void closeSessionRequested(const QString &sessionId);
 
   private:

--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -270,11 +270,13 @@ MainWindow::MainWindow(QWidget *parent)
     // MCP server
     m_mcpServer = new mcp::McpServer(this);
     connect(m_mcpServer, &mcp::McpServer::createSessionRequested, this,
-            [this](const QString &sessionId, const QString &hostname, quint16 port, bool useTLS) {
+            [this](const QString &sessionId, const QString &hostname, quint16 port,
+                   bool useTLS, const QString &deviceType) {
         session::SessionConfig cfg;
         cfg.setHostname(hostname);
         cfg.setPort(port);
         cfg.setUseTLS(useTLS);
+        cfg.setDeviceType(deviceType);
         cfg.setName(QString("MCP: %1").arg(hostname));
         connectToServer(cfg, sessionId);
     });
@@ -1417,4 +1419,3 @@ void MainWindow::fillSessionsCombo(QComboBox *combo, const QString &placeholder)
     }
     combo->blockSignals(false);
 }
-

--- a/src/ui/rendering/gddm_5292_decoder.cpp
+++ b/src/ui/rendering/gddm_5292_decoder.cpp
@@ -1,0 +1,306 @@
+// 5250ng - A modern IBM TN5250 terminal emulator
+// Copyright (C) 2025-2026 Remi GASCOU (Podalirius)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+#include "gddm_5292_decoder.h"
+
+#include <QPainter>
+#include <QPen>
+
+namespace ui::rendering {
+
+Gddm5292Decoder::Gddm5292Decoder()
+    : m_plane(kWidth, kHeight, QImage::Format_ARGB32_Premultiplied) {
+    reset(true);
+}
+
+void Gddm5292Decoder::reset(bool clearPlane) {
+    m_graphicsMode = false;
+    m_displayEnabled = false;
+    m_suppressPacing = false;
+    m_pendingOrder = PendingOrder::None;
+    m_pendingData.clear();
+    m_palette = {QColor(0, 0, 0), QColor(255, 0, 0), QColor(0, 255, 0),
+                 QColor(0, 0, 255), QColor(255, 0, 255), QColor(255, 255, 0),
+                 QColor(0, 255, 255), QColor(255, 255, 255)};
+    m_colorIndex = 7;
+    m_lineWeight = 1;
+    if (clearPlane)
+        m_plane.fill(Qt::transparent);
+}
+
+bool Gddm5292Decoder::recognizes(const QByteArray &data) const {
+    return m_graphicsMode
+        || (!data.isEmpty() && static_cast<uint8_t>(data.front()) == 0xFF);
+}
+
+bool Gddm5292Decoder::isGraphicsData(uint8_t byte) {
+    return (byte & 0xC0) == 0x40;
+}
+
+int Gddm5292Decoder::decodeCoordinate(uint8_t high, uint8_t low) {
+    return ((high & 0x0F) << 6) | (low & 0x3F);
+}
+
+bool Gddm5292Decoder::fail(Result &result, int offset, const QString &message) {
+    result.error = true;
+    result.errorMessage = QString("offset %1: %2").arg(offset).arg(message);
+    result.pacingResponse = false;
+    m_graphicsMode = false;
+    m_pendingOrder = PendingOrder::None;
+    m_pendingData.clear();
+    return false;
+}
+
+bool Gddm5292Decoder::drawPolyline(Result &result) {
+    if (m_pendingData.size() < 8 || (m_pendingData.size() % 4) != 0)
+        return fail(result, m_pendingData.size(), "polyline requires complete coordinate pairs");
+
+    QPainter painter(&m_plane);
+    painter.setRenderHint(QPainter::Antialiasing, false);
+    painter.setCompositionMode(QPainter::CompositionMode_Source);
+    painter.setPen(QPen(m_palette[static_cast<size_t>(m_colorIndex)], m_lineWeight,
+                        Qt::SolidLine, Qt::SquareCap, Qt::MiterJoin));
+
+    auto pointAt = [this](int offset) {
+        const int x = decodeCoordinate(static_cast<uint8_t>(m_pendingData[offset]),
+                                       static_cast<uint8_t>(m_pendingData[offset + 1]));
+        const int y = decodeCoordinate(static_cast<uint8_t>(m_pendingData[offset + 2]),
+                                       static_cast<uint8_t>(m_pendingData[offset + 3]));
+        return QPoint(x, kHeight - 1 - y);
+    };
+
+    QPoint previous = pointAt(0);
+    for (int offset = 4; offset < m_pendingData.size(); offset += 4) {
+        const QPoint next = pointAt(offset);
+        painter.drawLine(previous, next);
+        previous = next;
+    }
+    result.changed = true;
+    return true;
+}
+
+bool Gddm5292Decoder::completePending(Result &result) {
+    bool ok = true;
+    if (m_pendingOrder == PendingOrder::Polyline) {
+        ok = drawPolyline(result);
+    } else if (m_pendingOrder == PendingOrder::ColorTable) {
+        if ((m_pendingData.size() % 3) != 0) {
+            ok = fail(result, m_pendingData.size(),
+                      "color table requires index/red-green/blue triples");
+        } else {
+            for (int offset = 0; offset < m_pendingData.size(); offset += 3) {
+                const int index = static_cast<uint8_t>(m_pendingData[offset]) & 0x07;
+                if (index == 0) {
+                    ok = fail(result, offset, "color table index zero cannot be changed");
+                    break;
+                }
+                const uint8_t redGreen = static_cast<uint8_t>(m_pendingData[offset + 1]);
+                const uint8_t blue = static_cast<uint8_t>(m_pendingData[offset + 2]);
+                const int redIntensity = (redGreen >> 3) & 0x07;
+                const int greenIntensity = redGreen & 0x07;
+                const int blueIntensity = (blue >> 3) & 0x07;
+                m_palette[static_cast<size_t>(index)] =
+                    QColor(redIntensity * 255 / 7, greenIntensity * 255 / 7,
+                           blueIntensity * 255 / 7);
+            }
+        }
+    }
+    m_pendingOrder = PendingOrder::None;
+    m_pendingData.clear();
+    return ok;
+}
+
+Gddm5292Decoder::Result Gddm5292Decoder::process(const QByteArray &data) {
+    Result result;
+    if (!recognizes(data))
+        return result;
+
+    result.handled = true;
+    ++m_blockCount;
+    m_suppressPacing = false;
+    int offset = 0;
+
+    if (!m_graphicsMode) {
+        if (data.size() >= 2 && static_cast<uint8_t>(data[0]) == 0xFF
+            && static_cast<uint8_t>(data[1]) == 0xFF) {
+            reset(true);
+            result.changed = true;
+            result.pacingResponse = true;
+            return result;
+        }
+        m_graphicsMode = true;
+        offset = 1;
+    } else if (!data.isEmpty() && static_cast<uint8_t>(data[0]) == 0xFF) {
+        // A second Begin Graphics while already active is a system reset only
+        // when followed by the required second FF byte.
+        if (data.size() >= 2 && static_cast<uint8_t>(data[1]) == 0xFF) {
+            reset(true);
+            result.changed = true;
+            result.pacingResponse = true;
+            return result;
+        }
+        return fail(result, 0, "unexpected Begin Graphics while graphics mode is active"), result;
+    }
+
+    bool endedWithMoreData = false;
+    while (offset < data.size()) {
+        const uint8_t byte = static_cast<uint8_t>(data[offset]);
+
+        if (m_pendingOrder != PendingOrder::None) {
+            if (isGraphicsData(byte)) {
+                m_pendingData.append(static_cast<char>(byte));
+                ++offset;
+                continue;
+            }
+            if (byte == 0x92) {
+                if (!completePending(result))
+                    return result;
+                ++offset;
+                continue;
+            }
+            if (byte == 0x91) {
+                endedWithMoreData = true;
+                ++offset;
+                break;
+            }
+            fail(result, offset, "variable order was not terminated by End of Data");
+            return result;
+        }
+
+        switch (byte) {
+        case 0x90: // End current nonspanned block; graphics mode remains active.
+            offset = data.size();
+            continue;
+        case 0x91:
+            fail(result, offset, "More Data to Come without a variable order");
+            return result;
+        case 0x92:
+            fail(result, offset, "End of Data without a variable order");
+            return result;
+        case 0x93:
+            m_displayEnabled = true;
+            result.changed = true;
+            ++offset;
+            continue;
+        case 0x94:
+            m_displayEnabled = false;
+            result.changed = true;
+            ++offset;
+            continue;
+        case 0x95:
+            m_graphicsMode = false;
+            // End Graphics terminates this graphics write block. IBM i pads
+            // short blocks after 0x95; those bytes are not graphics orders.
+            offset = data.size();
+            continue;
+        case 0x96:
+            m_suppressPacing = true;
+            ++offset;
+            continue;
+        default:
+            break;
+        }
+
+        auto readFixedData = [&](int count, QByteArray &values) {
+            if (offset + count >= data.size())
+                return fail(result, offset, "truncated fixed-length graphics order");
+            for (int index = 1; index <= count; ++index) {
+                const uint8_t value = static_cast<uint8_t>(data[offset + index]);
+                if (!isGraphicsData(value))
+                    return fail(result, offset + index, "graphics-data byte expected");
+                values.append(static_cast<char>(value));
+            }
+            offset += count + 1;
+            return true;
+        };
+
+        QByteArray values;
+        switch (byte) {
+        case 0x80: // Read Status
+            if (!readFixedData(2, values)) return result;
+            result.readStatusOffset = decodeCoordinate(
+                static_cast<uint8_t>(values[0]), static_cast<uint8_t>(values[1]));
+            break;
+        case 0xB0: // Set Color
+            if (!readFixedData(1, values)) return result;
+            m_colorIndex = static_cast<uint8_t>(values[0]) & 0x3F;
+            if (m_colorIndex > 7) {
+                fail(result, offset - 1, "color index is outside 0..7");
+                return result;
+            }
+            break;
+        case 0xB1: // Set Style
+            if (!readFixedData(4, values)) return result;
+            break;
+        case 0xB2: // Set Style Offset
+        case 0xB3: // Set Function
+        case 0xB5: // Set Marker
+            if (!readFixedData(1, values)) return result;
+            break;
+        case 0xB4: // Set Color Table
+            m_pendingOrder = PendingOrder::ColorTable;
+            ++offset;
+            break;
+        case 0xB6: // Set Line Weight
+            if (!readFixedData(1, values)) return result;
+            m_lineWeight = ((static_cast<uint8_t>(values[0]) & 0x3F) == 0) ? 1 : 2;
+            break;
+        case 0xB7: // Set Fill Mode
+            if (!readFixedData(2, values)) return result;
+            break;
+        case 0xA0: // Draw Polyline
+            m_pendingOrder = PendingOrder::Polyline;
+            ++offset;
+            break;
+        case 0xA1: // Draw Scanline (retained for a later rendering phase)
+        case 0xA4: // Write Polymarker
+        case 0xA5: // Fill Polygon
+        case 0xA6: // Define Shield Area
+            m_pendingOrder = PendingOrder::Ignore;
+            ++offset;
+            break;
+        case 0xA3: { // Write Background
+            if (!readFixedData(1, values)) return result;
+            const int color = static_cast<uint8_t>(values[0]) & 0x3F;
+            if (color > 7) {
+                fail(result, offset - 1, "background color index is outside 0..7");
+                return result;
+            }
+            m_plane.fill(m_palette[static_cast<size_t>(color)]);
+            result.changed = true;
+            break;
+        }
+        case 0xC0: // Printer Data Follows
+        case 0xC2: // Load printer alphanumeric color-mix table
+        case 0xC3: // Load printer graphics color-mix table
+            m_pendingOrder = PendingOrder::Ignore;
+            ++offset;
+            break;
+        case 0xC1: // Screen Copy
+            ++offset;
+            break;
+        case 0xC4: // Set printer timeout
+            if (!readFixedData(1, values)) return result;
+            break;
+        default:
+            fail(result, offset, QString("unsupported graphics order 0x%1")
+                                     .arg(byte, 2, 16, QChar('0')));
+            return result;
+        }
+    }
+
+    if (m_pendingOrder != PendingOrder::None && !endedWithMoreData) {
+        fail(result, data.size(), "unterminated variable order at end of block");
+        return result;
+    }
+
+    result.pacingResponse = !m_suppressPacing;
+    return result;
+}
+
+} // namespace ui::rendering

--- a/src/ui/rendering/gddm_5292_decoder.h
+++ b/src/ui/rendering/gddm_5292_decoder.h
@@ -1,0 +1,71 @@
+// 5250ng - A modern IBM TN5250 terminal emulator
+// Copyright (C) 2025-2026 Remi GASCOU (Podalirius)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+#pragma once
+
+#include <QByteArray>
+#include <QColor>
+#include <QImage>
+#include <QString>
+#include <array>
+#include <cstdint>
+
+namespace ui::rendering {
+
+class Gddm5292Decoder {
+  public:
+    static constexpr int kWidth = 480;
+    static constexpr int kHeight = 288;
+
+    struct Result {
+        bool handled = false;
+        bool pacingResponse = false;
+        bool changed = false;
+        bool error = false;
+        int readStatusOffset = -1;
+        QString errorMessage;
+    };
+
+    Gddm5292Decoder();
+
+    bool recognizes(const QByteArray &data) const;
+    Result process(const QByteArray &data);
+
+    bool graphicsMode() const { return m_graphicsMode; }
+    bool displayEnabled() const { return m_displayEnabled; }
+    const QImage &graphicsPlane() const { return m_plane; }
+    quint64 blockCount() const { return m_blockCount; }
+
+  private:
+    enum class PendingOrder {
+        None,
+        Polyline,
+        ColorTable,
+        Ignore
+    };
+
+    void reset(bool clearPlane);
+    bool completePending(Result &result);
+    bool drawPolyline(Result &result);
+    bool fail(Result &result, int offset, const QString &message);
+    static bool isGraphicsData(uint8_t byte);
+    static int decodeCoordinate(uint8_t high, uint8_t low);
+
+    bool m_graphicsMode = false;
+    bool m_displayEnabled = false;
+    bool m_suppressPacing = false;
+    PendingOrder m_pendingOrder = PendingOrder::None;
+    QByteArray m_pendingData;
+    std::array<QColor, 8> m_palette;
+    int m_colorIndex = 7;
+    int m_lineWeight = 1;
+    QImage m_plane;
+    quint64 m_blockCount = 0;
+};
+
+} // namespace ui::rendering

--- a/src/ui/rendering/tn5250_command_handler.cpp
+++ b/src/ui/rendering/tn5250_command_handler.cpp
@@ -183,7 +183,57 @@ void TN5250CommandHandler::handleRawScreenData(const QByteArray &data) {
             logger::Logger::instance()->debug(QString::fromStdString(line));
         }
 
-        if (m_renderer) {
+        QByteArray graphicsData = data;
+        if (!m_gddmDecoder.recognizes(data)) {
+            const int beginGraphics = data.indexOf(static_cast<char>(0xFF));
+            if (beginGraphics > 0) {
+                if (m_renderer)
+                    m_renderer->render(data.left(beginGraphics));
+                graphicsData = data.mid(beginGraphics);
+            }
+        }
+
+        const Gddm5292Decoder::Result graphics = m_gddmDecoder.process(graphicsData);
+        if (graphics.handled) {
+            m_displayWidget->setGddmGraphicsPlane(m_gddmDecoder.graphicsPlane(),
+                                                  m_gddmDecoder.displayEnabled());
+            if (graphics.error) {
+                logger::Logger::instance()->error(
+                    QString("CommandHandler: 5292 graphics error: %1")
+                        .arg(graphics.errorMessage));
+            } else if (graphics.pacingResponse && m_sendToHost) {
+                bool includeModifiedFields = false;
+                if (graphics.readStatusOffset >= 0) {
+                    // Successful 5292 Model 2 Level 2 status. The read order
+                    // writes these bytes into the alphanumeric buffer so the
+                    // enclosing 5250 Read MDT can return them to GDDM.
+                    const QByteArray status = QByteArray::fromHex(
+                        "fffffff280ffff4040404040404040404040404040");
+                    auto *screen = m_displayWidget->screenBuffer();
+                    const int cells = screen->rows() * screen->cols();
+                    for (int index = 0; index < status.size(); ++index) {
+                        const int address = graphics.readStatusOffset + index;
+                        if (address >= cells)
+                            break;
+                        screen->writeChar(address / screen->cols(), address % screen->cols(),
+                                          static_cast<uint8_t>(status[index]));
+                    }
+                    if (graphics.readStatusOffset < cells) {
+                        screen->markFieldModified(graphics.readStatusOffset / screen->cols(),
+                                                  graphics.readStatusOffset % screen->cols());
+                    }
+                    includeModifiedFields = true;
+                }
+                // Command-12/PF12 is the documented successful 5292 block
+                // completion response. Read Status additionally returns the
+                // host-created MDT field containing the status bytes.
+                m_sendToHost(buildFieldResponse(0x3C, includeModifiedFields));
+            }
+            logger::Logger::instance()->debug(
+                QString("CommandHandler: 5292 graphics block %1 (%2 bytes, mode=%3, display=%4)")
+                    .arg(m_gddmDecoder.blockCount()).arg(data.size())
+                    .arg(m_gddmDecoder.graphicsMode()).arg(m_gddmDecoder.displayEnabled()));
+        } else if (m_renderer) {
             m_renderer->render(data);
         }
     }
@@ -595,7 +645,8 @@ void TN5250CommandHandler::onClearFormatTableRequested() {
     logger::Logger::instance()->debug("CommandHandler: Format table cleared");
 }
 
-QByteArray TN5250CommandHandler::buildFieldResponse(uint8_t aidByte) {
+QByteArray TN5250CommandHandler::buildFieldResponse(uint8_t aidByte,
+                                                    bool includeModifiedFields) {
     QByteArray response;
 
     if (!m_displayWidget || !m_displayWidget->screenBuffer()) {
@@ -613,7 +664,9 @@ QByteArray TN5250CommandHandler::buildFieldResponse(uint8_t aidByte) {
     response.append(static_cast<char>(aidByte));
 
     // SBA address points to the field data start position
-    QVector<ui::widgets::ScreenBuffer::Field> modFields = screen->getModifiedFields();
+    QVector<ui::widgets::ScreenBuffer::Field> modFields;
+    if (includeModifiedFields)
+        modFields = screen->getModifiedFields();
     LOG_DEBUG(QString("CommandHandler: buildFieldResponse: aid=0x%1 cursor=(%2,%3) modifiedFields=%4")
         .arg(aidByte, 2, 16, QChar('0')).arg(cursor.y() + 1).arg(cursor.x() + 1)
         .arg(modFields.size()));

--- a/src/ui/rendering/tn5250_command_handler.h
+++ b/src/ui/rendering/tn5250_command_handler.h
@@ -20,6 +20,7 @@
 #include "core/command_runner.h"
 #include "network/tn5250_qt/client/decoder_adapter.h"
 #include "session/config.h"
+#include "gddm_5292_decoder.h"
 #include "tn5250_stream_renderer.h"
 #include "ui/widgets/Q5250ScreenWidget/Q5250ScreenWidget.h"
 #include "ui/widgets/Q5250ScreenWidget/screen_buffer.h"
@@ -89,7 +90,7 @@ class TN5250CommandHandler : public QObject {
 
     void sendNegResponse(uint8_t category, uint8_t modifier, uint8_t uByte1, uint8_t uByte2);
 
-    QByteArray buildFieldResponse(uint8_t aidByte);
+    QByteArray buildFieldResponse(uint8_t aidByte, bool includeModifiedFields = true);
     QByteArray buildReadScreenResponse(bool includeAttributes);
     QByteArray buildQueryResponse();
     QByteArray buildSaveScreenResponse();
@@ -108,6 +109,7 @@ class TN5250CommandHandler : public QObject {
   private:
     ui::widgets::Q5250ScreenWidget *m_displayWidget = nullptr;
     TN5250StreamRenderer *m_renderer = nullptr;
+    Gddm5292Decoder m_gddmDecoder;
     SendToHostFn m_sendToHost;
     SendGDSFn m_sendGDS;
     uint8_t m_pendingCC2 = 0;

--- a/src/ui/widgets/Q5250ScreenWidget/Q5250ScreenWidget.cpp
+++ b/src/ui/widgets/Q5250ScreenWidget/Q5250ScreenWidget.cpp
@@ -292,6 +292,12 @@ void Q5250ScreenWidget::setForegroundColor(const QColor &color) {
  */
 void Q5250ScreenWidget::updateScreen() { update(); }
 
+void Q5250ScreenWidget::setGddmGraphicsPlane(const QImage &plane, bool visible) {
+    m_gddmGraphicsPlane = plane;
+    m_gddmGraphicsVisible = visible;
+    update();
+}
+
 /**
  * @brief Renders the full 5250 screen: cells, underlines, grid, selection, cursor rules, hotspots.
  * @param painter Painter already set up for this widget; clipping and translation applied here.
@@ -319,6 +325,17 @@ void Q5250ScreenWidget::renderScreen(QPainter &painter) {
             const ScreenCell &cell = m_screenBuffer->cell(row, col);
             renderCell(painter, row, col, cell);
         }
+    }
+
+    if (m_gddmGraphicsVisible && !m_gddmGraphicsPlane.isNull()) {
+        const QSizeF presentationSize(cols * m_cellWidthF, rows * m_cellHeightF);
+        QSizeF graphicsSize = m_gddmGraphicsPlane.size();
+        graphicsSize.scale(presentationSize, Qt::KeepAspectRatio);
+        const QRectF target((presentationSize.width() - graphicsSize.width()) / 2.0,
+                            (presentationSize.height() - graphicsSize.height()) / 2.0,
+                            graphicsSize.width(), graphicsSize.height());
+        painter.setRenderHint(QPainter::SmoothPixmapTransform, false);
+        painter.drawImage(target, m_gddmGraphicsPlane);
     }
 
     // Draw contiguous underlines: scan each row for runs of underlined cells

--- a/src/ui/widgets/Q5250ScreenWidget/Q5250ScreenWidget.h
+++ b/src/ui/widgets/Q5250ScreenWidget/Q5250ScreenWidget.h
@@ -25,6 +25,7 @@
 #include "screen_buffer.h"
 #include "ui/themes/terminal_theme.h"
 #include <QClipboard>
+#include <QImage>
 #include <QKeyEvent>
 #include <QMouseEvent>
 #include <QTimer>
@@ -90,6 +91,12 @@ class Q5250ScreenWidget : public QWidget {
     // Screen buffer access
     ScreenBuffer *screenBuffer() { return m_screenBuffer; }
     const ScreenBuffer *screenBuffer() const { return m_screenBuffer; }
+
+    // IBM 5292 Model 2 graphics are retained independently from the
+    // alphanumeric presentation space and composited during painting.
+    void setGddmGraphicsPlane(const QImage &plane, bool visible);
+    const QImage &gddmGraphicsPlane() const { return m_gddmGraphicsPlane; }
+    bool gddmGraphicsVisible() const { return m_gddmGraphicsVisible; }
 
     // Display configuration
     void setScreenSize(int rows, int cols);
@@ -311,6 +318,8 @@ class Q5250ScreenWidget : public QWidget {
     bool m_showInputFields;
     bool m_showCellGrid = false;
     QColor m_cellGridColor = QColor(255, 255, 255, 40);
+    QImage m_gddmGraphicsPlane;
+    bool m_gddmGraphicsVisible = false;
 
     // 5250 terminal state
     KeyboardState m_keyboardState;

--- a/tests/unit/test_command_handler_soh.cpp
+++ b/tests/unit/test_command_handler_soh.cpp
@@ -35,6 +35,9 @@ class TestCommandHandlerSoh : public QObject {
     void testSohErrorRowClampedToScreen();
     void testWriteErrorCodeWithHostileErrorRow();
     void testSohValidErrorRowKept();
+    void testGddmBlockBypassesAlphanumericRendererAndPaces();
+    void testGddmSuppressPacingOrder();
+    void testGddmReadStatusWithAlphanumericPrefix();
 
   private:
     Q5250ScreenWidget *m_widget = nullptr;
@@ -86,6 +89,69 @@ void TestCommandHandlerSoh::testSohValidErrorRowKept() {
     QCOMPARE(m_widget->errorLineRow(), 23);
     m_handler->onSohReceived(1, 0, 0, 0);
     QCOMPARE(m_widget->errorLineRow(), 0);
+}
+
+void TestCommandHandlerSoh::testGddmBlockBypassesAlphanumericRendererAndPaces() {
+    QList<QByteArray> responses;
+    m_handler->setSendToHostCallback(
+        [&responses](const QByteArray &response) { responses.append(response); });
+
+    m_handler->handleRawScreenData(QByteArray::fromHex(
+        "ff93b041a04040404a41644072425640599295"));
+
+    QVERIFY(m_widget->gddmGraphicsVisible());
+    QCOMPARE(m_widget->gddmGraphicsPlane().pixelColor(0, 277), QColor(255, 0, 0));
+    QCOMPARE(m_widget->screenBuffer()->character(0, 0), static_cast<uint8_t>(0x40));
+    QCOMPARE(responses.size(), 1);
+    QCOMPARE(responses[0].size(), 3);
+    QCOMPARE(static_cast<uint8_t>(responses[0][2]), static_cast<uint8_t>(0x3C));
+
+    m_widget->resize(800, 480);
+    QImage composed(m_widget->size(), QImage::Format_ARGB32_Premultiplied);
+    composed.fill(Qt::black);
+    m_widget->render(&composed);
+    bool foundRedGraphicsPixel = false;
+    for (int y = 0; y < composed.height() && !foundRedGraphicsPixel; ++y) {
+        for (int x = 0; x < composed.width(); ++x) {
+            const QColor pixel = composed.pixelColor(x, y);
+            if (pixel.red() > 200 && pixel.green() < 40 && pixel.blue() < 40) {
+                foundRedGraphicsPixel = true;
+                break;
+            }
+        }
+    }
+    QVERIFY(foundRedGraphicsPixel);
+}
+
+void TestCommandHandlerSoh::testGddmSuppressPacingOrder() {
+    QList<QByteArray> responses;
+    m_handler->setSendToHostCallback(
+        [&responses](const QByteArray &response) { responses.append(response); });
+
+    m_handler->handleRawScreenData(QByteArray::fromHex("ff9695"));
+
+    QVERIFY(responses.isEmpty());
+    QCOMPARE(m_widget->screenBuffer()->character(0, 0), static_cast<uint8_t>(0x40));
+}
+
+void TestCommandHandlerSoh::testGddmReadStatusWithAlphanumericPrefix() {
+    QList<QByteArray> responses;
+    m_handler->setSendToHostCallback(
+        [&responses](const QByteArray &response) { responses.append(response); });
+
+    m_handler->handleRawScreenData(QByteArray::fromHex(
+        "1101031d4800270032ff804043959090909090"));
+
+    QCOMPARE(responses.size(), 1);
+    QCOMPARE(static_cast<uint8_t>(responses[0][2]), static_cast<uint8_t>(0x3C));
+    QVERIFY(responses[0].size() > 10);
+    QCOMPARE(static_cast<uint8_t>(responses[0][3]), static_cast<uint8_t>(0x11));
+    QCOMPARE(static_cast<uint8_t>(responses[0][6]), static_cast<uint8_t>(0xFF));
+    QCOMPARE(static_cast<uint8_t>(responses[0][8]), static_cast<uint8_t>(0xFF));
+    QCOMPARE(static_cast<uint8_t>(responses[0][9]), static_cast<uint8_t>(0xF2));
+    QCOMPARE(static_cast<uint8_t>(responses[0][10]), static_cast<uint8_t>(0x80));
+    QCOMPARE(m_widget->screenBuffer()->character(0, 3), static_cast<uint8_t>(0xFF));
+    QCOMPARE(m_widget->screenBuffer()->character(0, 6), static_cast<uint8_t>(0xF2));
 }
 
 QTEST_MAIN(TestCommandHandlerSoh)

--- a/tests/unit/test_gddm_5292.cpp
+++ b/tests/unit/test_gddm_5292.cpp
@@ -1,0 +1,134 @@
+// 5250ng - A modern IBM TN5250 terminal emulator
+// Copyright (C) 2025-2026 Remi GASCOU (Podalirius)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+#include "ui/rendering/gddm_5292_decoder.h"
+
+#include <QtTest/QtTest>
+
+using ui::rendering::Gddm5292Decoder;
+
+class TestGddm5292 : public QObject {
+    Q_OBJECT
+
+  private slots:
+    void ignoresAlphanumericWrites();
+    void decodesDocumentedPolylineFixture();
+    void resumesVariableOrderAcrossBlocks();
+    void systemResetClearsPlane();
+    void suppressesPacingWhenRequested();
+    void rejectsMalformedCoordinates();
+    void decodesReadStatusOffset();
+    void decodesCapturedGddmDemoBlock();
+};
+
+void TestGddm5292::ignoresAlphanumericWrites() {
+    Gddm5292Decoder decoder;
+    const auto result = decoder.process(QByteArray::fromHex("114040"));
+    QVERIFY(!result.handled);
+    QCOMPARE(decoder.blockCount(), quint64(0));
+}
+
+void TestGddm5292::decodesDocumentedPolylineFixture() {
+    Gddm5292Decoder decoder;
+    const QByteArray block = QByteArray::fromHex(
+        "ff93b041a04040404a41644072425640599295");
+
+    const auto result = decoder.process(block);
+
+    QVERIFY(result.handled);
+    QVERIFY(!result.error);
+    QVERIFY(result.pacingResponse);
+    QVERIFY(result.changed);
+    QVERIFY(decoder.displayEnabled());
+    QVERIFY(!decoder.graphicsMode());
+    QCOMPARE(decoder.graphicsPlane().size(), QSize(480, 288));
+    QCOMPARE(decoder.graphicsPlane().pixelColor(0, 277), QColor(255, 0, 0));
+    QCOMPARE(decoder.graphicsPlane().pixelColor(100, 237), QColor(255, 0, 0));
+}
+
+void TestGddm5292::resumesVariableOrderAcrossBlocks() {
+    Gddm5292Decoder decoder;
+    const auto first = decoder.process(QByteArray::fromHex("ff93a04040404a416491"));
+    QVERIFY(first.handled);
+    QVERIFY(!first.error);
+    QVERIFY(first.pacingResponse);
+    QVERIFY(decoder.graphicsMode());
+    QVERIFY(decoder.graphicsPlane().pixelColor(0, 277).alpha() == 0);
+
+    const auto second = decoder.process(QByteArray::fromHex("4072425640599295"));
+    QVERIFY(second.handled);
+    QVERIFY(!second.error);
+    QVERIFY(second.changed);
+    QVERIFY(!decoder.graphicsMode());
+    QCOMPARE(decoder.graphicsPlane().pixelColor(0, 277), QColor(255, 255, 255));
+}
+
+void TestGddm5292::systemResetClearsPlane() {
+    Gddm5292Decoder decoder;
+    decoder.process(QByteArray::fromHex("ff93a04040404a416440729295"));
+    QVERIFY(decoder.displayEnabled());
+
+    const auto reset = decoder.process(QByteArray::fromHex("ffff"));
+    QVERIFY(reset.handled);
+    QVERIFY(reset.pacingResponse);
+    QVERIFY(!decoder.displayEnabled());
+    QVERIFY(!decoder.graphicsMode());
+    QVERIFY(decoder.graphicsPlane().pixelColor(0, 277).alpha() == 0);
+}
+
+void TestGddm5292::suppressesPacingWhenRequested() {
+    Gddm5292Decoder decoder;
+    const auto result = decoder.process(QByteArray::fromHex("ff9695"));
+    QVERIFY(result.handled);
+    QVERIFY(!result.error);
+    QVERIFY(!result.pacingResponse);
+}
+
+void TestGddm5292::rejectsMalformedCoordinates() {
+    Gddm5292Decoder decoder;
+    const auto result = decoder.process(QByteArray::fromHex("ffa04040404a92"));
+    QVERIFY(result.handled);
+    QVERIFY(result.error);
+    QVERIFY(!result.pacingResponse);
+    QVERIFY(!decoder.graphicsMode());
+}
+
+void TestGddm5292::decodesReadStatusOffset() {
+    Gddm5292Decoder decoder;
+    const auto result = decoder.process(QByteArray::fromHex("ff804043959090909090"));
+    QVERIFY(result.handled);
+    QVERIFY(!result.error);
+    QVERIFY(result.pacingResponse);
+    QCOMPARE(result.readStatusOffset, 3);
+    QVERIFY(!decoder.graphicsMode());
+}
+
+void TestGddm5292::decodesCapturedGddmDemoBlock() {
+    Gddm5292Decoder decoder;
+    const QByteArray block = QByteArray::fromHex(
+        "ffb14f404f40b343b240a34093c3414642434342444545444641474892"
+        "b4414078427840437878444740454778467f40477f7892b14f404f40b640"
+        "b044b343a040404040466f444292"
+        "9393939393939393939393939393939393939393939393939393939393939393"
+        "9393939393939393939393939393939393939393939393939393939393939393"
+        "9393939393939393939393939393939393939393939393939393939393939393"
+        "939393939393939393939393939393939395");
+
+    const auto result = decoder.process(block);
+    QVERIFY(result.handled);
+    QVERIFY(!result.error);
+    QVERIFY(result.pacingResponse);
+    QVERIFY(result.changed);
+    QVERIFY(decoder.displayEnabled());
+    QVERIFY(!decoder.graphicsMode());
+    QCOMPARE(decoder.graphicsPlane().pixelColor(0, 287), QColor(0, 255, 0));
+    QCOMPARE(decoder.graphicsPlane().pixelColor(431, 29), QColor(0, 255, 0));
+}
+
+QTEST_MAIN(TestGddm5292)
+#include "test_gddm_5292.moc"

--- a/tests/unit/test_mcp_validation.cpp
+++ b/tests/unit/test_mcp_validation.cpp
@@ -41,6 +41,14 @@ class TestMcpValidation : public QObject {
         QCOMPARE(port.value("minimum").toInt(), 1);
         QCOMPARE(port.value("maximum").toInt(), 65535);
     }
+
+    void schemaPublishesGraphicsDeviceType() {
+        const QJsonObject schema = agent::toolCreateSessionSchema();
+        const QJsonObject deviceType = schema.value("properties").toObject()
+                                           .value("deviceType").toObject();
+        QCOMPARE(deviceType.value("type").toString(), QString("string"));
+        QCOMPARE(deviceType.value("default").toString(), QString("IBM-3179-2"));
+    }
 };
 
 QTEST_MAIN(TestMcpValidation)


### PR DESCRIPTION
### Linked Issue
Closes #175

### Root Cause
5250ng treated every Write to Display payload as an alphanumeric 5250 data stream and exposed no IBM 5292 device type through MCP sessions. It therefore neither recognized the 5292 Begin Graphics framing nor returned the workstation status and pacing responses required for GDDM to continue sending graphics data.

The screen widget also had no retained graphics plane, so decoded 5292 drawing output had nowhere to persist or composite with the terminal presentation.

### Fix Description
Adds a stateful IBM 5292 Model 2 decoder for graphics framing, control orders, status reads, palette updates, background writes, line attributes, and polylines. The command handler separates an alphanumeric prefix from an embedded graphics block, supplies the documented 5292 Level 2 status through the host-created MDT field, and sends the required Command-12 pacing response.

Adds a retained 480x288 graphics plane to the screen widget and composites it without smoothing. MCP create_session now accepts an optional deviceType while preserving IBM-3179-2 as the default, allowing validation sessions to negotiate IBM-5292-2 explicitly. Unsupported variable drawing and printer orders are consumed safely so basic GDDM streams remain synchronized.

### How Verified
- Built the complete project with `cmake --build build -j2`.
- Ran `ctest --test-dir build --output-on-failure`: all 26 tests passed.
- Connected to RSRCH09 through the MCP server as IBM-5292-2, signed on, and ran `CALL GDDMTEST/GDDMDEMO`. The client processed the status exchange and four graphics blocks without decoder errors.
- Captured and inspected the live screen: it displayed the expected bright-green diagonal line on a black GDDM graphics plane.
- Ran `git diff --check` successfully.

### Test Coverage
**Added:**
- `tests/unit/test_gddm_5292.cpp`: recognition, documented polyline decoding, spanned orders, reset, pacing suppression, malformed data, Read Status, and the captured GDDMDEMO block including its palette.
- `tests/unit/test_command_handler_soh.cpp`: graphics routing, pacing responses, compositor output, and Read Status embedded after an alphanumeric prefix.
- `tests/unit/test_mcp_validation.cpp`: published MCP deviceType schema and default.

### Scope of Change
- **Files changed:** `CMakeLists.txt`; MCP schema/server/handler files; `src/ui/main_window.cpp`; `src/ui/rendering/gddm_5292_decoder.*`; TN5250 command handler files; Q5250 screen widget files; three unit-test files.
- **Submodule pointer updated:** no.
- **Behavioral changes outside the bug fix:** none.

### Risk and Rollout
The new decoder is activated only by 5292 Begin Graphics framing, and the MCP device type remains backward-compatible by default. The primary regression risk is malformed or unsupported 5292 orders; these fail closed with logging, and covered ignored orders preserve stream synchronization. This is safe to merge without staged rollout.

### Notes
This PR implements the basic 5292 subset exercised by GDDMDEMO. Additional GDDM drawing primitives can be added incrementally on top of the retained decoder state.