### PR TITLE
[bugfix] Fix GDDM I/O feature orders (Fixes #187)

### DIFF
--- a/src/ui/rendering/gddm_5292_decoder.cpp
+++ b/src/ui/rendering/gddm_5292_decoder.cpp
@@ -69,6 +69,8 @@ void Gddm5292Decoder::reset(bool clearPlane) {
     m_fillReference = FillReference::Vertical;
     m_fillMode = FillMode::SolidBoundaryAndFill;
     m_fillReferenceShift = 0;
+    // The 5292 default is three five-and-a-half-second time units.
+    m_printerTimeout = 3;
     m_rasterFunction = RasterFunction::Replace;
     m_lastError = ErrorCode::None;
     m_lastErrorOffset = -1;
@@ -513,6 +515,12 @@ bool Gddm5292Decoder::completePending(Result &result, int offset) {
                 result.changed = true;
             }
         }
+    } else if (m_pendingOrder == PendingOrder::PrinterData) {
+        result.printerData = m_pendingData;
+    } else if (m_pendingOrder == PendingOrder::PrinterColorTableAN) {
+        result.printerColorTableAN = m_pendingData;
+    } else if (m_pendingOrder == PendingOrder::PrinterColorTableGraphics) {
+        result.printerColorTableGraphics = m_pendingData;
     }
     m_pendingOrder = PendingOrder::None;
     m_pendingData.clear();
