### PR TITLE
[enhancement] Add GDDM shapes and colours example

### DIFF
--- a/examples/gddm/GDDMALL.RPG
+++ b/examples/gddm/GDDMALL.RPG
@@ -1,0 +1,188 @@
+     IPARAM       DS
+     I                                    B   1   40ATTYPE
+     I                                    B   5   80ATMOD
+     I                                    B   9  120COUNT
+     C                     CALL 'GDDM'
+     C                     PARM 'FSINIT ' RTN     8
+     C                     CALL 'GDDM'
+     C                     PARM 'GSLW   ' RTN     8
+     C                     PARM 2         N       40
+     C                     CALL 'GDDM'
+     C                     PARM 'GSPAT  ' RTN     8
+     C                     PARM 1         N       40
+
+     C* Draw a multicolour frame and diagonals.
+     C                     CALL 'GDDM'
+     C                     PARM 'GSCOL  ' RTN     8
+     C                     PARM 2         N       40
+     C                     CALL 'GDDM'
+     C                     PARM 'GSMOVE ' RTN     8
+     C                     PARM 5.0       X       51
+     C                     PARM 5.0       X       51
+     C                     CALL 'GDDM'
+     C                     PARM 'GSLINE ' RTN     8
+     C                     PARM 45.0      X       51
+     C                     PARM 5.0       X       51
+     C                     CALL 'GSLINE ' RTN     8
+     C                     PARM 45.0      X       51
+     C                     PARM 45.0      X       51
+     C                     CALL 'GSLINE ' RTN     8
+     C                     PARM 5.0       X       51
+     C                     PARM 45.0      X       51
+     C                     CALL 'GSLINE ' RTN     8
+     C                     PARM 5.0       X       51
+     C                     PARM 5.0       X       51
+
+     C                     CALL 'GDDM'
+     C                     PARM 'GSCOL  ' RTN     8
+     C                     PARM 1         N       40
+     C                     CALL 'GSMOVE ' RTN     8
+     C                     PARM 5.0       X       51
+     C                     PARM 5.0       X       51
+     C                     CALL 'GSLINE ' RTN     8
+     C                     PARM 45.0      X       51
+     C                     PARM 45.0      X       51
+     C                     CALL 'GSCOL  ' RTN     8
+     C                     PARM 3         N       40
+     C                     CALL 'GSMOVE ' RTN     8
+     C                     PARM 5.0       X       51
+     C                     PARM 45.0      X       51
+     C                     CALL 'GSLINE ' RTN     8
+     C                     PARM 45.0      X       51
+     C                     PARM 5.0       X       51
+
+     C* Draw a filled triangle with an explicit boundary.
+     C                     CALL 'GDDM'
+     C                     PARM 'GSCOL  ' RTN     8
+     C                     PARM 4         N       40
+     C                     CALL 'GSPAT  ' RTN     8
+     C                     PARM 3         N       40
+     C                     CALL 'GSMOVE ' RTN     8
+     C                     PARM 55.0      X       51
+     C                     PARM 10.0      X       51
+     C                     CALL 'GDDM'
+     C                     PARM 'GSAREA ' RTN     8
+     C                     PARM 1         N       40
+     C                     CALL 'GSLINE ' RTN     8
+     C                     PARM 90.0      X       51
+     C                     PARM 10.0      X       51
+     C                     CALL 'GSLINE ' RTN     8
+     C                     PARM 72.5      X       51
+     C                     PARM 42.0      X       51
+     C                     CALL 'GSLINE ' RTN     8
+     C                     PARM 55.0      X       51
+     C                     PARM 10.0      X       51
+     C                     CALL 'GDDM'
+     C                     PARM 'GSENDA ' RTN     8
+
+     C* Draw a filled rectangle with a different colour and pattern.
+     C                     CALL 'GDDM'
+     C                     PARM 'GSCOL  ' RTN     8
+     C                     PARM 5         N       40
+     C                     CALL 'GSPAT  ' RTN     8
+     C                     PARM 5         N       40
+     C                     CALL 'GSMOVE ' RTN     8
+     C                     PARM 55.0      X       51
+     C                     PARM 50.0      X       51
+     C                     CALL 'GDDM'
+     C                     PARM 'GSAREA ' RTN     8
+     C                     PARM 0         N       40
+     C                     CALL 'GSLINE ' RTN     8
+     C                     PARM 90.0      X       51
+     C                     PARM 50.0      X       51
+     C                     CALL 'GSLINE ' RTN     8
+     C                     PARM 90.0      X       51
+     C                     PARM 85.0      X       51
+     C                     CALL 'GSLINE ' RTN     8
+     C                     PARM 55.0      X       51
+     C                     PARM 85.0      X       51
+     C                     CALL 'GSLINE ' RTN     8
+     C                     PARM 55.0      X       51
+     C                     PARM 50.0      X       51
+     C                     CALL 'GDDM'
+     C                     PARM 'GSENDA ' RTN     8
+
+     C* Exercise marker symbols in all supported positions.
+     C                     CALL 'GDDM'
+     C                     PARM 'GSCOL  ' RTN     8
+     C                     PARM 6         N       40
+     C                     CALL 'GSMOVE ' RTN     8
+     C                     PARM 10.0      X       51
+     C                     PARM 70.0      X       51
+     C                     CALL 'GDDM'
+     C                     PARM 'GSMS   ' RTN     8
+     C                     PARM 0         N       40
+     C                     CALL 'GDDM'
+     C                     PARM 'GSMARK ' RTN     8
+     C                     PARM 10.0      X       51
+     C                     PARM 70.0      X       51
+     C                     CALL 'GDDM'
+     C                     PARM 'GSMS   ' RTN     8
+     C                     PARM 1         N       40
+     C                     CALL 'GSMARK ' RTN     8
+     C                     PARM 20.0      X       51
+     C                     PARM 70.0      X       51
+     C                     CALL 'GDDM'
+     C                     PARM 'GSMS   ' RTN     8
+     C                     PARM 2         N       40
+     C                     CALL 'GSMARK ' RTN     8
+     C                     PARM 30.0      X       51
+     C                     PARM 70.0      X       51
+     C                     CALL 'GDDM'
+     C                     PARM 'GSMS   ' RTN     8
+     C                     PARM 3         N       40
+     C                     CALL 'GSMARK ' RTN     8
+     C                     PARM 40.0      X       51
+     C                     PARM 70.0      X       51
+     C                     CALL 'GDDM'
+     C                     PARM 'GSMS   ' RTN     8
+     C                     PARM 4         N       40
+     C                     CALL 'GSMARK ' RTN     8
+     C                     PARM 50.0      X       51
+     C                     PARM 70.0      X       51
+     C                     CALL 'GDDM'
+     C                     PARM 'GSMS   ' RTN     8
+     C                     PARM 5         N       40
+     C                     CALL 'GSMARK ' RTN     8
+     C                     PARM 60.0      X       51
+     C                     PARM 70.0      X       51
+     C                     CALL 'GDDM'
+     C                     PARM 'GSMS   ' RTN     8
+     C                     PARM 6         N       40
+     C                     CALL 'GSMARK ' RTN     8
+     C                     PARM 70.0      X       51
+     C                     PARM 70.0      X       51
+     C                     CALL 'GDDM'
+     C                     PARM 'GSMS   ' RTN     8
+     C                     PARM 7         N       40
+     C                     CALL 'GSMARK ' RTN     8
+     C                     PARM 80.0      X       51
+     C                     PARM 70.0      X       51
+     C                     CALL 'GDDM'
+     C                     PARM 'GSMS   ' RTN     8
+     C                     PARM 8         N       40
+     C                     CALL 'GSMARK ' RTN     8
+     C                     PARM 90.0      X       51
+     C                     PARM 70.0      X       51
+
+     C* Add a circular outline to exercise arc conversion.
+     C                     CALL 'GDDM'
+     C                     PARM 'GSCOL  ' RTN     8
+     C                     PARM 7         N       40
+     C                     CALL 'GSMOVE ' RTN     8
+     C                     PARM 30.0      X       51
+     C                     PARM 25.0      X       51
+     C                     CALL 'GSARC  ' RTN     8
+     C                     PARM 30.0      X       51
+     C                     PARM 25.0      X       51
+     C                     PARM 360.0     X       51
+
+     C                     CALL 'GDDM'
+     C                     PARM 'ASREAD ' RTN     8
+     C                     PARM 0         ATTYPE
+     C                     PARM           ATMOD
+     C                     PARM           COUNT
+     C                     CALL 'GDDM'
+     C                     PARM 'FSTERM ' RTN     8
+     C                     SETON                     LR
+     C                     RETRN

