### PR TITLE
[enhancement] Fix save-session prompt styling (Fixes #177)

### DIFF
--- a/src/ui/dialogs/connect_dialog.cpp
+++ b/src/ui/dialogs/connect_dialog.cpp
@@ -26,7 +26,7 @@
 #include <QFileInfo>
 #include <QGroupBox>
 #include <QStandardPaths>
-#include <QInputDialog>
+#include "ui/widgets/Frameless/StyledInputDialog.h"
 #include "ui/widgets/Frameless/StyledMessageBox.h"
 
 ConnectDialog::ConnectDialog(QWidget *parent) : ui::widgets::BaseFramelessDialog(parent) {
@@ -416,7 +416,7 @@ void ConnectDialog::loadSession(const QString &sessionName) {
 
 void ConnectDialog::saveCurrentAsSession() {
     bool ok;
-    QString sessionName = QInputDialog::getText(
+    QString sessionName = ui::widgets::StyledInputDialog::getText(
         this, "Save Session", "Session name:", QLineEdit::Normal,
         m_currentConfig.name(), &ok
     );


### PR DESCRIPTION
### Linked Issue
Closes #177

### Root Cause
`ConnectDialog::saveCurrentAsSession()` called the generic Qt `QInputDialog` directly. That dialog does not inherit from the application `BaseFramelessDialog`, so it bypassed the custom title bar and application-consistent input-dialog layout.

### Fix Description
Replace the generic input-dialog call with the existing `ui::widgets::StyledInputDialog`. Its API preserves the current label, initial value, echo mode, acceptance flag, and cancellation behavior while rendering through the application dialog component.

### How Verified
- **Build:** `cmake --build build --target 5250ng -j2` completed successfully.
- **Tests:** `ctest --test-dir build --output-on-failure` passed all 25 tests.
- **Static:** `ConnectDialog::saveCurrentAsSession()` now calls `StyledInputDialog::getText`; that component derives from `BaseFramelessDialog` and uses the custom title bar and themed controls.

### Test Coverage
**None:** The repository has no automated widget harness for modal dialog window chrome. The change uses the already established and compiled `StyledInputDialog` path used by other application input prompts.

### Scope of Change
- **Files changed:** `src/ui/dialogs/connect_dialog.cpp`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
The change is local to the save-session name prompt and preserves the existing input and acceptance API, so it is safe to merge without staged rollout.