@@ -739,16 +747,25 @@ Gddm5292Decoder::Result Gddm5292Decoder::process(const QByteArray &data) {
             ++offset;
             break;
         case 0xC0:
+            m_pendingOrder = PendingOrder::PrinterData;
+            ++offset;
+            break;
         case 0xC2:
+            m_pendingOrder = PendingOrder::PrinterColorTableAN;
+            ++offset;
+            break;
         case 0xC3:
-            m_pendingOrder = PendingOrder::Ignore;
+            m_pendingOrder = PendingOrder::PrinterColorTableGraphics;
             ++offset;
             break;
         case 0xC1:
+            result.screenCopyRequested = true;
             ++offset;
             break;
         case 0xC4:
             if (!readFixedData(1, values)) return result;
+            m_printerTimeout = static_cast<uint8_t>(values[0]) & 0x3F;
+            result.printerTimeout = m_printerTimeout;
             break;
         default:
             fail(result, ErrorCode::G2, offset, QString("unsupported graphics order 0x%1")

--- a/src/ui/rendering/gddm_5292_decoder.h
+++ b/src/ui/rendering/gddm_5292_decoder.h
@@ -43,6 +43,11 @@ class Gddm5292Decoder {
         bool changed = false;
         bool error = false;
         Completion completion = Completion::None;
+        bool screenCopyRequested = false;
+        QByteArray printerData;
+        QByteArray printerColorTableAN;
+        QByteArray printerColorTableGraphics;
+        int printerTimeout = -1;
         QVector<StatusWrite> statusWrites;
         QString errorMessage;
     };
@@ -82,6 +87,9 @@ class Gddm5292Decoder {
         FillPolygon,
         ShieldArea,
         ColorTable,
+        PrinterData,
+        PrinterColorTableAN,
+        PrinterColorTableGraphics,
         Ignore
     };
 
@@ -151,6 +159,7 @@ class Gddm5292Decoder {
     FillReference m_fillReference = FillReference::Vertical;
     FillMode m_fillMode = FillMode::SolidBoundaryAndFill;
     int m_fillReferenceShift = 0;
+    int m_printerTimeout = 3;
     RasterFunction m_rasterFunction = RasterFunction::Replace;
     ErrorCode m_lastError = ErrorCode::None;
     int m_lastErrorOffset = -1;

--- a/src/ui/rendering/tn5250_command_handler.cpp
+++ b/src/ui/rendering/tn5250_command_handler.cpp
@@ -100,6 +100,14 @@ void TN5250CommandHandler::setSendGDSCallback(SendGDSFn fn) {
     m_sendGDS = std::move(fn);
 }
 
+void TN5250CommandHandler::setGddmScreenCopyCallback(GddmScreenCopyFn fn) {
+    m_gddmScreenCopy = std::move(fn);
+}
+
+void TN5250CommandHandler::setGddmPrinterDataCallback(GddmPrinterDataFn fn) {
+    m_gddmPrinterData = std::move(fn);
+}
+
 void TN5250CommandHandler::connectDecoder(tn5250::client::DecoderAdapter *parser) {
     if (!parser) return;
     connect(parser, &tn5250::client::DecoderAdapter::commandReceived,
@@ -255,6 +263,23 @@ void TN5250CommandHandler::handleRawScreenData(const QByteArray &data) {
         if (graphics.handled) {
             m_displayWidget->setGddmGraphicsPlane(m_gddmDecoder.graphicsPlane(),
                                                   m_gddmDecoder.displayEnabled());
+            if (graphics.screenCopyRequested && m_gddmScreenCopy) {
+                QImage composite(m_displayWidget->size(),
+                                 QImage::Format_ARGB32_Premultiplied);
+                composite.fill(Qt::black);
+                m_displayWidget->render(&composite);
+                m_gddmScreenCopy(composite);
+            }
+            if (m_gddmPrinterData
+                && (!graphics.printerData.isEmpty()
+                    || !graphics.printerColorTableAN.isEmpty()
+                    || !graphics.printerColorTableGraphics.isEmpty()
+                    || graphics.printerTimeout >= 0)) {
+                m_gddmPrinterData(graphics.printerData,
+                                  graphics.printerColorTableAN,
+                                  graphics.printerColorTableGraphics,
+                                  graphics.printerTimeout);
+            }
             bool includeModifiedFields = false;
             auto *screen = m_displayWidget->screenBuffer();
             const int cells = screen->rows() * screen->cols();

--- a/src/ui/rendering/tn5250_command_handler.h
+++ b/src/ui/rendering/tn5250_command_handler.h
@@ -46,12 +46,18 @@ class TN5250CommandHandler : public QObject {
   public:
     using SendToHostFn = std::function<void(const QByteArray &)>;
     using SendGDSFn = std::function<void(uint8_t flagsHi, uint8_t opcode, const QByteArray &payload)>;
+    using GddmScreenCopyFn = std::function<void(const QImage &)>;
+    using GddmPrinterDataFn = std::function<void(const QByteArray &,
+                                                 const QByteArray &,
+                                                 const QByteArray &, int)>;
 
     explicit TN5250CommandHandler(QObject *parent = nullptr);
 
     void setDisplayWidget(ui::widgets::Q5250ScreenWidget *widget);
     void setSendToHostCallback(SendToHostFn fn);
     void setSendGDSCallback(SendGDSFn fn);
+    void setGddmScreenCopyCallback(GddmScreenCopyFn fn);
+    void setGddmPrinterDataCallback(GddmPrinterDataFn fn);
 
     // Connect all decoder signals to this handler
     void connectDecoder(tn5250::client::DecoderAdapter *parser);
@@ -112,6 +118,8 @@ class TN5250CommandHandler : public QObject {
     Gddm5292Decoder m_gddmDecoder;
     SendToHostFn m_sendToHost;
     SendGDSFn m_sendGDS;
+    GddmScreenCopyFn m_gddmScreenCopy;
+    GddmPrinterDataFn m_gddmPrinterData;
     uint8_t m_pendingCC2 = 0;
     uint8_t m_readType = 0; // 0x52=READ_MDT, 0x42=READ_INPUT
     core::CommandRunner *m_commandRunner = nullptr;

--- a/tests/unit/test_command_handler_soh.cpp
+++ b/tests/unit/test_command_handler_soh.cpp
@@ -42,6 +42,7 @@ class TestCommandHandlerSoh : public QObject {
     void testGddmResetAndErrorUseDocumentedAids();
     void testEBCDICffInTextDoesNotBeginGraphics();
     void testGddmGraphicsRemainBehindAlphanumericPlane();
+    void testGddmIoFeatureCallbacks();
 
   private:
     Q5250ScreenWidget *m_widget = nullptr;
@@ -178,6 +179,45 @@ void TestCommandHandlerSoh::testGddmGraphicsRemainBehindAlphanumericPlane() {
     QCOMPARE(composed.pixelColor(blankCellCenter), QColor(0, 0, 0));
     QCOMPARE(composed.pixelColor(presentationLeftEdge), QColor(0, 0, 0));
     QCOMPARE(m_widget->screenBuffer()->character(0, 0), static_cast<uint8_t>(0xC1));
+}
+
+void TestCommandHandlerSoh::testGddmIoFeatureCallbacks() {
+    m_widget->resize(160, 96);
+    QImage screenCopy;
+    QByteArray printerData;
+    QByteArray printerColorAN;
+    QByteArray printerColorGraphics;
+    int printerTimeout = -1;
+    int copyCount = 0;
+    int printerCount = 0;
+    m_handler->setGddmScreenCopyCallback([&](const QImage &image) {
+        screenCopy = image;
+        ++copyCount;
+    });
+    m_handler->setGddmPrinterDataCallback(
+        [&](const QByteArray &data, const QByteArray &colorAN,
+            const QByteArray &colorGraphics, int timeout) {
+            printerData = data;
+            printerColorAN = colorAN;
+            printerColorGraphics = colorGraphics;
+            printerTimeout = timeout;
+            ++printerCount;
+        });
+
+    m_handler->handleRawScreenData(QByteArray::fromHex("ff93a341c195"));
+
+    QCOMPARE(copyCount, 1);
+    QCOMPARE(screenCopy.size(), QSize(160, 96));
+    QCOMPARE(screenCopy.pixelColor(80, 48), QColor(255, 0, 0));
+
+    m_handler->handleRawScreenData(QByteArray::fromHex(
+        "ff93c0414292c2434492c3454692c44b95"));
+
+    QCOMPARE(printerCount, 1);
+    QCOMPARE(printerData, QByteArray::fromHex("4142"));
+    QCOMPARE(printerColorAN, QByteArray::fromHex("4344"));
+    QCOMPARE(printerColorGraphics, QByteArray::fromHex("4546"));
+    QCOMPARE(printerTimeout, 0x0B);
 }
 
 void TestCommandHandlerSoh::testGddmSuppressPacingOrder() {

--- a/tests/unit/test_gddm_5292.cpp
+++ b/tests/unit/test_gddm_5292.cpp
@@ -56,6 +56,7 @@ class TestGddm5292 : public QObject {
     void appliesFillModeReferenceShift();
     void appliesNestedShieldAreasOnce();
     void rejectsTooManyPolygonEdges();
+    void surfacesIoFeatureOrders();
 };
 
 void TestGddm5292::ignoresAlphanumericWrites() {
@@ -339,6 +340,31 @@ void TestGddm5292::rejectsTooManyPolygonEdges() {
     QCOMPARE(result.completion, Gddm5292Decoder::Completion::FatalError);
     QCOMPARE(decoder.statusBytes().left(2), QByteArray::fromHex("c7f4"));
     QVERIFY(!decoder.graphicsMode());
+}
+
+void TestGddm5292::surfacesIoFeatureOrders() {
+    Gddm5292Decoder decoder;
+    const auto result = decoder.process(QByteArray::fromHex(
+        "ff93c0414292c2434492c3454692c44bc195"));
+
+    QVERIFY(!result.error);
+    QCOMPARE(result.completion, Gddm5292Decoder::Completion::Success);
+    QVERIFY(result.screenCopyRequested);
+    QCOMPARE(result.printerData, QByteArray::fromHex("4142"));
+    QCOMPARE(result.printerColorTableAN, QByteArray::fromHex("4344"));
+    QCOMPARE(result.printerColorTableGraphics, QByteArray::fromHex("4546"));
+    QCOMPARE(result.printerTimeout, 0x0B);
+
+    Gddm5292Decoder spanning;
+    const auto first = spanning.process(QByteArray::fromHex("ff93c04191"));
+    QVERIFY(!first.error);
+    QVERIFY(first.printerData.isEmpty());
+    QVERIFY(spanning.graphicsMode());
+
+    const auto second = spanning.process(QByteArray::fromHex("42429295"));
+    QVERIFY(!second.error);
+    QCOMPARE(second.printerData, QByteArray::fromHex("414242"));
+    QVERIFY(!spanning.graphicsMode());
 }
 
 QTEST_MAIN(TestGddm5292)


### PR DESCRIPTION
### Linked Issue

Closes #187

### Root Cause

The 5292 decoder classified printer I/O feature orders C0, C2, and C3 as ignored variable orders, so their payloads were discarded. C1 was consumed without producing an observable screen-copy request, and C4 consumed its timeout byte without retaining or exposing the configured value. The command handler only applied the graphics plane and had no boundary for these side effects.

### Fix Description

The decoder now retains completed printer data and both printer color-mix tables, reports screen-copy requests, and stores the documented printer timeout state. The command handler exposes optional callbacks for screen-copy images and printer I/O payloads. A screen-copy request captures the current composite widget image; printer callbacks receive the data, color tables, and explicit timeout update. Existing sessions remain unchanged when callbacks are not registered.

### How Verified

- Built the complete debug target set with `cmake --build build -j2`.
- Ran `QT_QPA_PLATFORM=offscreen ctest --test-dir build --output-on-failure`.
- All 26 CTest targets passed.
- The focused decoder and command-handler tests passed, including block-spanning printer data and composite screen-copy assertions.

### Test Coverage

Added:
- `tests/unit/test_gddm_5292.cpp::surfacesIoFeatureOrders`
- `tests/unit/test_command_handler_soh.cpp::testGddmIoFeatureCallbacks`

These tests cover C0/C1/C2/C3/C4 decoding, variable-order spanning, callback payloads, timeout values, and the captured screen-copy image.

### Scope of Change

- **Files changed:**
  - `src/ui/rendering/gddm_5292_decoder.cpp`
  - `src/ui/rendering/gddm_5292_decoder.h`
  - `src/ui/rendering/tn5250_command_handler.cpp`
  - `src/ui/rendering/tn5250_command_handler.h`
  - `tests/unit/test_command_handler_soh.cpp`
  - `tests/unit/test_gddm_5292.cpp`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout

The new integrations are opt-in callbacks, so existing rendering and command handling are unchanged without a consumer. Decoder state is isolated to 5292 graphics processing; live IBM i printer hardware is not required for this phase.

### Notes

This draft is stacked on PR #186 and depends on the earlier GDDM phases in PRs #182 and #184. Live IBM i verification remains deferred to the planned GDDM test phase.