--- a/examples/gddm/README.md
+++ b/examples/gddm/README.md
@@ -1,0 +1,46 @@
+# GDDM shapes and colours example
+
+`GDDMALL.RPG` is a fixed-format RPG/400 program for an IBM i GDDM graphics
+device. It exercises the primitives that 5250ng currently decodes:
+
+- colour changes and double-width lines;
+- a multicolour frame and diagonals;
+- patterned filled triangles and rectangles (`GSAREA`/`GSENDA`);
+- marker symbols 0 through 8 (`GSMS`/`GSMARK`); and
+- a circular outline (`GSARC`), which GDDM converts to device geometry.
+
+The program uses the normal GDDM lifecycle (`FSINIT`, drawing calls, `ASREAD`,
+and `FSTERM`) and the default 0..100 world-coordinate window. Coordinates are
+therefore independent of the 5292's 480x288 pels; GDDM performs the mapping.
+
+## Install and run on IBM i
+
+The target library and source file can be created once with:
+
+```text
+CRTLIB LIB(GDDMTEST) TYPE(*TEST) TEXT('GDDM examples')
+CRTSRCPF FILE(GDDMTEST/QRPGSRC) RCDLEN(112) TEXT('GDDM examples')
+ADDPFM FILE(GDDMTEST/QRPGSRC) MBR(GDDMALL) TEXT('GDDM shapes and colours')
+```
+
+Create member `GDDMALL` in `GDDMTEST/QRPGSRC` and copy the contents of
+`GDDMALL.RPG` into it. This is fixed-format RPG/400: preserve the leading
+columns and the `C`/`I` form-type positions when transferring the source.
+Compile and run it with:
+
+```text
+CRTRPGPGM PGM(GDDMTEST/GDDMALL) SRCFILE(GDDMTEST/QRPGSRC) REPLACE(*YES)
+CALL GDDMTEST/GDDMALL
+```
+
+Use a graphics-capable 5292 session (`IBM-5292-2`) to see the graphics plane.
+On a non-graphics 5250 session, IBM i uses its dummy `5292M2` device and the
+program still completes, but no graphics block is displayed.
+
+## Expected layout
+
+The upper-left area contains the red frame and blue/magenta diagonals. The
+right half contains a green patterned triangle and a cyan patterned rectangle.
+The marker row runs across the middle of the screen in yellow. A white circle
+is drawn near the lower-left area. `ASREAD` flushes the retained page and waits
+for an AID key before `FSTERM` releases the graphics state.


### PR DESCRIPTION
### Summary

Adds a reusable fixed-format RPG/400 GDDM example that exercises multiple colours and shapes on an IBM 5292 graphics session.

### Contents

- `examples/gddm/GDDMALL.RPG`: frame, diagonals, patterned areas, markers, and arc.
- `examples/gddm/README.md`: IBM i setup, compile, run, and expected layout.

### Verification

- Fixed-format source column and line-length validation passed.
- `QT_QPA_PLATFORM=offscreen ./build/test_gddm_5292 -platform offscreen`: 22 passed.

### Scope

Only the new example and its runbook are changed.