### PR TITLE
[bugfix] Fix GDDM protocol state and responses (Fixes #181)

### DIFF
--- a/src/ui/rendering/gddm_5292_decoder.cpp
+++ b/src/ui/rendering/gddm_5292_decoder.cpp
@@ -8,14 +8,21 @@
 
 #include "gddm_5292_decoder.h"
 
-#include <QPainter>
-#include <QPen>
+#include <algorithm>
+#include <cstdlib>
 
 namespace ui::rendering {
 
 Gddm5292Decoder::Gddm5292Decoder()
-    : m_plane(kWidth, kHeight, QImage::Format_ARGB32_Premultiplied) {
+    : m_plane(kWidth, kHeight, QImage::Format_Indexed8) {
     reset(true);
+}
+
+void Gddm5292Decoder::applyPalette() {
+    QVector<QRgb> table(256, qRgb(0, 0, 0));
+    for (size_t index = 0; index < m_palette.size(); ++index)
+        table[static_cast<int>(index)] = m_palette[index].rgb();
+    m_plane.setColorTable(table);
 }
 
 void Gddm5292Decoder::reset(bool clearPlane) {
@@ -29,8 +36,12 @@ void Gddm5292Decoder::reset(bool clearPlane) {
                  QColor(0, 255, 255), QColor(255, 255, 255)};
     m_colorIndex = 7;
     m_lineWeight = 1;
+    m_rasterFunction = RasterFunction::Replace;
+    m_lastError = ErrorCode::None;
+    m_lastErrorOffset = -1;
+    applyPalette();
     if (clearPlane)
-        m_plane.fill(Qt::transparent);
+        m_plane.fill(0);
 }
 
 bool Gddm5292Decoder::recognizes(const QByteArray &data) const {
@@ -46,67 +57,164 @@ int Gddm5292Decoder::decodeCoordinate(uint8_t high, uint8_t low) {
     return ((high & 0x0F) << 6) | (low & 0x3F);
 }
 
-bool Gddm5292Decoder::fail(Result &result, int offset, const QString &message) {
+int Gddm5292Decoder::decodeBufferOffset(uint8_t high, uint8_t low) {
+    return ((high & 0x3F) << 6) | (low & 0x3F);
+}
+
+QByteArray Gddm5292Decoder::encodedErrorCode(ErrorCode code) {
+    if (code == ErrorCode::None)
+        return QByteArray::fromHex("ffff");
+    QByteArray encoded;
+    encoded.reserve(2);
+    encoded.append(static_cast<char>(0xC7));
+    encoded.append(static_cast<char>(0xF0 + static_cast<int>(code)));
+    return encoded;
+}
+
+QByteArray Gddm5292Decoder::statusBytes() const {
+    QByteArray status;
+    status.reserve(20);
+    status.append(encodedErrorCode(m_lastError));
+    status.append(QByteArray::fromHex("fff280"));
+    if (m_lastErrorOffset < 0) {
+        status.append(QByteArray::fromHex("ffff"));
+    } else {
+        status.append(static_cast<char>((m_lastErrorOffset >> 8) & 0xFF));
+        status.append(static_cast<char>(m_lastErrorOffset & 0xFF));
+    }
+    status.append(QByteArray(13, static_cast<char>(0x40)));
+    return status;
+}
+
+bool Gddm5292Decoder::fail(Result &result, ErrorCode code, int offset,
+                           const QString &message) {
+    m_lastError = code;
+    m_lastErrorOffset = std::max(0, offset);
     result.error = true;
-    result.errorMessage = QString("offset %1: %2").arg(offset).arg(message);
-    result.pacingResponse = false;
+    result.errorMessage = QString("G%1 at offset %2: %3")
+                              .arg(static_cast<int>(code)).arg(offset).arg(message);
+    result.completion = m_suppressPacing ? Completion::None : Completion::FatalError;
     m_graphicsMode = false;
     m_pendingOrder = PendingOrder::None;
     m_pendingData.clear();
     return false;
 }
 
+void Gddm5292Decoder::writePel(int x, int y, int colorIndex) {
+    if (x < 0 || x >= kWidth || y < 0 || y >= kHeight)
+        return;
+
+    auto *line = m_plane.scanLine(y);
+    const int previous = line[x] & 0x07;
+    int next = colorIndex & 0x07;
+    switch (m_rasterFunction) {
+    case RasterFunction::Or:
+        next = previous | next;
+        break;
+    case RasterFunction::Xor:
+        next = previous ^ next;
+        break;
+    case RasterFunction::Replace:
+        break;
+    }
+    line[x] = static_cast<uchar>(next);
+}
+
+void Gddm5292Decoder::drawLine(int x0, int y0, int x1, int y1) {
+    const int dx = std::abs(x1 - x0);
+    const int sx = x0 < x1 ? 1 : -1;
+    const int dy = -std::abs(y1 - y0);
+    const int sy = y0 < y1 ? 1 : -1;
+    int error = dx + dy;
+
+    for (;;) {
+        for (int weightY = 0; weightY < m_lineWeight; ++weightY) {
+            for (int weightX = 0; weightX < m_lineWeight; ++weightX)
+                writePel(x0 + weightX, y0 + weightY, m_colorIndex);
+        }
+        if (x0 == x1 && y0 == y1)
+            break;
+        const int twiceError = 2 * error;
+        if (twiceError >= dy) {
+            error += dy;
+            x0 += sx;
+        }
+        if (twiceError <= dx) {
+            error += dx;
+            y0 += sy;
+        }
+    }
+}
+
 bool Gddm5292Decoder::drawPolyline(Result &result) {
-    if (m_pendingData.size() < 8 || (m_pendingData.size() % 4) != 0)
-        return fail(result, m_pendingData.size(), "polyline requires complete coordinate pairs");
+    if (m_pendingData.size() < 8 || (m_pendingData.size() % 4) != 0) {
+        return fail(result, ErrorCode::G1, m_pendingData.size(),
+                    "polyline requires complete coordinate pairs");
+    }
 
-    QPainter painter(&m_plane);
-    painter.setRenderHint(QPainter::Antialiasing, false);
-    painter.setCompositionMode(QPainter::CompositionMode_Source);
-    painter.setPen(QPen(m_palette[static_cast<size_t>(m_colorIndex)], m_lineWeight,
-                        Qt::SolidLine, Qt::SquareCap, Qt::MiterJoin));
-
-    auto pointAt = [this](int offset) {
-        const int x = decodeCoordinate(static_cast<uint8_t>(m_pendingData[offset]),
-                                       static_cast<uint8_t>(m_pendingData[offset + 1]));
-        const int y = decodeCoordinate(static_cast<uint8_t>(m_pendingData[offset + 2]),
-                                       static_cast<uint8_t>(m_pendingData[offset + 3]));
-        return QPoint(x, kHeight - 1 - y);
+    auto pointAt = [this, &result](int offset, int &x, int &y) {
+        x = decodeCoordinate(static_cast<uint8_t>(m_pendingData[offset]),
+                             static_cast<uint8_t>(m_pendingData[offset + 1]));
+        const int graphicsY = decodeCoordinate(
+            static_cast<uint8_t>(m_pendingData[offset + 2]),
+            static_cast<uint8_t>(m_pendingData[offset + 3]));
+        if (x >= kWidth || graphicsY >= kHeight) {
+            fail(result, ErrorCode::G1, offset, "coordinate is outside the 480x288 PEL buffer");
+            return false;
+        }
+        y = kHeight - 1 - graphicsY;
+        return true;
     };
 
-    QPoint previous = pointAt(0);
+    int previousX = 0;
+    int previousY = 0;
+    if (!pointAt(0, previousX, previousY))
+        return false;
     for (int offset = 4; offset < m_pendingData.size(); offset += 4) {
-        const QPoint next = pointAt(offset);
-        painter.drawLine(previous, next);
-        previous = next;
+        int nextX = 0;
+        int nextY = 0;
+        if (!pointAt(offset, nextX, nextY))
+            return false;
+        drawLine(previousX, previousY, nextX, nextY);
+        previousX = nextX;
+        previousY = nextY;
     }
     result.changed = true;
     return true;
 }
 
-bool Gddm5292Decoder::completePending(Result &result) {
+bool Gddm5292Decoder::completePending(Result &result, int offset) {
+    if (m_pendingData.isEmpty())
+        return fail(result, ErrorCode::G1, offset,
+                    "variable order requires at least one graphics-data byte");
+
     bool ok = true;
     if (m_pendingOrder == PendingOrder::Polyline) {
         ok = drawPolyline(result);
     } else if (m_pendingOrder == PendingOrder::ColorTable) {
         if ((m_pendingData.size() % 3) != 0) {
-            ok = fail(result, m_pendingData.size(),
+            ok = fail(result, ErrorCode::G1, offset,
                       "color table requires index/red-green/blue triples");
         } else {
-            for (int offset = 0; offset < m_pendingData.size(); offset += 3) {
-                const int index = static_cast<uint8_t>(m_pendingData[offset]) & 0x07;
-                if (index == 0) {
-                    ok = fail(result, offset, "color table index zero cannot be changed");
+            for (int dataOffset = 0; dataOffset < m_pendingData.size(); dataOffset += 3) {
+                const int index = static_cast<uint8_t>(m_pendingData[dataOffset]) & 0x3F;
+                if (index == 0 || index > 7) {
+                    ok = fail(result, ErrorCode::G3, dataOffset,
+                              "color table index must be in 1..7");
                     break;
                 }
-                const uint8_t redGreen = static_cast<uint8_t>(m_pendingData[offset + 1]);
-                const uint8_t blue = static_cast<uint8_t>(m_pendingData[offset + 2]);
+                const uint8_t redGreen = static_cast<uint8_t>(m_pendingData[dataOffset + 1]);
+                const uint8_t blue = static_cast<uint8_t>(m_pendingData[dataOffset + 2]);
                 const int redIntensity = (redGreen >> 3) & 0x07;
                 const int greenIntensity = redGreen & 0x07;
                 const int blueIntensity = (blue >> 3) & 0x07;
                 m_palette[static_cast<size_t>(index)] =
                     QColor(redIntensity * 255 / 7, greenIntensity * 255 / 7,
                            blueIntensity * 255 / 7);
+            }
+            if (ok) {
+                applyPalette();
+                result.changed = true;
             }
         }
     }
@@ -130,21 +238,21 @@ Gddm5292Decoder::Result Gddm5292Decoder::process(const QByteArray &data) {
             && static_cast<uint8_t>(data[1]) == 0xFF) {
             reset(true);
             result.changed = true;
-            result.pacingResponse = true;
+            result.completion = Completion::SystemReset;
             return result;
         }
         m_graphicsMode = true;
         offset = 1;
     } else if (!data.isEmpty() && static_cast<uint8_t>(data[0]) == 0xFF) {
-        // A second Begin Graphics while already active is a system reset only
-        // when followed by the required second FF byte.
         if (data.size() >= 2 && static_cast<uint8_t>(data[1]) == 0xFF) {
             reset(true);
             result.changed = true;
-            result.pacingResponse = true;
+            result.completion = Completion::SystemReset;
             return result;
         }
-        return fail(result, 0, "unexpected Begin Graphics while graphics mode is active"), result;
+        fail(result, ErrorCode::G1, 0,
+             "unexpected Begin Graphics while graphics mode is active");
+        return result;
     }
 
     bool endedWithMoreData = false;
@@ -158,29 +266,36 @@ Gddm5292Decoder::Result Gddm5292Decoder::process(const QByteArray &data) {
                 continue;
             }
             if (byte == 0x92) {
-                if (!completePending(result))
+                if (!completePending(result, offset))
                     return result;
                 ++offset;
                 continue;
             }
             if (byte == 0x91) {
+                if (m_pendingData.isEmpty()) {
+                    fail(result, ErrorCode::G1, offset,
+                         "More Data to Come requires graphics data");
+                    return result;
+                }
                 endedWithMoreData = true;
                 ++offset;
                 break;
             }
-            fail(result, offset, "variable order was not terminated by End of Data");
+            fail(result, ErrorCode::G1, offset,
+                 "variable order was not terminated by End of Data");
             return result;
         }
 
         switch (byte) {
-        case 0x90: // End current nonspanned block; graphics mode remains active.
+        case 0x90:
             offset = data.size();
             continue;
         case 0x91:
-            fail(result, offset, "More Data to Come without a variable order");
+            fail(result, ErrorCode::G1, offset,
+                 "More Data to Come without a variable order");
             return result;
         case 0x92:
-            fail(result, offset, "End of Data without a variable order");
+            fail(result, ErrorCode::G1, offset, "End of Data without a variable order");
             return result;
         case 0x93:
             m_displayEnabled = true;
@@ -194,8 +309,6 @@ Gddm5292Decoder::Result Gddm5292Decoder::process(const QByteArray &data) {
             continue;
         case 0x95:
             m_graphicsMode = false;
-            // End Graphics terminates this graphics write block. IBM i pads
-            // short blocks after 0x95; those bytes are not graphics orders.
             offset = data.size();
             continue;
         case 0x96:
@@ -208,11 +321,13 @@ Gddm5292Decoder::Result Gddm5292Decoder::process(const QByteArray &data) {
 
         auto readFixedData = [&](int count, QByteArray &values) {
             if (offset + count >= data.size())
-                return fail(result, offset, "truncated fixed-length graphics order");
+                return fail(result, ErrorCode::G1, offset,
+                            "truncated fixed-length graphics order");
             for (int index = 1; index <= count; ++index) {
                 const uint8_t value = static_cast<uint8_t>(data[offset + index]);
                 if (!isGraphicsData(value))
-                    return fail(result, offset + index, "graphics-data byte expected");
+                    return fail(result, ErrorCode::G1, offset + index,
+                                "graphics-data byte expected");
                 values.append(static_cast<char>(value));
             }
             offset += count + 1;
@@ -221,85 +336,113 @@ Gddm5292Decoder::Result Gddm5292Decoder::process(const QByteArray &data) {
 
         QByteArray values;
         switch (byte) {
-        case 0x80: // Read Status
+        case 0x80: {
             if (!readFixedData(2, values)) return result;
-            result.readStatusOffset = decodeCoordinate(
+            const int statusOffset = decodeBufferOffset(
                 static_cast<uint8_t>(values[0]), static_cast<uint8_t>(values[1]));
+            if (statusOffset > 1919) {
+                fail(result, ErrorCode::G1, offset - 2,
+                     "Read Status offset is outside the 1920-byte alphanumeric buffer");
+                return result;
+            }
+            result.statusWrites.append({statusOffset, statusBytes()});
             break;
-        case 0xB0: // Set Color
+        }
+        case 0xB0:
             if (!readFixedData(1, values)) return result;
             m_colorIndex = static_cast<uint8_t>(values[0]) & 0x3F;
             if (m_colorIndex > 7) {
-                fail(result, offset - 1, "color index is outside 0..7");
+                fail(result, ErrorCode::G3, offset - 1, "color index must be in 0..7");
                 return result;
             }
             break;
-        case 0xB1: // Set Style
+        case 0xB1:
             if (!readFixedData(4, values)) return result;
             break;
-        case 0xB2: // Set Style Offset
-        case 0xB3: // Set Function
-        case 0xB5: // Set Marker
+        case 0xB2:
             if (!readFixedData(1, values)) return result;
             break;
-        case 0xB4: // Set Color Table
+        case 0xB5:
+            if (!readFixedData(1, values)) return result;
+            if ((static_cast<uint8_t>(values[0]) & 0x3F) > 8) {
+                fail(result, ErrorCode::G3, offset - 1, "marker index must be in 0..8");
+                return result;
+            }
+            break;
+        case 0xB3: {
+            if (!readFixedData(1, values)) return result;
+            const int function = static_cast<uint8_t>(values[0]) & 0x03;
+            if (function < static_cast<int>(RasterFunction::Or)
+                || function > static_cast<int>(RasterFunction::Replace)) {
+                fail(result, ErrorCode::G3, offset - 1, "invalid raster function");
+                return result;
+            }
+            m_rasterFunction = static_cast<RasterFunction>(function);
+            break;
+        }
+        case 0xB4:
             m_pendingOrder = PendingOrder::ColorTable;
             ++offset;
             break;
-        case 0xB6: // Set Line Weight
+        case 0xB6:
             if (!readFixedData(1, values)) return result;
             m_lineWeight = ((static_cast<uint8_t>(values[0]) & 0x3F) == 0) ? 1 : 2;
             break;
-        case 0xB7: // Set Fill Mode
+        case 0xB7:
             if (!readFixedData(2, values)) return result;
             break;
-        case 0xA0: // Draw Polyline
+        case 0xA0:
             m_pendingOrder = PendingOrder::Polyline;
             ++offset;
             break;
-        case 0xA1: // Draw Scanline (retained for a later rendering phase)
-        case 0xA4: // Write Polymarker
-        case 0xA5: // Fill Polygon
-        case 0xA6: // Define Shield Area
-            m_pendingOrder = PendingOrder::Ignore;
-            ++offset;
-            break;
-        case 0xA3: { // Write Background
+        case 0xA3: {
             if (!readFixedData(1, values)) return result;
             const int color = static_cast<uint8_t>(values[0]) & 0x3F;
             if (color > 7) {
-                fail(result, offset - 1, "background color index is outside 0..7");
+                fail(result, ErrorCode::G3, offset - 1,
+                     "background color index must be in 0..7");
                 return result;
             }
-            m_plane.fill(m_palette[static_cast<size_t>(color)]);
+            for (int y = 0; y < kHeight; ++y) {
+                for (int x = 0; x < kWidth; ++x)
+                    writePel(x, y, color);
+            }
             result.changed = true;
             break;
         }
-        case 0xC0: // Printer Data Follows
-        case 0xC2: // Load printer alphanumeric color-mix table
-        case 0xC3: // Load printer graphics color-mix table
+        case 0xA1:
+        case 0xA4:
+        case 0xA5:
+        case 0xA6:
+            fail(result, ErrorCode::G2, offset, QString("unsupported drawing order 0x%1")
+                                                    .arg(byte, 2, 16, QChar('0')));
+            return result;
+        case 0xC0:
+        case 0xC2:
+        case 0xC3:
             m_pendingOrder = PendingOrder::Ignore;
             ++offset;
             break;
-        case 0xC1: // Screen Copy
+        case 0xC1:
             ++offset;
             break;
-        case 0xC4: // Set printer timeout
+        case 0xC4:
             if (!readFixedData(1, values)) return result;
             break;
         default:
-            fail(result, offset, QString("unsupported graphics order 0x%1")
-                                     .arg(byte, 2, 16, QChar('0')));
+            fail(result, ErrorCode::G2, offset, QString("unsupported graphics order 0x%1")
+                                                    .arg(byte, 2, 16, QChar('0')));
             return result;
         }
     }
 
     if (m_pendingOrder != PendingOrder::None && !endedWithMoreData) {
-        fail(result, data.size(), "unterminated variable order at end of block");
+        fail(result, ErrorCode::G1, data.size(),
+             "unterminated variable order at end of block");
         return result;
     }
 
-    result.pacingResponse = !m_suppressPacing;
+    result.completion = m_suppressPacing ? Completion::None : Completion::Success;
     return result;
 }
 

--- a/src/ui/rendering/gddm_5292_decoder.h
+++ b/src/ui/rendering/gddm_5292_decoder.h
@@ -12,6 +12,7 @@
 #include <QColor>
 #include <QImage>
 #include <QString>
+#include <QVector>
 #include <array>
 #include <cstdint>
 
@@ -22,12 +23,25 @@ class Gddm5292Decoder {
     static constexpr int kWidth = 480;
     static constexpr int kHeight = 288;
 
+    enum class Completion {
+        None,
+        Success,
+        SystemReset,
+        RecoverableError,
+        FatalError
+    };
+
+    struct StatusWrite {
+        int offset = 0;
+        QByteArray data;
+    };
+
     struct Result {
         bool handled = false;
-        bool pacingResponse = false;
         bool changed = false;
         bool error = false;
-        int readStatusOffset = -1;
+        Completion completion = Completion::None;
+        QVector<StatusWrite> statusWrites;
         QString errorMessage;
     };
 
@@ -40,8 +54,24 @@ class Gddm5292Decoder {
     bool displayEnabled() const { return m_displayEnabled; }
     const QImage &graphicsPlane() const { return m_plane; }
     quint64 blockCount() const { return m_blockCount; }
+    QByteArray statusBytes() const;
 
   private:
+    enum class ErrorCode {
+        None,
+        G1,
+        G2,
+        G3,
+        G4,
+        G5
+    };
+
+    enum class RasterFunction {
+        Or = 1,
+        Xor = 2,
+        Replace = 3
+    };
+
     enum class PendingOrder {
         None,
         Polyline,
@@ -50,11 +80,16 @@ class Gddm5292Decoder {
     };
 
     void reset(bool clearPlane);
-    bool completePending(Result &result);
+    bool completePending(Result &result, int offset);
     bool drawPolyline(Result &result);
-    bool fail(Result &result, int offset, const QString &message);
+    bool fail(Result &result, ErrorCode code, int offset, const QString &message);
+    void applyPalette();
+    void writePel(int x, int y, int colorIndex);
+    void drawLine(int x0, int y0, int x1, int y1);
+    static QByteArray encodedErrorCode(ErrorCode code);
     static bool isGraphicsData(uint8_t byte);
     static int decodeCoordinate(uint8_t high, uint8_t low);
+    static int decodeBufferOffset(uint8_t high, uint8_t low);
 
     bool m_graphicsMode = false;
     bool m_displayEnabled = false;
@@ -64,6 +99,9 @@ class Gddm5292Decoder {
     std::array<QColor, 8> m_palette;
     int m_colorIndex = 7;
     int m_lineWeight = 1;
+    RasterFunction m_rasterFunction = RasterFunction::Replace;
+    ErrorCode m_lastError = ErrorCode::None;
+    int m_lastErrorOffset = -1;
     QImage m_plane;
     quint64 m_blockCount = 0;
 };

--- a/src/ui/rendering/tn5250_command_handler.cpp
+++ b/src/ui/rendering/tn5250_command_handler.cpp
@@ -25,6 +25,64 @@
 
 namespace ui::rendering {
 
+namespace {
+
+// A Begin Graphics byte is meaningful only where a 5250 display order may
+// begin. IBM i precedes Read Status graphics blocks with SBA/SF orders that
+// define the MDT field; an 0xFF after ordinary EBCDIC text is character data.
+int findGddmStart(const QByteArray &data) {
+    int offset = 0;
+    while (offset < data.size()) {
+        const uint8_t byte = static_cast<uint8_t>(data[offset]);
+        if (byte == 0xFF)
+            return offset;
+
+        if (byte == 0x11) { // SBA
+            if (offset + 2 >= data.size())
+                return -1;
+            offset += 3;
+            continue;
+        }
+
+        if (byte == 0x1D) { // SF, including any optional FCW pairs
+            if (offset + 4 >= data.size())
+                return -1;
+            int fieldOffset = offset + 3;
+            while (fieldOffset < data.size()
+                   && (static_cast<uint8_t>(data[fieldOffset]) & 0xE0) != 0x20) {
+                if (fieldOffset + 1 >= data.size())
+                    return -1;
+                fieldOffset += 2;
+            }
+            if (fieldOffset + 2 >= data.size())
+                return -1;
+            offset = fieldOffset + 3;
+            continue;
+        }
+
+        return -1;
+    }
+    return -1;
+}
+
+uint8_t completionAid(Gddm5292Decoder::Completion completion) {
+    switch (completion) {
+    case Gddm5292Decoder::Completion::SystemReset:
+        return 0x38; // Command-8
+    case Gddm5292Decoder::Completion::RecoverableError:
+        return 0x39; // Command-9
+    case Gddm5292Decoder::Completion::FatalError:
+        return 0x3A; // Command-10
+    case Gddm5292Decoder::Completion::Success:
+        return 0x3C; // Command-12
+    case Gddm5292Decoder::Completion::None:
+        return 0;
+    }
+    return 0;
+}
+
+} // namespace
+
 TN5250CommandHandler::TN5250CommandHandler(QObject *parent)
     : QObject(parent) {}
 
@@ -185,7 +243,7 @@ void TN5250CommandHandler::handleRawScreenData(const QByteArray &data) {
 
         QByteArray graphicsData = data;
         if (!m_gddmDecoder.recognizes(data)) {
-            const int beginGraphics = data.indexOf(static_cast<char>(0xFF));
+            const int beginGraphics = findGddmStart(data);
             if (beginGraphics > 0) {
                 if (m_renderer)
                     m_renderer->render(data.left(beginGraphics));
@@ -197,38 +255,27 @@ void TN5250CommandHandler::handleRawScreenData(const QByteArray &data) {
         if (graphics.handled) {
             m_displayWidget->setGddmGraphicsPlane(m_gddmDecoder.graphicsPlane(),
                                                   m_gddmDecoder.displayEnabled());
+            bool includeModifiedFields = false;
+            auto *screen = m_displayWidget->screenBuffer();
+            const int cells = screen->rows() * screen->cols();
+            for (const auto &statusWrite : graphics.statusWrites) {
+                for (int index = 0; index < statusWrite.data.size(); ++index) {
+                    const int address = (statusWrite.offset + index) % cells;
+                    screen->writeChar(address / screen->cols(), address % screen->cols(),
+                                      static_cast<uint8_t>(statusWrite.data[index]));
+                    screen->markFieldModified(address / screen->cols(),
+                                              address % screen->cols());
+                }
+                includeModifiedFields = true;
+            }
             if (graphics.error) {
                 logger::Logger::instance()->error(
                     QString("CommandHandler: 5292 graphics error: %1")
                         .arg(graphics.errorMessage));
-            } else if (graphics.pacingResponse && m_sendToHost) {
-                bool includeModifiedFields = false;
-                if (graphics.readStatusOffset >= 0) {
-                    // Successful 5292 Model 2 Level 2 status. The read order
-                    // writes these bytes into the alphanumeric buffer so the
-                    // enclosing 5250 Read MDT can return them to GDDM.
-                    const QByteArray status = QByteArray::fromHex(
-                        "fffffff280ffff4040404040404040404040404040");
-                    auto *screen = m_displayWidget->screenBuffer();
-                    const int cells = screen->rows() * screen->cols();
-                    for (int index = 0; index < status.size(); ++index) {
-                        const int address = graphics.readStatusOffset + index;
-                        if (address >= cells)
-                            break;
-                        screen->writeChar(address / screen->cols(), address % screen->cols(),
-                                          static_cast<uint8_t>(status[index]));
-                    }
-                    if (graphics.readStatusOffset < cells) {
-                        screen->markFieldModified(graphics.readStatusOffset / screen->cols(),
-                                                  graphics.readStatusOffset % screen->cols());
-                    }
-                    includeModifiedFields = true;
-                }
-                // Command-12/PF12 is the documented successful 5292 block
-                // completion response. Read Status additionally returns the
-                // host-created MDT field containing the status bytes.
-                m_sendToHost(buildFieldResponse(0x3C, includeModifiedFields));
             }
+            const uint8_t aid = completionAid(graphics.completion);
+            if (aid != 0 && m_sendToHost)
+                m_sendToHost(buildFieldResponse(aid, includeModifiedFields));
             logger::Logger::instance()->debug(
                 QString("CommandHandler: 5292 graphics block %1 (%2 bytes, mode=%3, display=%4)")
                     .arg(m_gddmDecoder.blockCount()).arg(data.size())

--- a/tests/unit/test_command_handler_soh.cpp
+++ b/tests/unit/test_command_handler_soh.cpp
@@ -38,6 +38,9 @@ class TestCommandHandlerSoh : public QObject {
     void testGddmBlockBypassesAlphanumericRendererAndPaces();
     void testGddmSuppressPacingOrder();
     void testGddmReadStatusWithAlphanumericPrefix();
+    void testGddmStatusWriteIsIndependentOfPacing();
+    void testGddmResetAndErrorUseDocumentedAids();
+    void testEBCDICffInTextDoesNotBeginGraphics();
 
   private:
     Q5250ScreenWidget *m_widget = nullptr;
@@ -152,6 +155,47 @@ void TestCommandHandlerSoh::testGddmReadStatusWithAlphanumericPrefix() {
     QCOMPARE(static_cast<uint8_t>(responses[0][10]), static_cast<uint8_t>(0x80));
     QCOMPARE(m_widget->screenBuffer()->character(0, 3), static_cast<uint8_t>(0xFF));
     QCOMPARE(m_widget->screenBuffer()->character(0, 6), static_cast<uint8_t>(0xF2));
+}
+
+void TestCommandHandlerSoh::testGddmStatusWriteIsIndependentOfPacing() {
+    QList<QByteArray> responses;
+    m_handler->setSendToHostCallback(
+        [&responses](const QByteArray &response) { responses.append(response); });
+
+    m_handler->handleRawScreenData(QByteArray::fromHex(
+        "1101031d4800270032ff8040439695"));
+
+    QVERIFY(responses.isEmpty());
+    QCOMPARE(m_widget->screenBuffer()->character(0, 3), static_cast<uint8_t>(0xFF));
+    QCOMPARE(m_widget->screenBuffer()->character(0, 6), static_cast<uint8_t>(0xF2));
+}
+
+void TestCommandHandlerSoh::testGddmResetAndErrorUseDocumentedAids() {
+    QList<QByteArray> responses;
+    m_handler->setSendToHostCallback(
+        [&responses](const QByteArray &response) { responses.append(response); });
+
+    m_handler->handleRawScreenData(QByteArray::fromHex("ffff"));
+    QCOMPARE(responses.size(), 1);
+    QCOMPARE(static_cast<uint8_t>(responses[0][2]), static_cast<uint8_t>(0x38));
+
+    m_handler->handleRawScreenData(QByteArray::fromHex("ffa04040404a92"));
+    QCOMPARE(responses.size(), 2);
+    QCOMPARE(static_cast<uint8_t>(responses[1][2]), static_cast<uint8_t>(0x3A));
+}
+
+void TestCommandHandlerSoh::testEBCDICffInTextDoesNotBeginGraphics() {
+    QList<QByteArray> responses;
+    m_handler->setSendToHostCallback(
+        [&responses](const QByteArray &response) { responses.append(response); });
+
+    m_handler->handleRawScreenData(QByteArray::fromHex("c1ffc2"));
+
+    QVERIFY(responses.isEmpty());
+    QVERIFY(!m_widget->gddmGraphicsVisible());
+    QCOMPARE(m_widget->screenBuffer()->character(0, 0), static_cast<uint8_t>(0xC1));
+    QCOMPARE(m_widget->screenBuffer()->character(0, 1), static_cast<uint8_t>(0xFF));
+    QCOMPARE(m_widget->screenBuffer()->character(0, 2), static_cast<uint8_t>(0xC2));
 }
 
 QTEST_MAIN(TestCommandHandlerSoh)

--- a/tests/unit/test_gddm_5292.cpp
+++ b/tests/unit/test_gddm_5292.cpp
@@ -23,6 +23,11 @@ class TestGddm5292 : public QObject {
     void suppressesPacingWhenRequested();
     void rejectsMalformedCoordinates();
     void decodesReadStatusOffset();
+    void appliesIndexedRasterFunctions();
+    void paletteChangesRecolorExistingPels();
+    void reportsStructuredErrorStatus();
+    void classifiesUndefinedAndInvalidSetOrders();
+    void suppressesFatalErrorCompletionWhenRequested();
     void decodesCapturedGddmDemoBlock();
 };
 
@@ -42,7 +47,7 @@ void TestGddm5292::decodesDocumentedPolylineFixture() {
 
     QVERIFY(result.handled);
     QVERIFY(!result.error);
-    QVERIFY(result.pacingResponse);
+    QCOMPARE(result.completion, Gddm5292Decoder::Completion::Success);
     QVERIFY(result.changed);
     QVERIFY(decoder.displayEnabled());
     QVERIFY(!decoder.graphicsMode());
@@ -56,9 +61,9 @@ void TestGddm5292::resumesVariableOrderAcrossBlocks() {
     const auto first = decoder.process(QByteArray::fromHex("ff93a04040404a416491"));
     QVERIFY(first.handled);
     QVERIFY(!first.error);
-    QVERIFY(first.pacingResponse);
+    QCOMPARE(first.completion, Gddm5292Decoder::Completion::Success);
     QVERIFY(decoder.graphicsMode());
-    QVERIFY(decoder.graphicsPlane().pixelColor(0, 277).alpha() == 0);
+    QCOMPARE(decoder.graphicsPlane().pixelColor(0, 277), QColor(0, 0, 0));
 
     const auto second = decoder.process(QByteArray::fromHex("4072425640599295"));
     QVERIFY(second.handled);
@@ -75,10 +80,10 @@ void TestGddm5292::systemResetClearsPlane() {
 
     const auto reset = decoder.process(QByteArray::fromHex("ffff"));
     QVERIFY(reset.handled);
-    QVERIFY(reset.pacingResponse);
+    QCOMPARE(reset.completion, Gddm5292Decoder::Completion::SystemReset);
     QVERIFY(!decoder.displayEnabled());
     QVERIFY(!decoder.graphicsMode());
-    QVERIFY(decoder.graphicsPlane().pixelColor(0, 277).alpha() == 0);
+    QCOMPARE(decoder.graphicsPlane().pixelColor(0, 277), QColor(0, 0, 0));
 }
 
 void TestGddm5292::suppressesPacingWhenRequested() {
@@ -86,7 +91,7 @@ void TestGddm5292::suppressesPacingWhenRequested() {
     const auto result = decoder.process(QByteArray::fromHex("ff9695"));
     QVERIFY(result.handled);
     QVERIFY(!result.error);
-    QVERIFY(!result.pacingResponse);
+    QCOMPARE(result.completion, Gddm5292Decoder::Completion::None);
 }
 
 void TestGddm5292::rejectsMalformedCoordinates() {
@@ -94,18 +99,79 @@ void TestGddm5292::rejectsMalformedCoordinates() {
     const auto result = decoder.process(QByteArray::fromHex("ffa04040404a92"));
     QVERIFY(result.handled);
     QVERIFY(result.error);
-    QVERIFY(!result.pacingResponse);
+    QCOMPARE(result.completion, Gddm5292Decoder::Completion::FatalError);
     QVERIFY(!decoder.graphicsMode());
 }
 
 void TestGddm5292::decodesReadStatusOffset() {
     Gddm5292Decoder decoder;
-    const auto result = decoder.process(QByteArray::fromHex("ff804043959090909090"));
+    const auto result = decoder.process(QByteArray::fromHex("ff805443959090909090"));
     QVERIFY(result.handled);
     QVERIFY(!result.error);
-    QVERIFY(result.pacingResponse);
-    QCOMPARE(result.readStatusOffset, 3);
+    QCOMPARE(result.completion, Gddm5292Decoder::Completion::Success);
+    QCOMPARE(result.statusWrites.size(), 1);
+    QCOMPARE(result.statusWrites[0].offset, 1283);
+    QByteArray expectedStatus = QByteArray::fromHex("fffffff280ffff");
+    expectedStatus.append(QByteArray(13, static_cast<char>(0x40)));
+    QCOMPARE(result.statusWrites[0].data, expectedStatus);
+    QCOMPARE(result.statusWrites[0].data.size(), 20);
     QVERIFY(!decoder.graphicsMode());
+}
+
+void TestGddm5292::appliesIndexedRasterFunctions() {
+    Gddm5292Decoder decoder;
+    const QByteArray point = QByteArray::fromHex("a0404040404040404092");
+
+    decoder.process(QByteArray::fromHex("ff93b041b343") + point);
+    QCOMPARE(decoder.graphicsPlane().pixelColor(0, 287), QColor(255, 0, 0));
+
+    decoder.process(QByteArray::fromHex("b042b341") + point);
+    QCOMPARE(decoder.graphicsPlane().pixelColor(0, 287), QColor(0, 0, 255));
+
+    decoder.process(QByteArray::fromHex("b342") + point);
+    QCOMPARE(decoder.graphicsPlane().pixelColor(0, 287), QColor(255, 0, 0));
+
+    decoder.process(QByteArray::fromHex("b343") + point + QByteArray::fromHex("95"));
+    QCOMPARE(decoder.graphicsPlane().pixelColor(0, 287), QColor(0, 255, 0));
+}
+
+void TestGddm5292::paletteChangesRecolorExistingPels() {
+    Gddm5292Decoder decoder;
+    decoder.process(QByteArray::fromHex(
+        "ff93b041a0404040404040404092b4417f789295"));
+
+    QCOMPARE(decoder.graphicsPlane().format(), QImage::Format_Indexed8);
+    QCOMPARE(decoder.graphicsPlane().pixelColor(0, 287), QColor(255, 255, 255));
+}
+
+void TestGddm5292::reportsStructuredErrorStatus() {
+    Gddm5292Decoder decoder;
+    const auto malformed = decoder.process(QByteArray::fromHex("ffa04040404a92"));
+    QVERIFY(malformed.error);
+    QCOMPARE(malformed.completion, Gddm5292Decoder::Completion::FatalError);
+    QCOMPARE(decoder.statusBytes().left(2), QByteArray::fromHex("c7f1"));
+    QVERIFY(decoder.statusBytes().mid(5, 2) != QByteArray::fromHex("ffff"));
+}
+
+void TestGddm5292::classifiesUndefinedAndInvalidSetOrders() {
+    Gddm5292Decoder undefinedOrder;
+    const auto undefined = undefinedOrder.process(QByteArray::fromHex("ffa2"));
+    QVERIFY(undefined.error);
+    QCOMPARE(undefinedOrder.statusBytes().left(2), QByteArray::fromHex("c7f2"));
+
+    Gddm5292Decoder invalidSet;
+    const auto invalid = invalidSet.process(QByteArray::fromHex("ffb549"));
+    QVERIFY(invalid.error);
+    QCOMPARE(invalidSet.statusBytes().left(2), QByteArray::fromHex("c7f3"));
+}
+
+void TestGddm5292::suppressesFatalErrorCompletionWhenRequested() {
+    Gddm5292Decoder decoder;
+    const auto result = decoder.process(QByteArray::fromHex("ff96a2"));
+
+    QVERIFY(result.error);
+    QCOMPARE(result.completion, Gddm5292Decoder::Completion::None);
+    QCOMPARE(decoder.statusBytes().left(2), QByteArray::fromHex("c7f2"));
 }
 
 void TestGddm5292::decodesCapturedGddmDemoBlock() {
@@ -122,7 +188,7 @@ void TestGddm5292::decodesCapturedGddmDemoBlock() {
     const auto result = decoder.process(block);
     QVERIFY(result.handled);
     QVERIFY(!result.error);
-    QVERIFY(result.pacingResponse);
+    QCOMPARE(result.completion, Gddm5292Decoder::Completion::Success);
     QVERIFY(result.changed);
     QVERIFY(decoder.displayEnabled());
     QVERIFY(!decoder.graphicsMode());


### PR DESCRIPTION
### Linked Issue
Closes #181

### Root Cause
The initial 5292 decoder represented completion as a pacing boolean and one status offset, while drawing directly into final RGBA colors. That state model could not preserve three-bit PEL operations, multiple status writes, persistent graphics errors, or distinct reset and error outcomes.

The command handler also searched an entire display payload for byte `0xFF`, without respecting 5250 display-order boundaries, and coupled Read Status buffer updates to whether a completion response was sent.

### Fix Description
The decoder now retains an indexed 480x288 PEL plane and applies Replace, OR, and XOR to color indexes with deterministic line rasterization. Palette changes update already-drawn PELs. It retains structured G1-G5 error state and offsets, snapshots 20-byte status writes at full 12-bit A/N buffer addresses, and returns typed success, reset, recoverable-error, and fatal-error completions.

The command handler writes status data independently of pacing, maps completions to Cmd-12, Cmd-8, Cmd-9, and Cmd-10 AIDs, and recognizes Begin Graphics only after a valid sequence of 5250 SBA/SF setup orders.

### How Verified
- **Build:** `cmake --build build -j4` completed successfully.
- **Tests:** `QT_QPA_PLATFORM=offscreen ctest --test-dir build --output-on-failure -j4` passed all 26 targets.
- **Runtime fixture:** the captured `GDDMDEMO` graphics block passes `decodesCapturedGddmDemoBlock` and renders the expected green diagonal endpoints.
- **Protocol fixtures:** focused tests verify 12-bit status offsets, indexed palette retention, Replace/OR/XOR results, G1/G2/G3 status, status writes under suppressed pacing, reset/error AIDs, and ordinary EBCDIC `0xFF` handling.

### Test Coverage
**Added:**
- `tests/unit/test_gddm_5292.cpp`: `appliesIndexedRasterFunctions`, `paletteChangesRecolorExistingPels`, `reportsStructuredErrorStatus`, and `classifiesUndefinedAndInvalidSetOrders`, and `suppressesFatalErrorCompletionWhenRequested`; expanded status, reset, malformed-data, and captured-demo assertions.
- `tests/unit/test_command_handler_soh.cpp`: `testGddmStatusWriteIsIndependentOfPacing`, `testGddmResetAndErrorUseDocumentedAids`, and `testEBCDICffInTextDoesNotBeginGraphics`.

### Scope of Change
- **Files changed:** `src/ui/rendering/gddm_5292_decoder.cpp`, `src/ui/rendering/gddm_5292_decoder.h`, `src/ui/rendering/tn5250_command_handler.cpp`, `tests/unit/test_gddm_5292.cpp`, `tests/unit/test_command_handler_soh.cpp`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
The change is confined to IBM 5292 graphics decoding and its command-handler response path. The main regression risk is PEL rasterization at line edges; captured-stream and coordinate fixtures cover the currently implemented polyline path, so staged rollout is not required.

### Notes
Live visual verification against RSRCH09 remains pending because TCP port 23 timed out from the build environment. The captured host stream and complete automated suite pass.
